### PR TITLE
feat: support refreshing a single card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides context for Claude and other coding agents working on this co
 
 ## What is gwaim?
 
-gwaim (Git Worktree AI Manager) is a Go TUI that manages git worktrees in the context of coding agents. It provides a multi-repository dashboard with a two-column layout: a left panel listing registered repos and a right panel showing the selected repo's worktree cards. It detects which coding agents are running in each worktree and provides actions to create/delete/repair worktrees, pull, open editors, and open terminal tabs.
+gwaim (Git Worktree AI Manager) is a Go TUI that manages git worktrees in the context of coding agents. It provides a multi-repository dashboard with a two-column layout: a left panel listing registered repos and a right panel showing the selected repo's worktree cards. It detects which coding agents are running in each worktree and provides actions to create/delete worktrees, pull, refresh card state, open editors, and open terminal tabs.
 
 ## Build and test commands
 
@@ -25,7 +25,7 @@ Go version: 1.25+ (check `go env GOROOT` if you hit version mismatches).
 cmd/gwaim/main.go           Entry point (creates App, auto-adds current repo)
 internal/
   config/config.go          Repo list persistence (~/.config/gwaim/repos.json)
-  git/worktree.go           Go-git v6 wrapper: list, create, remove, repair, pull, fetch, sync status
+  git/worktree.go           Go-git v6 wrapper: list, create, remove, pull, fetch, sync status
   git/credential.go         Git credential helper protocol (git credential fill)
   agent/agents.go           Agent kind registry (claude, kiro, copilot, codex, opencode, gemini)
   agent/detect.go           Agent process detection (uses shared process.Lister)
@@ -58,7 +58,7 @@ docs/
 
 ## Architecture decisions
 
-**No shelling out to git** for git operations. The exceptions are `git credential fill` in `internal/git/credential.go` (credential helper protocol, because go-git has no built-in credential helper support), `git worktree repair` in `internal/git/worktree.go` (because go-git v6 has no repair API), and `git worktree add` in `FetchPR` (shells out to add the worktree with a sanitized directory name while preserving the original branch ref).
+**No shelling out to git** for git operations. The exceptions are `git credential fill` in `internal/git/credential.go` (credential helper protocol, because go-git has no built-in credential helper support) and `git worktree add` in `FetchPR` (shells out to add the worktree with a sanitized directory name while preserving the original branch ref).
 
 **FetchPR directory naming**: The directory basename is sanitized (slashes → dashes) so `.git/worktrees/<key>` is safe, but the local branch ref keeps its original name (e.g., `ralph/issue-19` stays `ralph/issue-19`, not `ralph-issue-19`). `FetchPR` returns `(wtPath string, err error)` so the TUI uses the actual path rather than re-deriving it.
 
@@ -104,7 +104,7 @@ docs/
 
 Modes: `modeNormal`, `modeCreate`, `modeFetchPR`, `modeConfirmDelete`
 
-- `modeNormal` -- Arrow keys navigate, `c`/`d`/`e`/`f`/`p`/`r`/`m`/`Enter`/`q` trigger actions.
+- `modeNormal` -- Arrow keys navigate, `c`/`d`/`e`/`f`/`p`/`r` (refresh)/`m`/`Enter`/`q` trigger actions.
 - `modeCreate` -- Text input active. `Enter` confirms, `Esc` cancels. Only accessible from main card (cursor == 0).
 - `modeFetchPR` -- Text input active. Accepts `"123"` or `"owner/repo#123"`. `Enter` validates via `gh` and fetches; `Esc` or empty input cancels. Only accessible from main card.
 - `modeConfirmDelete` -- Two-step: `y` arms the deletion, then `Enter` confirms. `Esc` or any other key cancels. Not available on main worktree. Renders as a centered popup overlay via `overlayCenter()` in `viewContent()`, not in the scrollable viewport. On confirm, the worktree directory is removed. All App-level navigation (Tab, arrows, mouse) is blocked while the popup is active — keys are forwarded directly to the child.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - **Delete worktrees** -- Press `d` on any linked worktree to delete it. A centered popup overlay shows what will happen: press `y` to arm, then `Enter` to confirm. `Esc` cancels at any point. The worktree directory is removed, the branch is deleted, and stale metadata is pruned. The main worktree cannot be deleted.
 - **Pull** -- Press `p` to pull. Fetches all configured remotes (origin, upstream, forks, etc.) first so all tracking refs are current, then merges from origin. Uses go-git with credentials resolved from your configured git credential helpers (osxkeychain, gh auth, etc.).
 - **Fetch PR into worktree** -- Press `f` from the main card to fetch a pull request into a new linked worktree. A prompt accepts a plain PR number (`123`) or a fork reference (`owner/repo#123`). gwaim validates the PR via `gh`, fetches the head branch, and creates a worktree for it. The branch ref is preserved exactly (e.g., `ralph/issue-19`), while the directory name is sanitized to be filesystem-safe.
-- **Repair worktrees** -- Press `r` from the main card to run `git worktree repair`, which fixes broken links between the main worktree and linked worktrees (e.g., after a worktree directory was moved manually). The status bar shows which worktrees were repaired, or "Nothing to repair" if all links are healthy.
+- **Refresh** -- Press `r` to force-refresh all cards in the current repo: worktree dirty/sync status, running agents, open IDEs, and PR status. This triggers a full network refresh (git fetch + PR lookup) rather than waiting for the next automatic refresh cycle.
 - **Open in terminal** -- Press `Enter` to open the selected worktree in a new terminal tab. If an agent is running in the worktree, the agent command is executed automatically. The first `Enter` creates a tab named after the repo (e.g., `docker/sandboxes`); subsequent presses add split panels to that same tab.
 - **Mouse support** -- Press `m` to toggle mouse mode. When enabled, click on cards to select them. When disabled (default), normal text selection works for copying paths, branch names, etc.
 - **Scrollable viewport** -- The main worktree card stays pinned at the top; linked worktree cards scroll independently below it. A scrollbar on the right panel border shows the current scroll position. Scroll with the mouse wheel, page up/down, or arrow keys (which auto-scroll to keep the selected card visible).
@@ -27,7 +27,7 @@
 - **Go 1.25+** -- Required to build from source.
 - **gh CLI** (GitHub) -- The [GitHub CLI](https://cli.github.com/) is required for pull request and CI status information on GitHub-hosted repositories. Install it and authenticate with `gh auth login`.
 - **glab CLI** (GitLab) -- The [GitLab CLI](https://gitlab.com/gitlab-org/cli) is required for merge request and CI pipeline status on GitLab-hosted repositories. Install it and authenticate with `glab auth login`.
-- **git** -- Required on the host for credential helper resolution (`git credential fill`) and worktree repair (`git worktree repair`). All other git operations use go-git natively.
+- **git** -- Required on the host for credential helper resolution (`git credential fill`). All other git operations use go-git natively.
 - **Global gitignore** -- gwaim creates worktrees in a `.gwaim-worktrees/` directory at the repository root. You must add this to your global gitignore so it is not tracked by any repository:
 
   ```bash
@@ -256,7 +256,7 @@ The current refresh interval is shown in the help bar at the bottom of the scree
 | `d`              | Delete the selected linked worktree (y + Enter to confirm)        |
 | `e`              | Open the selected worktree in an editor (`$GWAIM_EDITOR` or `code`) |
 | `p`              | Pull from remote (fetches and merges into main branch)            |
-| `r`              | Repair worktree links (only from the main card)                   |
+| `r`              | Force-refresh all cards in the repo (worktrees, agents, IDEs, PRs)|
 | `m`              | Toggle mouse mode on/off (default: off for text selection)        |
 
 ### Navigation model
@@ -287,7 +287,7 @@ gwaim is structured into the following internal packages:
 
 - **`cmd/gwaim`** -- Entry point. Loads the repo config, auto-adds the current directory's repo if applicable, creates the agent detector, and starts the Bubbletea program with the `App` model.
 - **`internal/config`** -- Persists the list of registered repositories to `~/.config/gwaim/repos.json`. Provides `Load`/`Save`/`Add`/`Remove` with atomic writes (write to `.tmp`, rename). Deduplicates by repo path.
-- **`internal/git`** -- Git operations using [go-git v6](https://github.com/go-git/go-git). Handles repository opening, worktree listing (main + linked), creation, removal, repair, pruning, pull, fetch, and sync status computation. Uses the `x/plumbing/worktree` extension for linked worktree management. Credentials are resolved via `git credential fill`. Repair shells out to `git worktree repair` (go-git v6 has no repair API).
+- **`internal/git`** -- Git operations using [go-git v6](https://github.com/go-git/go-git). Handles repository opening, worktree listing (main + linked), creation, removal, pruning, pull, fetch, and sync status computation. Uses the `x/plumbing/worktree` extension for linked worktree management. Credentials are resolved via `git credential fill`.
 - **`internal/agent`** -- Detects coding agent processes using [gopsutil](https://github.com/shirou/gopsutil). Enumerates all processes, filters by known agent patterns, resolves their CWDs, and matches them to worktree paths. Reports PID, process state, and start time.
 - **`internal/provider`** -- Multi-provider PR/MR abstraction. Defines a `PRProvider` interface and auto-detects the hosting provider (GitHub, GitLab) from the origin remote URL. Includes `GitHubProvider` (via `gh` CLI), `GitLabProvider` (via `glab` CLI), and `UnsupportedProvider` (graceful fallback for unknown hosts). Runs lookups concurrently (up to 4 at a time). Extracts PR/MR number, title, state, draft status, and CI check/pipeline status.
 - **`internal/github`** -- GitHub-specific PR helpers: `ParsePRRef` (parses `"123"` or `"owner/repo#123"`) and `ValidatePR` (confirms a PR exists via `gh` and returns its head branch) for the fetch-PR flow.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - **Delete worktrees** -- Press `d` on any linked worktree to delete it. A centered popup overlay shows what will happen: press `y` to arm, then `Enter` to confirm. `Esc` cancels at any point. The worktree directory is removed, the branch is deleted, and stale metadata is pruned. The main worktree cannot be deleted.
 - **Pull** -- Press `p` to pull. Fetches all configured remotes (origin, upstream, forks, etc.) first so all tracking refs are current, then merges from origin. Uses go-git with credentials resolved from your configured git credential helpers (osxkeychain, gh auth, etc.).
 - **Fetch PR into worktree** -- Press `f` from the main card to fetch a pull request into a new linked worktree. A prompt accepts a plain PR number (`123`) or a fork reference (`owner/repo#123`). gwaim validates the PR via `gh`, fetches the head branch, and creates a worktree for it. The branch ref is preserved exactly (e.g., `ralph/issue-19`), while the directory name is sanitized to be filesystem-safe.
-- **Refresh** -- Press `r` to force-refresh all cards in the current repo: worktree dirty/sync status, running agents, open IDEs, and PR status. This triggers a full network refresh (git fetch + PR lookup) rather than waiting for the next automatic refresh cycle.
+- **Refresh card** -- Press `r` to force-refresh the selected card's state: worktree dirty/sync status, running agents, open IDEs, and PR status. This triggers a network refresh (git fetch + PR lookup) for the selected worktree rather than waiting for the next automatic refresh cycle.
 - **Open in terminal** -- Press `Enter` to open the selected worktree in a new terminal tab. If an agent is running in the worktree, the agent command is executed automatically. The first `Enter` creates a tab named after the repo (e.g., `docker/sandboxes`); subsequent presses add split panels to that same tab.
 - **Mouse support** -- Press `m` to toggle mouse mode. When enabled, click on cards to select them. When disabled (default), normal text selection works for copying paths, branch names, etc.
 - **Scrollable viewport** -- The main worktree card stays pinned at the top; linked worktree cards scroll independently below it. A scrollbar on the right panel border shows the current scroll position. Scroll with the mouse wheel, page up/down, or arrow keys (which auto-scroll to keep the selected card visible).
@@ -256,7 +256,7 @@ The current refresh interval is shown in the help bar at the bottom of the scree
 | `d`              | Delete the selected linked worktree (y + Enter to confirm)        |
 | `e`              | Open the selected worktree in an editor (`$GWAIM_EDITOR` or `code`) |
 | `p`              | Pull from remote (fetches and merges into main branch)            |
-| `r`              | Force-refresh all cards in the repo (worktrees, agents, IDEs, PRs)|
+| `r`              | Force-refresh the selected card (worktree, agents, IDEs, PRs)     |
 | `m`              | Toggle mouse mode on/off (default: off for text selection)        |
 
 ### Navigation model

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -524,7 +524,6 @@ func (r *Repository) Pull() error {
 	return err
 }
 
-// Repair runs "git worktree repair" to fix broken worktree links.
 func isAuthError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "authentication required") ||

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -525,23 +525,6 @@ func (r *Repository) Pull() error {
 }
 
 // Repair runs "git worktree repair" to fix broken worktree links.
-// This shells out to git because go-git v6 does not provide a repair API.
-// It returns the repair output (written to stderr by git), which describes
-// each repaired worktree in the format "repair: <msg>: <path>".
-// An empty string means nothing needed repair.
-func (r *Repository) Repair() (string, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	cmd := exec.Command("git", "worktree", "repair")
-	cmd.Dir = r.repoRoot
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
 func isAuthError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "authentication required") ||

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -876,7 +876,7 @@ func extractRepoPath(msg tea.Msg) string {
 		return m.repoPath
 	case pullMsg:
 		return m.repoPath
-	case worktreeRepairedMsg:
+	case cardRefreshMsg:
 		return m.repoPath
 	case localFlashDoneMsg:
 		return m.repoPath

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -400,7 +400,7 @@ func TestExtractRepoPath(t *testing.T) {
 		{"worktreeRemovedMsg", worktreeRemovedMsg{repoPath: "/e"}, "/e"},
 		{"prFetchedMsg", prFetchedMsg{repoPath: "/f"}, "/f"},
 		{"pullMsg", pullMsg{repoPath: "/g"}, "/g"},
-		{"worktreeRepairedMsg", worktreeRepairedMsg{repoPath: "/h"}, "/h"},
+		{"cardRefreshMsg", cardRefreshMsg{repoPath: "/h"}, "/h"},
 		{"localFlashDoneMsg", localFlashDoneMsg{repoPath: "/i"}, "/i"},
 		{"netFlashDoneMsg", netFlashDoneMsg{repoPath: "/j"}, "/j"},
 		{"cliCheckMsg", cliCheckMsg{repoPath: "/k"}, "/k"},

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -11,7 +11,7 @@ type keyMap struct {
 	FetchPR  key.Binding
 	Delete   key.Binding
 	Pull     key.Binding
-	Repair   key.Binding
+	Refresh  key.Binding
 	Editor   key.Binding
 	Mouse    key.Binding
 	Enter    key.Binding
@@ -52,9 +52,9 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("p"),
 			key.WithHelp("p", "pull"),
 		),
-		Repair: key.NewBinding(
+		Refresh: key.NewBinding(
 			key.WithKeys("r"),
-			key.WithHelp("r", "repair"),
+			key.WithHelp("r", "refresh"),
 		),
 		Editor: key.NewBinding(
 			key.WithKeys("e"),

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -66,11 +66,17 @@ type editorOpenedMsg struct {
 	err error
 }
 
-// worktreeRepairedMsg is sent after a worktree repair completes.
-type worktreeRepairedMsg struct {
-	repoPath string
-	output   string // per-worktree repair details from git, empty if nothing needed repair
-	err      error
+// cardRefreshMsg carries updated state for a single worktree card.
+type cardRefreshMsg struct {
+	repoPath  string
+	wtPath    string // worktree path identifying the card
+	worktrees []git.Worktree
+	agents    agent.DetectionResult
+	ides      ide.DetectionResult
+	prs       provider.PRResult
+	hasPRs    bool
+	err       error
+	fetchErr  error
 }
 
 // tickMsg triggers a network refresh (fetch + PRs).

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -363,19 +363,38 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Pull changes local state only; sync status will update on next network tick.
 		return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp))
 
-	case worktreeRepairedMsg:
+	case cardRefreshMsg:
 		if m.isStale(msg.repoPath) {
 			return m, nil
 		}
-		rp := m.repoPath()
 		if msg.err != nil {
-			m.statusMsg = errorStyle.Render("Repair: " + msg.err.Error())
-		} else if msg.output != "" {
-			m.statusMsg = cleanStyle.Render("Repair: " + msg.output)
-		} else {
-			m.statusMsg = cleanStyle.Render("Nothing to repair")
+			m.statusMsg = errorStyle.Render("Refresh: " + msg.err.Error())
+			return m, nil
 		}
-		return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp))
+		if msg.fetchErr != nil {
+			m.statusMsg = errorStyle.Render("Fetch: " + msg.fetchErr.Error())
+		} else {
+			m.statusMsg = cleanStyle.Render("Refreshed")
+		}
+		// Update worktree list (needed for dirty/sync status).
+		m.worktrees = msg.worktrees
+		// Merge per-card agent/IDE/PR data into existing maps.
+		for k, v := range msg.agents {
+			m.agents[k] = v
+		}
+		for k, v := range msg.ides {
+			m.ides[k] = v
+		}
+		if msg.hasPRs {
+			for k, v := range msg.prs {
+				m.prs[k] = v
+			}
+		}
+		if m.cursor >= len(m.worktrees) && len(m.worktrees) > 0 {
+			m.cursor = len(m.worktrees) - 1
+		}
+		m.syncViewport()
+		return m, nil
 
 	case tea.KeyMsg:
 		updated, cmd := m.handleKey(msg)
@@ -540,12 +559,13 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.statusMsg = cleanStyle.Render("Pulling...")
 		return m, doPull(m.repo, m.repoPath())
 
-	case key.Matches(msg, m.keys.Repair):
-		if m.cursor != 0 {
-			return m, nil // repair only from main worktree
+	case key.Matches(msg, m.keys.Refresh):
+		if m.cursor >= len(m.worktrees) {
+			return m, nil
 		}
-		m.statusMsg = cleanStyle.Render("Repairing worktrees...")
-		return m, doRepairWorktrees(m.repo, m.repoPath())
+		wt := m.worktrees[m.cursor]
+		m.statusMsg = cleanStyle.Render("Refreshing card state...")
+		return m, doCardRefresh(m.repo, m.detector, m.ideDetector, m.procLister, m.prProv, m.cliAvail, m.repoPath(), wt.Path, wt.Branch)
 
 	case key.Matches(msg, m.keys.Mouse):
 		m.mouseOn = !m.mouseOn
@@ -860,7 +880,7 @@ func (m Model) viewContent() string {
 	if m.mouseOn {
 		mouseLabel = "m mouse:on"
 	}
-	helpText := "←→↑↓ navigate • ↵ open tab • e editor • p pull • r repair • c create • f fetch PR • d delete • " + mouseLabel + " • q quit"
+	helpText := "←→↑↓ navigate • ↵ open tab • e editor • p pull • r refresh • c create • f fetch PR • d delete • " + mouseLabel + " • q quit"
 	help := helpStyle.MaxWidth(m.width).Render(helpText)
 
 	if m.ready {
@@ -1054,6 +1074,49 @@ func doNetworkRefresh(repo *git.Repository, detector *agent.Detector, ideDetecto
 	}
 }
 
+// doCardRefresh refreshes a single worktree card: fetches remotes for sync
+// status, detects agents/IDEs only for the target path, and looks up PRs
+// only for the target branch.
+func doCardRefresh(repo *git.Repository, detector *agent.Detector, ideDetector *ide.Detector, procLister process.Lister, prProv provider.PRProvider, cliAvail provider.CLIAvailability, repoPath, wtPath, branch string) tea.Cmd {
+	return func() tea.Msg {
+		fetchErr := repo.Fetch()
+
+		wts, err := repo.ListWorktrees()
+		if err != nil {
+			return cardRefreshMsg{repoPath: repoPath, wtPath: wtPath, err: err}
+		}
+
+		// Detect agents/IDEs only for the target worktree.
+		ctx := context.Background()
+		procs, procErr := procLister.Processes(ctx)
+		var agents agent.DetectionResult
+		var ides ide.DetectionResult
+		if procErr == nil {
+			agents = detector.DetectFromProcesses(procs, []string{wtPath})
+			ides = ideDetector.DetectFromProcesses(procs, []string{wtPath})
+		}
+
+		// Look up PR only for the target branch.
+		var prs provider.PRResult
+		if cliAvail == provider.CLIAvailable {
+			prs = prProv.FetchPRs(repo.Root(), []string{branch})
+		} else {
+			prs = make(provider.PRResult)
+		}
+
+		return cardRefreshMsg{
+			repoPath:  repoPath,
+			wtPath:    wtPath,
+			worktrees: wts,
+			agents:    agents,
+			ides:      ides,
+			prs:       prs,
+			hasPRs:    true,
+			fetchErr:  fetchErr,
+		}
+	}
+}
+
 func doCheckCLI(prProv provider.PRProvider, repoPath string) tea.Cmd {
 	return func() tea.Msg {
 		return cliCheckMsg{repoPath: repoPath, avail: prProv.CheckCLI()}
@@ -1112,13 +1175,6 @@ func doFetchPR(repo *git.Repository, input, repoPath string) tea.Cmd {
 
 		wtPath, err := repo.FetchPR(ref.Number, branchName, remoteURL)
 		return prFetchedMsg{repoPath: repoPath, branchName: branchName, wtPath: wtPath, err: err}
-	}
-}
-
-func doRepairWorktrees(repo *git.Repository, repoPath string) tea.Cmd {
-	return func() tea.Msg {
-		output, err := repo.Repair()
-		return worktreeRepairedMsg{repoPath: repoPath, output: output, err: err}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -302,7 +302,7 @@ func TestUpdate(t *testing.T) {
 		}
 	})
 
-	t.Run("repair from main worktree", func(t *testing.T) {
+	t.Run("refresh from main worktree", func(t *testing.T) {
 		m := testModel(2)
 		m.cursor = 0 // main worktree
 
@@ -311,14 +311,14 @@ func TestUpdate(t *testing.T) {
 		model := updated.(Model)
 
 		if model.statusMsg == "" {
-			t.Error("expected status message for repair")
+			t.Error("expected status message for refresh")
 		}
 		if cmd == nil {
-			t.Error("expected a command for repair")
+			t.Error("expected a command for refresh")
 		}
 	})
 
-	t.Run("repair blocked from non-main worktree", func(t *testing.T) {
+	t.Run("refresh from non-main worktree", func(t *testing.T) {
 		m := testModel(2)
 		m.cursor = 1 // non-main worktree
 
@@ -326,11 +326,11 @@ func TestUpdate(t *testing.T) {
 		updated, cmd := m.Update(msg)
 		model := updated.(Model)
 
-		if model.statusMsg != "" {
-			t.Error("expected no status message when repair from non-main")
+		if model.statusMsg == "" {
+			t.Error("expected status message for refresh")
 		}
-		if cmd != nil {
-			t.Error("expected no command when repair from non-main")
+		if cmd == nil {
+			t.Error("expected a command for refresh")
 		}
 	})
 


### PR DESCRIPTION
## What's changed

Replace the `r` keybinding from "repair worktrees" (`git worktree repair`) to "refresh card", which force-refreshes the **selected** worktree card's state — dirty/sync status, running agents, open IDEs, and PR status — without waiting for the next automatic refresh cycle.

The new `doCardRefresh` command is scoped to a single card: it fetches remotes for sync status, but only detects agents/IDEs for the target worktree path and only looks up PRs for the target branch. Other cards' state is untouched until the next periodic refresh.

## Why is this important?

The previous `r` key ran `git worktree repair`, which is rarely needed in normal workflows. A per-card manual refresh is far more useful — it lets users immediately see updated agent/IDE/PR state after starting or stopping a process, without waiting up to 30 seconds for the next network refresh cycle.

## Changes

### TUI (`internal/tui/`)
- Rename `keys.Repair` → `keys.Refresh` in keymap; update help text
- Add `cardRefreshMsg` message type carrying per-card refresh results
- Add `doCardRefresh` command: fetches remotes, lists worktrees, detects agents/IDEs for one path, looks up PR for one branch
- Handle `cardRefreshMsg` in `Update`: merges per-card agent/IDE/PR data into existing maps
- Remove `worktreeRepairedMsg` type and handler
- Remove `doRepairWorktrees` command
- `r` key now works from any card (main or linked), not just main

### Git (`internal/git/`)
- Remove `Repository.Repair()` method and its stale comment

### Tests
- Replace repair tests with refresh tests (verify refresh works from both main and non-main worktrees)
- Add `cardRefreshMsg` to `extractRepoPath` test table

### Docs
- Update CLAUDE.md and README.md to reflect the new refresh behavior and remove all repair references

## Test plan
- [x] `task test-race` — all tests pass
- [x] `task lint` — zero issues
- [x] `task install` — builds and installs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
