### PR TITLE
feat(sandbox): add sandbox mode as default way of enrolling repositories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides context for Claude and other coding agents working on this co
 
 gwaim (Git Worktree AI Manager) is a Go TUI that manages git worktrees in the context of coding agents. It provides a multi-repository dashboard with a two-column layout: a left panel listing registered repos and a right panel showing the selected repo's worktree cards. It detects which coding agents are running in each worktree and provides actions to create/delete worktrees, pull, refresh card state, open editors, and open terminal tabs.
 
+**gwaim recommends Docker Sandboxes (`sbx`) as the default mode for coding agents.** Sandbox mode provides each worktree with an isolated Docker environment (its own filesystem, Docker daemon, and network), so agents can install packages, build containers, and modify files without touching the host. When adding a repo, sandbox mode is the recommended choice. Regular (host-only) mode is available as a fallback for repos that don't need isolation.
+
 ## Build and test commands
 
 ```
@@ -32,6 +34,7 @@ internal/
   ide/ides.go               IDE kind registry (vscode, cursor, zed, windsurf, goland, intellij, pycharm, neovim, vim)
   ide/detect.go             IDE process detection (matches CWD + cmdline against worktree paths)
 
+  sandbox/sandbox.go        Docker Sandbox (sbx) CLI wrapper: preflight, status check, command builders
   process/process.go        Shared process enumeration types (Lister, Info, OSLister, Enrich)
   github/pr.go              GitHub-specific PR helpers (ParsePRRef, ValidatePR for fetch-PR flow)
   provider/provider.go      PRProvider interface, provider detection, shared types
@@ -78,15 +81,62 @@ docs/
 
 **Split viewport**: The right panel has two sections: a fixed top (main worktree card + create/fetchPR input) and a scrollable viewport (linked worktree cards only). `renderFixedTop()` produces the pinned content and sets `fixedTopHeight`; `renderLinkedCards()` produces the viewport content. `syncViewport()` calls both, caches the fixed-top output in `fixedTopContent`, feeds only linked cards into the viewport, and dynamically sizes `viewport.Height` as `m.height - fixedTopHeight - footerHeight`. The scrollbar on the right panel border tracks only the linked-cards scroll position. Cursor navigation calls `ensureCursorVisible()` to auto-scroll the viewport when the selected card is off-screen.
 
-**Multi-repo architecture**: The `App` model (`tui/app.go`) wraps multiple `Model` instances in a two-column layout. Left panel (~15%) shows registered repos as individual cards (rounded border, cyan when selected), right panel (~85%) shows the active repo's worktree dashboard. `Tab`/`Shift+Tab` switches focus between panels. Clicking a card also focuses and selects the repo. Repos are persisted in `~/.config/gwaim/repos.json` via `internal/config`. All async messages carry a `repoPath` field; `App.Update` routes them to the correct child model by matching `repoPath` to `repoTab.path`. Stale messages (from a previously-active repo) are discarded by `Model.isStale()`.
+**Multi-repo architecture**: The `App` model (`tui/app.go`) wraps multiple `Model` instances in a two-column layout. Left panel (~15%) shows registered repos as a tree (header per repo group, indented mode lines below), right panel (~85%) shows the active mode's worktree dashboard. The tree layout looks like:
+```
+mdelapenya/gwaim          ← header (dimmed, click selects first mode)
+  ▸ 📂                    ← selected mode child (regular)
+    🐳 [claude]           ← sandbox mode child
+docker/sandboxes
+    📂
+```
+`Tab`/`Shift+Tab` switches focus between panels. Clicking a mode line also focuses and selects it. Repos are persisted in `~/.config/gwaim/repos.json` via `internal/config`. Each repo entry has a `modes` list (see config format below). `repoTab` is now `repoGroup` — each group has `modes []config.ModeEntry` and `activeMode int`. There is **one `Model` per repo** with filtered views: `Model` has `activeMode *config.ModeEntry` and `allWorktrees`/`worktrees` (unfiltered/filtered). Regular mode shows `.gwaim-worktrees/` worktrees; sandbox mode shows `.sbx/<sandboxName>-worktrees/` worktrees. The main worktree is always shown. All async messages carry a `repoPath` field; `App.Update` routes them to the correct child model by matching `repoPath` to `repoGroup.path`. Stale messages (from a previously-active repo) are discarded by `Model.isStale()`.
 
-**Repo list scrolling**: The left panel has manual scroll support via `repoScrollOffset`. Each repo card is `repoCardHeight` (3) lines tall. When repos exceed the visible area (`visibleRepoCards()`), only the visible slice is rendered and a scrollbar appears on the left panel's right border. Keyboard navigation via `switchRepo()` calls `ensureActiveRepoVisible()` to auto-scroll. Mouse wheel events (`MouseButtonWheelUp`/`Down`) in the left panel adjust the scroll offset directly. Click detection accounts for scroll offset: `cardIdx = contentY/repoCardHeight + repoScrollOffset`. Both panels' scrollbar geometry is computed by `scrollbarGeometry()` and rendered in `buildPanels()` using `panelScroll` structs.
+**Mode navigation**: Up/down in the left panel traverses modes across groups. Switching modes within the same group does not pause/resume the child Model. Switching across groups does pause/resume.
+
+**Adding sandbox replaces regular mode** in the same repo group. If a repo group has only a regular mode and the user adds a sandbox, the regular mode entry is replaced.
+
+**Repo list scrolling**: The left panel has manual scroll support via `repoScrollOffset`. The tree uses variable heights per group (1 header line + N mode lines), so the old `repoCardHeight` constant has been removed. When groups exceed the visible area, only the visible slice is rendered and a scrollbar appears on the left panel's right border. Keyboard navigation calls `ensureActiveRepoVisible()` to auto-scroll. Mouse wheel events (`MouseButtonWheelUp`/`Down`) in the left panel adjust the scroll offset directly. Both panels' scrollbar geometry is computed by `scrollbarGeometry()` and rendered in `buildPanels()` using `panelScroll` structs.
 
 **Embedded models**: When a `Model` is used inside the `App`, it is created with `newEmbedded()` which sets `embedded = true`. Embedded models render refresh timestamps inside `renderFixedTop()` (above the main card, inside the right panel) instead of in a standalone header. The App header is title-only (`gwaim - Git Worktree Agent Manager`). The App calls `Model.ViewContent()` (body + help, no header) instead of `Model.View()`.
 
 **Manual panel borders**: Panel borders are rendered manually in `App.buildPanels()` using `╭╮│╰╯─` characters, NOT via lipgloss `Border()`. This was a deliberate decision: lipgloss `Border()` + `Height()`/`MaxHeight()` does not reliably produce panels of identical height when content includes ANSI-styled text. Manual borders give exact control over every row, ensuring both panels always have the same height. Border color is cyan when the panel is focused.
 
 **Layout height budget**: The `App.View()` layout is: header (1 row, title only) + two bordered panels (`contentH + 2` rows) = `a.height` rows total. Refresh timestamps are rendered inside the right panel by the embedded Model, not in the App header. Content lines are clamped via `splitClampPad()` and cell widths forced via `lipgloss.Width()/MaxWidth()` to prevent wrapping.
+
+**Config format**: The config file (`~/.config/gwaim/repos.json`) uses a `modes` list per repo entry:
+```go
+type ModeEntry struct {
+    Type        string // "regular" or "sandbox"
+    SandboxName string
+    Agent       string
+}
+type RepoEntry struct {
+    Path  string
+    Name  string
+    Modes []ModeEntry
+}
+```
+The old flat format (with `Sandbox bool`, `SandboxName string`, `Agent string` fields) is auto-migrated on load. The same repo can have multiple modes (e.g. one regular + multiple sandbox agents).
+
+**Sandbox mode** (recommended): Repos can be enrolled in sandbox mode (Docker Sandboxes via `sbx` CLI). Each sandbox mode entry has a `Type` of `"sandbox"`, a `SandboxName` (e.g. `"owner-repo-claude"`), and an `Agent` (e.g. `"claude"`). The same repo can have multiple sandbox entries with different agents. Adding a sandbox to a repo that only has a regular mode replaces the regular entry.
+
+**Sandbox lifecycle**: One sandbox (VM) is created per enrollment via `sbx create --name <name> <agent> <path>`. A pre-flight check (`sbx ls --json`) runs before enrollment to ensure sbx is bootstrapped (authenticated, daemon running, policy set). If not ready, the user is told to run `sbx ls` in a terminal first; the repo is NOT saved to config.
+
+**Sandbox worktree creation**: Worktrees are created inside the existing sandbox via `sbx run -d --branch <branch> <sandboxName>` (detached). No new sandbox/VM is created. The user attaches later by pressing Enter on the card, which opens a terminal with `sbx run --branch <branch> <sandboxName>` (no `cd` prefix — sbx knows which sandbox to enter). No terminal tabs are auto-opened on create or fetch PR — tabs only open on explicit Enter/double-click.
+
+**Sandbox worktree listing**: Uses standard git (sbx bind-mounts the workspace, so `.git/worktrees/` is visible on the host). No `sbx exec` needed for listing.
+
+**Sandbox worktree deletion**: Uses plain `git worktree remove` — the sandbox persists independently. There is no `sbx worktree remove` command.
+
+**Sandbox status monitoring**: Every local refresh cycle (5s), `sandbox.CheckStatus(name)` runs `sbx ls --json` and reports one of three states: `StatusRunning` (green on card), `StatusStopped` (yellow on card + status bar hint to run `sbx run <name>`), `StatusNotFound` (red on card + status bar with full `sbx create` command). The status bar message clears automatically when the sandbox state improves.
+
+**Sandbox fetch PR**: Uses `repo.FetchPRRef()` (ref only, no host worktree) then `sbx run -d --branch <branch> <sandboxName>` to create the worktree inside the sandbox.
+
+**Sandbox removal**: Pressing `d` on the main card of a sandbox repo shows a confirmation popup to run `sbx rm --force <name>`. This stops the sandbox, removes all its containers and worktrees. The sandbox status updates to `StatusNotFound` on the next refresh cycle, and `s` becomes available to recreate it.
+
+**Sandbox package** (`internal/sandbox`): `Available()`, `Preflight()`, `CheckStatus()`, `CheckAllStatuses()`, `Version()`, `CreateArgs()`, `RemoveArgs()`, `RunDetachedWithBranchArgs()`, `RunWithBranchArgs()`, `SanitizeName()`, `CommandString()`, `Create()`, `Start()`, `Stop()`, `Remove()`, `RunDetached()`.
+
+The enrollment flow in `app.go` uses `appModeSelectRepoMode` and `appModeEnrollAgent` modes.
 
 **Startup without a git repo**: gwaim can start from any directory. If the current directory is inside a git repo, it auto-adds it to the config. If not, the app shows an empty state with instructions to add a repo.
 
@@ -97,15 +147,22 @@ docs/
 ### App-level modes (tui/app.go)
 
 - `appModeNormal` -- Two-panel navigation. `Tab` switches focus. Left panel: `↑↓`/`jk` navigate repos, `a` add, `x` remove. Right panel: forwards to child Model.
-- `appModeAddRepo` -- Text input for repo path. `Enter` validates and adds. `Esc` cancels.
+- `appModeAddRepo` -- Text input for repo path. `Enter` validates (via `doValidateRepo`). `Esc` cancels.
+- `appModeSelectRepoMode` -- After path validation: `[s] Sandbox (recommended)  [r] Regular  [esc] Cancel`.
+- `appModeEnrollAgent` -- Text input for sandbox agent name (add-repo flow). `Enter` runs preflight check (`sbx ls --json`), then finalizes. `Esc` cancels.
+- `appModeAddSandboxMode` -- Text input for agent name when pressing `n` in left panel on an existing repo. `Enter` runs preflight, then adds sandbox mode to the group. `Esc` cancels.
+- Note: Up/down in the left panel traverses modes across groups. Switching modes within the same group does not pause/resume. Switching across groups does.
 - `appModeConfirmRemove` -- `y` confirms removal, any other key cancels. Renders as a centered popup overlay via `overlayCenter()` in `App.View()`. All navigation (Tab, arrows, mouse) is blocked while the popup is active.
 
 ### Per-repo modes (tui/model.go)
 
-Modes: `modeNormal`, `modeCreate`, `modeFetchPR`, `modeConfirmDelete`
+Modes: `modeNormal`, `modeCreate`, `modeFetchPR`, `modeConfirmDelete`, `modeConfirmCreateSandbox`, `modeConfirmRemoveSandbox`, `modeEnrollSandboxFromCard`
 
-- `modeNormal` -- Arrow keys navigate, `c`/`d`/`e`/`f`/`p`/`r` (refresh)/`m`/`Enter`/`q` trigger actions.
-- `modeCreate` -- Text input active. `Enter` confirms, `Esc` cancels. Only accessible from main card (cursor == 0).
+- `modeNormal` -- Arrow keys navigate, `c`/`d`/`e`/`f`/`n`/`s`/`S`/`p`/`r` (refresh)/`m`/`Enter`/`q` trigger actions. Sandbox keys: `n` (new sandbox when not found or non-sandbox), `s` (start stopped sandbox), `S` (stop running sandbox).
+- `modeCreate` -- Text input active. `Enter` confirms: in regular mode calls `repo.CreateWorktree()`; in sandbox mode calls `sbx run -d --branch <branch> <sandboxName>` (agent is fixed at enrollment). `Esc` cancels. Only accessible from main card (cursor == 0).
+- `modeConfirmCreateSandbox` -- `n` from main card when sandbox not found. Shows popup with full `sbx create` command. `y` confirms, any other key cancels.
+- `modeConfirmRemoveSandbox` -- `d` from main card in sandbox mode when sandbox exists. Shows popup with `sbx rm --force <name>`. `y` confirms, any other key cancels.
+- `modeEnrollSandboxFromCard` -- `n` from main card of a non-sandbox repo. Text input for agent name. `Enter` runs preflight + enrollment. `Esc` cancels.
 - `modeFetchPR` -- Text input active. Accepts `"123"` or `"owner/repo#123"`. `Enter` validates via `gh` and fetches; `Esc` or empty input cancels. Only accessible from main card.
 - `modeConfirmDelete` -- Two-step: `y` arms the deletion, then `Enter` confirms. `Esc` or any other key cancels. Not available on main worktree. Renders as a centered popup overlay via `overlayCenter()` in `viewContent()`, not in the scrollable viewport. On confirm, the worktree directory is removed. All App-level navigation (Tab, arrows, mouse) is blocked while the popup is active — keys are forwarded directly to the child.
 
@@ -117,7 +174,7 @@ Cursor 0 = main worktree. Cursor 1+ = linked worktrees. Left/right only work in 
 - **Git tests**: Use real temp repos via `t.TempDir()` + `gogit.PlainInit`. Test worktree create/remove/list/dirty.
 - **Agent tests**: Mock `process.Lister` interface with canned `process.Info` slices. No real processes.
 - **IDE tests**: Same mock pattern as agent tests. Test CWD matching, cmdline matching, process tree deduplication (Electron helpers grouped by PPID), two independent windows producing two entries, and nested helper rollup.
-- **App tests**: Create a `testApp(n)` with pre-populated repoTabs (no real repos). Test focus switching, repo navigation, add/remove modes, stale message routing.
+- **App tests**: Create a `testApp(n)` with pre-populated repoGroups (no real repos). Test focus switching, repo/mode navigation, add/remove modes, stale message routing.
 - **TUI tests**: Create a `testModel(n)` with pre-populated worktrees. Send `tea.KeyMsg` to `Update`, assert model fields.
 - **Card tests**: Call `card.Render(wt, agents, ides, pr, cliAvail, prov)` and assert output contains expected strings. IDE card tests verify `■ <kind>` rendering and `□ no IDE` placeholder.
 
@@ -134,6 +191,7 @@ Always run `go test -race ./...` -- the TUI must be safe for concurrent `View` +
 - **`tea.WindowSizeMsg` must not be used for child resizing** — the App intercepts it and overwrites stored terminal dimensions. Use `childResizeMsg` instead.
 - **`App.Init()` is async**: repos are loaded inside a `tea.Cmd` closure and arrive via `appInitMsg`. bubbletea's `WindowSizeMsg` arrives before `appInitMsg`, so the `appInitMsg` handler must resize all children using stored dimensions.
 - Always bounds-check `a.active < len(a.repos)` before accessing `a.repos[a.active]` — repos can be removed while the active index is stale.
+- **`repoCardHeight` constant removed** — the tree layout uses variable heights (1 header + N mode lines per group). Do not assume a fixed height per repo entry in the left panel.
 - **Confirmation dialogs should use popup overlays**, not status messages appended to the viewport bottom (which scroll off-screen). Use `overlayCenter()` to composite popups on top of `viewContent()`. See `modeConfirmDelete` for the pattern. Popups are fully modal: background is dimmed, and all navigation (Tab, arrows, mouse) is blocked. When a child model enters a modal mode, `handleKeyMsg` detects `!child.IsNormal()` and forwards keys directly to the child, bypassing App-level navigation.
 - **IDE `ProcessPatterns` order matters**: more specific patterns must come before broader ones (e.g. `"nvim"` before `"vim"`). Using a map would cause non-deterministic matching; the ordered `[]processPattern` slice is intentional.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 **Git Worktree AI Manager** -- A terminal UI for managing git worktrees and the coding agents running inside them.
 
+> **Recommended: use [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) (`sbx`) for coding agents.** Sandbox mode gives each worktree an isolated Docker environment — its own filesystem, Docker daemon, and network — so agents can install packages, build containers, and modify files without touching the host. When adding a repo, sandbox mode is the default and recommended choice.
+
 ## Features
 
-- **Multi-repo dashboard** -- Register multiple repositories and switch between them in a two-column layout. The left panel (15%) shows registered repos as clickable cards with a scrollbar when the list overflows, the right panel (85%) shows the selected repo's worktree dashboard. Press `Tab` to switch focus between panels.
-- **Persistent config** -- Registered repos are saved to `~/.config/gwaim/repos.json` and restored on next launch. Starting gwaim inside a git repo auto-adds it.
+- **Multi-repo dashboard** -- Register multiple repositories and switch between them in a two-column layout. The left panel (15%) shows registered repos as a tree: each repo is a header (dimmed, click selects first mode) with indented mode lines below (regular `📂` or sandbox `🐳 [agent]`). The right panel (85%) shows the selected mode's worktree dashboard. A scrollbar appears when the tree overflows. Press `Tab` to switch focus between panels. The same repo can have multiple modes (e.g. regular + multiple sandbox agents).
+- **Persistent config** -- Registered repos are saved to `~/.config/gwaim/repos.json` and restored on next launch. Starting gwaim inside a git repo auto-adds it. Each repo entry has a list of modes (`regular` or `sandbox` with agent name). The old flat config format is auto-migrated on load.
 - **Start from anywhere** -- gwaim can launch from any directory, not just inside a git repo. If no repos are registered, an empty state guides you to add one.
 - **Hierarchical layout** -- The main worktree sits at the top (double-bordered card), with linked worktrees displayed in a responsive grid below.
 - **Worktree cards** -- Each card shows: branch name, path, dirty/clean status, sync status (ahead/behind/diverged/up-to-date), active agents, open IDEs, and PR info.
@@ -13,7 +15,8 @@
 - **IDE detection** -- Detects open IDEs (VS Code, Cursor, Zed, Windsurf, GoLand, IntelliJ, PyCharm, Neovim, Vim) in each worktree. Matches by process name and worktree path (both CWD and cmdline). Electron-based IDEs (VS Code, Cursor) spawn many helper processes; gwaim groups them by process tree so each independent window appears as one card entry.
 - **PR/MR status** -- Fetches pull request (GitHub) or merge request (GitLab) information and CI check status for each branch. Shows PR/MR number, title, state (open/draft/merged/closed), and CI result (pass/fail/pending). The hosting provider is auto-detected from the origin remote URL.
 - **Sync status** -- Compares each branch against its remote tracking branches for reference remotes (`origin` and `upstream`) and shows whether it is up-to-date, ahead, behind, or diverged. Runs `git fetch` on every refresh cycle across all configured remotes to keep tracking refs current.
-- **Create worktrees** -- Press `c` from the main card to create a new linked worktree. A branch name prompt appears under the main card. After creation, a new terminal tab opens automatically in the worktree directory.
+- **Docker Sandbox mode** (recommended) -- When adding a repo, choose between Sandbox (recommended) and Regular mode (`[s] Sandbox (recommended)  [r] Regular  [esc] Cancel`). In sandbox mode, one sandbox (VM) is created per enrollment via `sbx create`. The agent (claude, codex, copilot, gemini, kiro, opencode, shell) is chosen at enrollment time and reused for all worktrees. The same repo can have multiple sandbox modes with different agents, each appearing as an indented `🐳 [agent]` line under the repo header in the left panel tree. Adding a sandbox to a repo with only a regular mode replaces the regular entry. The main card displays real-time sandbox status: running (green), stopped (yellow with start command), or not found (red with create command). A pre-flight check ensures `sbx` is bootstrapped before enrollment.
+- **Create worktrees** -- Press `c` from the main card to create a new linked worktree. A branch name prompt appears under the main card. In regular mode, a git worktree is created directly on the host. In sandbox mode, the worktree is created inside the existing sandbox via `sbx run -d --branch` (detached) — no new VM is created. No terminal tabs auto-open; press Enter on the card to attach.
 - **Delete worktrees** -- Press `d` on any linked worktree to delete it. A centered popup overlay shows what will happen: press `y` to arm, then `Enter` to confirm. `Esc` cancels at any point. The worktree directory is removed, the branch is deleted, and stale metadata is pruned. The main worktree cannot be deleted.
 - **Pull** -- Press `p` to pull. Fetches all configured remotes (origin, upstream, forks, etc.) first so all tracking refs are current, then merges from origin. Uses go-git with credentials resolved from your configured git credential helpers (osxkeychain, gh auth, etc.).
 - **Fetch PR into worktree** -- Press `f` from the main card to fetch a pull request into a new linked worktree. A prompt accepts a plain PR number (`123`) or a fork reference (`owner/repo#123`). gwaim validates the PR via `gh`, fetches the head branch, and creates a worktree for it. The branch ref is preserved exactly (e.g., `ralph/issue-19`), while the directory name is sanitized to be filesystem-safe.
@@ -28,16 +31,19 @@
 - **gh CLI** (GitHub) -- The [GitHub CLI](https://cli.github.com/) is required for pull request and CI status information on GitHub-hosted repositories. Install it and authenticate with `gh auth login`.
 - **glab CLI** (GitLab) -- The [GitLab CLI](https://gitlab.com/gitlab-org/cli) is required for merge request and CI pipeline status on GitLab-hosted repositories. Install it and authenticate with `glab auth login`.
 - **git** -- Required on the host for credential helper resolution (`git credential fill`). All other git operations use go-git natively.
-- **Global gitignore** -- gwaim creates worktrees in a `.gwaim-worktrees/` directory at the repository root. You must add this to your global gitignore so it is not tracked by any repository:
+- **sbx CLI** (recommended) -- The [Docker Sandboxes CLI](https://docs.docker.com/ai/sandboxes/) is required for sandbox mode, which is the recommended way to use gwaim with coding agents. Install it and run `sbx ls` once to complete setup (Docker auth, network policy). Each sandbox gets its own isolated Docker environment.
+- **Global gitignore** -- gwaim creates worktrees in `.gwaim-worktrees/` (regular mode) and `.sbx/` (sandbox mode) directories at the repository root. You must add these to your global gitignore so they are not tracked by any repository:
 
   ```bash
   echo ".gwaim-worktrees" >> ~/.config/git/ignore
+  echo ".sbx" >> ~/.config/git/ignore
   ```
 
   Or, if you use a custom `core.excludesFile`:
 
   ```bash
   echo ".gwaim-worktrees" >> "$(git config --global core.excludesFile)"
+  echo ".sbx" >> "$(git config --global core.excludesFile)"
   ```
 
 ## Supported providers
@@ -236,10 +242,11 @@ The current refresh interval is shown in the help bar at the bottom of the scree
 
 | Key              | Action                                                            |
 |------------------|-------------------------------------------------------------------|
-| `up` / `k`      | Select previous repo                                              |
-| `down` / `j`    | Select next repo                                                  |
-| `a`              | Add a new repository (enter path)                                 |
-| `x`              | Remove selected repository from dashboard (popup confirmation)   |
+| `up` / `k`      | Select previous mode (traverses modes across repo groups)         |
+| `down` / `j`    | Select next mode (traverses modes across repo groups)             |
+| `a`              | Add a new repository (enter path, choose regular/sandbox)         |
+| `n`              | Add a sandbox mode to the selected repo (prompts for agent)       |
+| `x`              | Remove selected mode from dashboard (popup confirmation)          |
 | `Enter`          | Switch focus to worktree dashboard                                |
 
 #### Worktree dashboard (right panel focused)
@@ -251,7 +258,11 @@ The current refresh interval is shown in the help bar at the bottom of the scree
 | `up` / `k`      | Move cursor up (first linked row goes to main)                    |
 | `down` / `j`    | Move cursor down (main goes to first linked card)                 |
 | `Enter`          | Open selected worktree in a new terminal tab/panel                |
+| `n`              | New sandbox (main card, when sandbox not found or non-sandbox repo) |
+| `s`              | Start stopped sandbox (main card, sandbox mode, when stopped)     |
+| `S`              | Stop running sandbox (main card, sandbox mode, when running)      |
 | `c`              | Create a new worktree (only from the main card)                   |
+| `d` (main card)  | Remove sandbox with `sbx rm` (sandbox mode only, confirmation popup) |
 | `f`              | Fetch a PR into a new worktree (only from the main card; accepts `123` or `owner/repo#123`) |
 | `d`              | Delete the selected linked worktree (y + Enter to confirm)        |
 | `e`              | Open the selected worktree in an editor (`$GWAIM_EDITOR` or `code`) |
@@ -281,19 +292,86 @@ When you press `Enter` on a worktree card:
 
 The gwaim dashboard stays running in its own tab throughout.
 
+## Sandbox workflows
+
+gwaim recommends Docker Sandboxes for coding agents. Here are all the ways to work with sandboxes:
+
+### Enroll a new repo in sandbox mode
+
+1. **Left panel focused** → press `a` to add a repo
+2. Enter the repo path → press Enter
+3. Choose `[s] Sandbox (recommended)` 
+4. Enter the agent name (e.g., `claude`) → press Enter
+5. gwaim runs a pre-flight check (`sbx ls --json`). If sbx is not bootstrapped, you'll see an error — run `sbx ls` in a terminal first to complete Docker auth and network policy setup
+6. On success: repo appears in the tree as `🐳 [claude]`, sandbox is created via `sbx create` in the background
+
+### Add another sandbox agent to an existing repo
+
+1. **Left panel focused** → select any mode of the repo
+2. Press `n`
+3. Enter the agent name (e.g., `gemini`) → press Enter
+4. Pre-flight check runs. On success: new `🐳 [gemini]` line appears under the repo header
+5. The tree now shows multiple agents:
+   ```
+   mdelapenya/gwaim
+     🐳 [claude]
+     🐳 [gemini]
+   ```
+
+### Convert a regular repo to sandbox mode
+
+1. **Right panel focused**, main card selected → press `n`
+2. Enter the agent name → press Enter
+3. The `📂 [host]` mode is replaced by `🐳 [claude]`
+
+### Create a worktree inside a sandbox
+
+1. Select the sandbox mode in the left panel tree (e.g., `🐳 [claude]`)
+2. **Right panel** → press `c` on the main card
+3. Enter the branch name → press Enter
+4. gwaim runs `sbx run -d --branch <branch> <sandboxName>` (detached) — the worktree is created inside the existing sandbox VM
+5. The worktree card appears on the next refresh cycle (≤5s)
+6. Press Enter on the card to attach: opens a terminal with `sbx run --branch <branch> <sandboxName>`
+
+### Create sandbox when it doesn't exist
+
+If the main card shows `🐳 sandbox: name (not found)` in red:
+1. Press `n` → confirmation popup shows the full `sbx create` command
+2. Press `y` → sandbox is created in the background
+
+### Remove a sandbox
+
+1. Select the sandbox mode → **right panel**, main card selected
+2. Press `d` → confirmation popup: `sbx rm --force <name>`
+3. Press `y` → sandbox is removed (all containers and worktrees destroyed)
+
+### Remove a mode from the repo list
+
+1. **Left panel focused** → select the mode to remove
+2. Press `x` → confirmation popup
+3. Press `y` → mode is removed from config. If it was the last mode, the repo is removed entirely
+
+### Sandbox status indicators
+
+The main card shows real-time sandbox status (checked every 5s):
+- **Green**: `🐳 sandbox: name (running)` + sbx version info
+- **Yellow**: `🐳 sandbox: name (stopped)` + status bar: `Sandbox stopped — run: sbx run <name>`
+- **Red**: `🐳 sandbox: name (not found)` + status bar: `Sandbox not found — press 'n' to create it`
+
 ## Architecture
 
 gwaim is structured into the following internal packages:
 
 - **`cmd/gwaim`** -- Entry point. Loads the repo config, auto-adds the current directory's repo if applicable, creates the agent detector, and starts the Bubbletea program with the `App` model.
-- **`internal/config`** -- Persists the list of registered repositories to `~/.config/gwaim/repos.json`. Provides `Load`/`Save`/`Add`/`Remove` with atomic writes (write to `.tmp`, rename). Deduplicates by repo path.
+- **`internal/config`** -- Persists the list of registered repositories to `~/.config/gwaim/repos.json`. Each `RepoEntry` has a `Path`, `Name`, and `Modes []ModeEntry` (each mode is `regular` or `sandbox` with optional agent/sandbox name). Provides `Load`/`Save`/`Add`/`Remove`/`AddMode`/`RemoveMode` with atomic writes (write to `.tmp`, rename). Deduplicates by repo path. Auto-migrates the old flat config format (with `Sandbox bool` fields) on load.
 - **`internal/git`** -- Git operations using [go-git v6](https://github.com/go-git/go-git). Handles repository opening, worktree listing (main + linked), creation, removal, pruning, pull, fetch, and sync status computation. Uses the `x/plumbing/worktree` extension for linked worktree management. Credentials are resolved via `git credential fill`.
 - **`internal/agent`** -- Detects coding agent processes using [gopsutil](https://github.com/shirou/gopsutil). Enumerates all processes, filters by known agent patterns, resolves their CWDs, and matches them to worktree paths. Reports PID, process state, and start time.
 - **`internal/provider`** -- Multi-provider PR/MR abstraction. Defines a `PRProvider` interface and auto-detects the hosting provider (GitHub, GitLab) from the origin remote URL. Includes `GitHubProvider` (via `gh` CLI), `GitLabProvider` (via `glab` CLI), and `UnsupportedProvider` (graceful fallback for unknown hosts). Runs lookups concurrently (up to 4 at a time). Extracts PR/MR number, title, state, draft status, and CI check/pipeline status.
 - **`internal/github`** -- GitHub-specific PR helpers: `ParsePRRef` (parses `"123"` or `"owner/repo#123"`) and `ValidatePR` (confirms a PR exists via `gh` and returns its head branch) for the fetch-PR flow.
+- **`internal/sandbox`** -- Docker Sandbox (`sbx`) CLI wrapper. Provides `Preflight()` to verify sbx is bootstrapped, `CheckStatus()` for real-time sandbox state monitoring (running/stopped/not found), `CreateArgs()`/`RunDetachedWithBranchArgs()`/`RunWithBranchArgs()` to build CLI commands, `SanitizeName()` for safe sandbox names, and `Create()`/`RunDetached()` for background execution.
 - **`internal/tui`** -- Two-layer Bubbletea TUI:
-  - **`App`** (`app.go`): Top-level model managing multiple repos. Renders a two-column layout with manually-drawn borders (`buildPanels()`). Left panel shows the repo list, right panel shows the active repo's worktree dashboard. Handles focus switching (`Tab`/`Shift+Tab`/mouse click), repo add/remove, and routes async messages to the correct child by `repoPath`.
-  - **`Model`** (`model.go`): Per-repo worktree dashboard. The main card is pinned at the top (`renderFixedTop`); linked worktree cards scroll in a viewport (`renderLinkedCards`). Manages card grid layout, hierarchical navigation, input modes (normal, create, fetch-PR, confirm-delete), mouse toggle, periodic refresh, and two-zone click detection. When embedded inside `App`, skips its own header rendering (the App renders it above both panels).
+  - **`App`** (`app.go`): Top-level model managing multiple repos. Renders a two-column layout with manually-drawn borders (`buildPanels()`). Left panel shows a tree of repo groups (header + indented mode lines), right panel shows the active mode's worktree dashboard. Each `repoGroup` holds `modes []config.ModeEntry` and `activeMode int`; there is one `Model` per repo with filtered views. Handles focus switching (`Tab`/`Shift+Tab`/mouse click), mode navigation (up/down traverses modes across groups), repo add/remove, and routes async messages to the correct child by `repoPath`.
+  - **`Model`** (`model.go`): Per-repo worktree dashboard. Has `activeMode *config.ModeEntry` and `allWorktrees`/`worktrees` (unfiltered/filtered). Regular mode shows `.gwaim-worktrees/` worktrees; sandbox mode shows `.sbx/<sandboxName>-worktrees/` worktrees; the main worktree is always shown. The main card is pinned at the top (`renderFixedTop`); linked worktree cards scroll in a viewport (`renderLinkedCards`). Manages card grid layout, hierarchical navigation, input modes (normal, create, fetch-PR, confirm-delete, confirm-create-sandbox, confirm-remove-sandbox, enroll-sandbox-from-card), mouse toggle, periodic refresh, and two-zone click detection. When embedded inside `App`, skips its own header rendering (the App renders it above both panels).
 - **`internal/tui/card`** -- Pure render function that produces card content for a single worktree. Displays branch, path, PR status, agent info, dirty status, and sync status using lipgloss styles.
 - **`internal/warp`** -- Terminal tab/panel management. Creates named repo tabs and split panels. Supports Warp, iTerm, Terminal.app on macOS; gnome-terminal, konsole, xfce4-terminal on Linux.
 
@@ -301,7 +379,7 @@ gwaim is structured into the following internal packages:
 
 1. On startup, `App.Init()` loads the repo config and opens each repository. The current directory's repo is auto-added by `main.go` before launch.
 2. Each repo's `Model.Init()` starts its own refresh cycles: quick refresh (branch names), local refresh (dirty + agents every 5s), and network refresh (fetch + PRs at configurable interval).
-3. All async messages carry a `repoPath` field. `App.Update` routes each message to the matching child `Model` by path. Messages for removed repos are silently discarded.
+3. All async messages carry a `repoPath` field. `App.Update` routes each message to the matching child `Model` by path (matched against `repoGroup.path`). Messages for removed repos are silently discarded.
 4. `Model.renderFixedTop` produces the pinned main card section; `Model.renderLinkedCards` produces the scrollable worktree card grid. Both record card bounding zones for click detection.
 5. `Model.syncViewport` caches the fixed-top content and pushes linked cards into the viewport, dynamically sizing the viewport height.
 6. `App.View` composes: header (title only, 1 row) + two bordered panels (repo list + dashboard) using manually-rendered border characters for pixel-perfect height matching. Refresh timestamps are rendered inside the right panel by the embedded Model's `renderFixedTop`, not in the App header.

--- a/cmd/gwaim/main.go
+++ b/cmd/gwaim/main.go
@@ -47,7 +47,7 @@ func main() {
 			repo, openErr := git.OpenRepository(repoRoot)
 			if openErr == nil {
 				cfg, _ := config.Load(configPath)
-				if cfg.Add(repoRoot, repo.RepoName()) {
+				if cfg.Add(repoRoot, repo.RepoName(), config.ModeEntry{Type: "regular"}) {
 					_ = config.Save(configPath, cfg)
 				}
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,10 +7,25 @@ import (
 	"path/filepath"
 )
 
-// RepoEntry represents a registered repository.
+// ModeEntry describes how a repo is managed: regular (host worktrees) or
+// sandbox (Docker Sandbox via sbx CLI).
+type ModeEntry struct {
+	Type        string `json:"type"`                   // "regular" or "sandbox"
+	SandboxName string `json:"sandbox_name,omitempty"` // sbx sandbox name (sandbox only)
+	Agent       string `json:"agent,omitempty"`        // agent name (sandbox only, e.g. "claude")
+}
+
+// RepoEntry represents a registered repository with one or more modes.
 type RepoEntry struct {
-	Path string `json:"path"` // absolute path to repo root
-	Name string `json:"name"` // display name (e.g., "owner/repo")
+	Path  string      `json:"path"`  // absolute path to repo root
+	Name  string      `json:"name"`  // display name (e.g., "owner/repo")
+	Modes []ModeEntry `json:"modes"` // at least one mode (regular or sandbox)
+
+	// Legacy fields for backward-compatible deserialization.
+	// Zeroed after migration; omitempty ensures they don't get written back.
+	Sandbox        bool   `json:"sandbox,omitempty"`
+	OldSandboxName string `json:"sandbox_name,omitempty"`
+	OldAgent       string `json:"agent,omitempty"`
 }
 
 // Config holds the list of registered repositories.
@@ -30,6 +45,7 @@ func DefaultPath() string {
 
 // Load reads the config from the given path.
 // Returns an empty Config (not an error) if the file does not exist.
+// Migrates old-format entries (no Modes field) to the new format.
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -42,7 +58,55 @@ func Load(path string) (*Config, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+	cfg.migrate()
 	return &cfg, nil
+}
+
+// migrate converts old-format entries (Sandbox bool, no Modes) to the new
+// format. Entries with the same path are merged into a single entry with
+// multiple modes.
+func (c *Config) migrate() {
+	merged := make(map[string]*RepoEntry)
+	var order []string
+
+	for i := range c.Repos {
+		r := &c.Repos[i]
+
+		// Convert old format to modes if needed.
+		if len(r.Modes) == 0 {
+			if r.Sandbox {
+				r.Modes = []ModeEntry{{
+					Type:        "sandbox",
+					SandboxName: r.OldSandboxName,
+					Agent:       r.OldAgent,
+				}}
+			} else {
+				r.Modes = []ModeEntry{{Type: "regular"}}
+			}
+		}
+		// Clear legacy fields.
+		r.Sandbox = false
+		r.OldSandboxName = ""
+		r.OldAgent = ""
+
+		// Merge entries with the same path.
+		if existing, ok := merged[r.Path]; ok {
+			for _, m := range r.Modes {
+				if !hasMode(existing.Modes, m) {
+					existing.Modes = append(existing.Modes, m)
+				}
+			}
+		} else {
+			merged[r.Path] = r
+			order = append(order, r.Path)
+		}
+	}
+
+	// Rebuild repos in original order.
+	c.Repos = make([]RepoEntry, 0, len(order))
+	for _, p := range order {
+		c.Repos = append(c.Repos, *merged[p])
+	}
 }
 
 // Save writes the config to the given path atomically (write to tmp, rename).
@@ -62,19 +126,54 @@ func Save(path string, cfg *Config) error {
 	return os.Rename(tmp, path)
 }
 
-// Add adds a repo entry if not already present (dedup by path).
-// Returns true if the entry was added.
-func (c *Config) Add(path, name string) bool {
-	for _, r := range c.Repos {
+// Add adds a mode to a repo. If the repo doesn't exist, it's created.
+// If adding a sandbox mode to a repo that has a regular mode, the regular
+// mode is replaced. Returns true if the config was changed.
+func (c *Config) Add(path, name string, mode ModeEntry) bool {
+	for i, r := range c.Repos {
 		if r.Path == path {
-			return false
+			if hasMode(r.Modes, mode) {
+				return false // already has this exact mode
+			}
+			// Adding sandbox replaces regular mode.
+			if mode.Type == "sandbox" {
+				c.Repos[i].Modes = removeRegularModes(r.Modes)
+			}
+			c.Repos[i].Modes = append(c.Repos[i].Modes, mode)
+			return true
 		}
 	}
-	c.Repos = append(c.Repos, RepoEntry{Path: path, Name: name})
+	c.Repos = append(c.Repos, RepoEntry{Path: path, Name: name, Modes: []ModeEntry{mode}})
 	return true
 }
 
-// Remove removes a repo entry by path.
+// RemoveMode removes a specific mode from a repo.
+// If the repo has no modes left, the entire entry is removed.
+// Returns true if the config was changed.
+func (c *Config) RemoveMode(path string, mode ModeEntry) bool {
+	for i, r := range c.Repos {
+		if r.Path == path {
+			newModes := make([]ModeEntry, 0, len(r.Modes))
+			for _, m := range r.Modes {
+				if !modesEqual(m, mode) {
+					newModes = append(newModes, m)
+				}
+			}
+			if len(newModes) == len(r.Modes) {
+				return false // mode not found
+			}
+			if len(newModes) == 0 {
+				c.Repos = append(c.Repos[:i], c.Repos[i+1:]...)
+			} else {
+				c.Repos[i].Modes = newModes
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// Remove removes a repo entry by path (all modes).
 // Returns true if the entry was found and removed.
 func (c *Config) Remove(path string) bool {
 	for i, r := range c.Repos {
@@ -94,4 +193,36 @@ func (c *Config) IndexOf(path string) int {
 		}
 	}
 	return -1
+}
+
+// hasMode returns true if modes contains an entry matching m.
+func hasMode(modes []ModeEntry, m ModeEntry) bool {
+	for _, existing := range modes {
+		if modesEqual(existing, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// modesEqual returns true if two mode entries are equivalent.
+func modesEqual(a, b ModeEntry) bool {
+	if a.Type != b.Type {
+		return false
+	}
+	if a.Type == "sandbox" {
+		return a.SandboxName == b.SandboxName
+	}
+	return true // both regular
+}
+
+// removeRegularModes returns a new slice with all regular modes removed.
+func removeRegularModes(modes []ModeEntry) []ModeEntry {
+	result := make([]ModeEntry, 0, len(modes))
+	for _, m := range modes {
+		if m.Type != "regular" {
+			result = append(result, m)
+		}
+	}
+	return result
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,8 +31,8 @@ func TestSaveAndLoad(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sub", "repos.json")
 	cfg := &Config{
 		Repos: []RepoEntry{
-			{Path: "/tmp/repo1", Name: "owner/repo1"},
-			{Path: "/tmp/repo2", Name: "owner/repo2"},
+			{Path: "/tmp/repo1", Name: "owner/repo1", Modes: []ModeEntry{{Type: "regular"}}},
+			{Path: "/tmp/repo2", Name: "owner/repo2", Modes: []ModeEntry{{Type: "sandbox", SandboxName: "sbx1", Agent: "claude"}}},
 		},
 	}
 
@@ -46,11 +47,11 @@ func TestSaveAndLoad(t *testing.T) {
 	if len(loaded.Repos) != 2 {
 		t.Fatalf("expected 2 repos, got %d", len(loaded.Repos))
 	}
-	if loaded.Repos[0].Path != "/tmp/repo1" {
-		t.Errorf("Repos[0].Path = %q, want /tmp/repo1", loaded.Repos[0].Path)
+	if loaded.Repos[0].Modes[0].Type != "regular" {
+		t.Errorf("Repos[0].Modes[0].Type = %q, want regular", loaded.Repos[0].Modes[0].Type)
 	}
-	if loaded.Repos[1].Name != "owner/repo2" {
-		t.Errorf("Repos[1].Name = %q, want owner/repo2", loaded.Repos[1].Name)
+	if loaded.Repos[1].Modes[0].Agent != "claude" {
+		t.Errorf("Repos[1].Modes[0].Agent = %q, want claude", loaded.Repos[1].Modes[0].Agent)
 	}
 }
 
@@ -58,78 +59,119 @@ func TestSaveAtomic(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "repos.json")
 
-	cfg := &Config{Repos: []RepoEntry{{Path: "/a", Name: "a"}}}
+	cfg := &Config{Repos: []RepoEntry{{Path: "/a", Name: "a", Modes: []ModeEntry{{Type: "regular"}}}}}
 	if err := Save(path, cfg); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
-	// Ensure no .tmp file remains.
 	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
 		t.Error("expected .tmp file to be cleaned up after atomic rename")
 	}
 }
 
-func TestAddDeduplicate(t *testing.T) {
+func TestAddNewRepo(t *testing.T) {
 	cfg := &Config{}
-
-	added := cfg.Add("/tmp/repo1", "repo1")
-	if !added {
-		t.Error("first Add should return true")
+	changed := cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "regular"})
+	if !changed {
+		t.Error("Add new repo should return true")
 	}
 	if len(cfg.Repos) != 1 {
 		t.Fatalf("expected 1 repo, got %d", len(cfg.Repos))
 	}
-
-	added = cfg.Add("/tmp/repo1", "repo1-different-name")
-	if added {
-		t.Error("duplicate Add should return false")
-	}
-	if len(cfg.Repos) != 1 {
-		t.Errorf("expected 1 repo after dedup, got %d", len(cfg.Repos))
+	if len(cfg.Repos[0].Modes) != 1 {
+		t.Fatalf("expected 1 mode, got %d", len(cfg.Repos[0].Modes))
 	}
 }
 
-func TestAddMultiple(t *testing.T) {
+func TestAddDuplicateMode(t *testing.T) {
 	cfg := &Config{}
-	cfg.Add("/tmp/repo1", "repo1")
-	cfg.Add("/tmp/repo2", "repo2")
-	cfg.Add("/tmp/repo3", "repo3")
+	cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "regular"})
+	changed := cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "regular"})
+	if changed {
+		t.Error("Add duplicate mode should return false")
+	}
+	if len(cfg.Repos[0].Modes) != 1 {
+		t.Errorf("expected 1 mode after dedup, got %d", len(cfg.Repos[0].Modes))
+	}
+}
 
-	if len(cfg.Repos) != 3 {
-		t.Errorf("expected 3 repos, got %d", len(cfg.Repos))
+func TestAddSandboxReplacesRegular(t *testing.T) {
+	cfg := &Config{}
+	cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "regular"})
+	changed := cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "sandbox", SandboxName: "sbx-claude", Agent: "claude"})
+	if !changed {
+		t.Error("Add sandbox should return true")
+	}
+	if len(cfg.Repos[0].Modes) != 1 {
+		t.Fatalf("expected 1 mode (regular replaced), got %d", len(cfg.Repos[0].Modes))
+	}
+	if cfg.Repos[0].Modes[0].Type != "sandbox" {
+		t.Errorf("mode type = %q, want sandbox", cfg.Repos[0].Modes[0].Type)
+	}
+}
+
+func TestAddMultipleSandboxModes(t *testing.T) {
+	cfg := &Config{}
+	cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "sandbox", SandboxName: "sbx-claude", Agent: "claude"})
+	cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "sandbox", SandboxName: "sbx-gemini", Agent: "gemini"})
+	if len(cfg.Repos[0].Modes) != 2 {
+		t.Fatalf("expected 2 sandbox modes, got %d", len(cfg.Repos[0].Modes))
+	}
+}
+
+func TestRemoveMode(t *testing.T) {
+	cfg := &Config{}
+	cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "sandbox", SandboxName: "sbx-claude", Agent: "claude"})
+	cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "sandbox", SandboxName: "sbx-gemini", Agent: "gemini"})
+
+	removed := cfg.RemoveMode("/tmp/repo1", ModeEntry{Type: "sandbox", SandboxName: "sbx-claude"})
+	if !removed {
+		t.Error("RemoveMode should return true")
+	}
+	if len(cfg.Repos[0].Modes) != 1 {
+		t.Fatalf("expected 1 mode after removal, got %d", len(cfg.Repos[0].Modes))
+	}
+	if cfg.Repos[0].Modes[0].Agent != "gemini" {
+		t.Errorf("remaining mode agent = %q, want gemini", cfg.Repos[0].Modes[0].Agent)
+	}
+}
+
+func TestRemoveLastModeRemovesRepo(t *testing.T) {
+	cfg := &Config{}
+	cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "regular"})
+
+	removed := cfg.RemoveMode("/tmp/repo1", ModeEntry{Type: "regular"})
+	if !removed {
+		t.Error("RemoveMode should return true")
+	}
+	if len(cfg.Repos) != 0 {
+		t.Errorf("expected 0 repos after removing last mode, got %d", len(cfg.Repos))
+	}
+}
+
+func TestRemoveModeNonExistent(t *testing.T) {
+	cfg := &Config{}
+	cfg.Add("/tmp/repo1", "repo1", ModeEntry{Type: "regular"})
+
+	removed := cfg.RemoveMode("/tmp/repo1", ModeEntry{Type: "sandbox", SandboxName: "nope"})
+	if removed {
+		t.Error("RemoveMode should return false for non-existent mode")
 	}
 }
 
 func TestRemove(t *testing.T) {
 	cfg := &Config{
 		Repos: []RepoEntry{
-			{Path: "/tmp/repo1", Name: "repo1"},
-			{Path: "/tmp/repo2", Name: "repo2"},
+			{Path: "/tmp/repo1", Name: "repo1", Modes: []ModeEntry{{Type: "regular"}}},
+			{Path: "/tmp/repo2", Name: "repo2", Modes: []ModeEntry{{Type: "regular"}}},
 		},
 	}
-
 	removed := cfg.Remove("/tmp/repo1")
 	if !removed {
-		t.Error("Remove should return true for existing entry")
+		t.Error("Remove should return true")
 	}
-	if len(cfg.Repos) != 1 {
-		t.Fatalf("expected 1 repo after removal, got %d", len(cfg.Repos))
-	}
-	if cfg.Repos[0].Path != "/tmp/repo2" {
-		t.Errorf("remaining repo = %q, want /tmp/repo2", cfg.Repos[0].Path)
-	}
-}
-
-func TestRemoveNonExistent(t *testing.T) {
-	cfg := &Config{
-		Repos: []RepoEntry{{Path: "/tmp/repo1", Name: "repo1"}},
-	}
-	removed := cfg.Remove("/tmp/nope")
-	if removed {
-		t.Error("Remove should return false for non-existent path")
-	}
-	if len(cfg.Repos) != 1 {
-		t.Errorf("repos should be unchanged, got %d", len(cfg.Repos))
+	if len(cfg.Repos) != 1 || cfg.Repos[0].Path != "/tmp/repo2" {
+		t.Errorf("unexpected repos after remove: %v", cfg.Repos)
 	}
 }
 
@@ -140,15 +182,112 @@ func TestIndexOf(t *testing.T) {
 			{Path: "/tmp/repo2", Name: "repo2"},
 		},
 	}
-
 	if idx := cfg.IndexOf("/tmp/repo1"); idx != 0 {
 		t.Errorf("IndexOf(/tmp/repo1) = %d, want 0", idx)
 	}
-	if idx := cfg.IndexOf("/tmp/repo2"); idx != 1 {
-		t.Errorf("IndexOf(/tmp/repo2) = %d, want 1", idx)
-	}
 	if idx := cfg.IndexOf("/tmp/nope"); idx != -1 {
 		t.Errorf("IndexOf(/tmp/nope) = %d, want -1", idx)
+	}
+}
+
+func TestMigrateOldFormatRegular(t *testing.T) {
+	// Simulate old-format JSON with Sandbox: false
+	oldJSON := `{"repos":[{"path":"/tmp/repo","name":"repo","sandbox":false}]}`
+	path := filepath.Join(t.TempDir(), "repos.json")
+	if err := os.WriteFile(path, []byte(oldJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(cfg.Repos))
+	}
+	if len(cfg.Repos[0].Modes) != 1 || cfg.Repos[0].Modes[0].Type != "regular" {
+		t.Errorf("expected regular mode, got %v", cfg.Repos[0].Modes)
+	}
+	// Legacy fields should be cleared.
+	if cfg.Repos[0].Sandbox {
+		t.Error("legacy Sandbox field should be cleared")
+	}
+}
+
+func TestMigrateOldFormatSandbox(t *testing.T) {
+	oldJSON := `{"repos":[{"path":"/tmp/repo","name":"repo","sandbox":true,"sandbox_name":"my-sbx","agent":"claude"}]}`
+	path := filepath.Join(t.TempDir(), "repos.json")
+	if err := os.WriteFile(path, []byte(oldJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Repos[0].Modes) != 1 {
+		t.Fatalf("expected 1 mode, got %d", len(cfg.Repos[0].Modes))
+	}
+	m := cfg.Repos[0].Modes[0]
+	if m.Type != "sandbox" || m.SandboxName != "my-sbx" || m.Agent != "claude" {
+		t.Errorf("unexpected mode: %+v", m)
+	}
+}
+
+func TestMigrateMergesDuplicatePaths(t *testing.T) {
+	// Old format: same repo twice (regular + sandbox)
+	oldJSON := `{"repos":[
+		{"path":"/tmp/repo","name":"repo"},
+		{"path":"/tmp/repo","name":"repo","sandbox":true,"sandbox_name":"sbx","agent":"claude"}
+	]}`
+	path := filepath.Join(t.TempDir(), "repos.json")
+	if err := os.WriteFile(path, []byte(oldJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("expected 1 merged repo, got %d", len(cfg.Repos))
+	}
+	if len(cfg.Repos[0].Modes) != 2 {
+		t.Fatalf("expected 2 modes, got %d", len(cfg.Repos[0].Modes))
+	}
+}
+
+func TestNewFormatRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "repos.json")
+	cfg := &Config{
+		Repos: []RepoEntry{
+			{
+				Path: "/tmp/repo",
+				Name: "repo",
+				Modes: []ModeEntry{
+					{Type: "sandbox", SandboxName: "sbx-claude", Agent: "claude"},
+					{Type: "sandbox", SandboxName: "sbx-gemini", Agent: "gemini"},
+				},
+			},
+		},
+	}
+	if err := Save(path, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify JSON doesn't contain legacy fields.
+	data, _ := os.ReadFile(path)
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Repos) != 1 || len(loaded.Repos[0].Modes) != 2 {
+		t.Errorf("round-trip failed: %+v", loaded.Repos)
 	}
 }
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -547,24 +547,19 @@ func (r *Repository) resolveCredentialsForRemote(remote *gogit.Remote) (*githttp
 	return credentialFill(urls[0])
 }
 
-// FetchPR fetches a GitHub pull request's head ref and creates a worktree for it.
-// The PR ref (refs/pull/<N>/head) is fetched to a local branch named branchName.
-// If remoteURL is non-empty, it is used as the fetch URL (for fork PRs);
-// otherwise the default origin remote is used.
-// Returns the path of the created worktree.
-func (r *Repository) FetchPR(prNumber int, branchName, remoteURL string) (string, error) {
+// FetchPRRef fetches a pull request's head ref to a local branch without creating a worktree.
+// Used in sandbox mode where the worktree is created inside the sandbox via sbx.
+func (r *Repository) FetchPRRef(prNumber int, branchName, remoteURL string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if err := r.reopen(); err != nil {
-		return "", err
+		return err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Fetch refs/pull/<N>/head to refs/heads/<branchName>.
-	// Keep the original branch name (slashes allowed in git refs).
 	refSpec := config.RefSpec(fmt.Sprintf("+refs/pull/%d/head:refs/heads/%s", prNumber, branchName))
 	opts := &gogit.FetchOptions{
 		RefSpecs: []config.RefSpec{refSpec},
@@ -578,14 +573,25 @@ func (r *Repository) FetchPR(prNumber int, branchName, remoteURL string) (string
 		if isAuthError(err) {
 			auth, credErr := r.resolveCredentials()
 			if credErr != nil {
-				return "", fmt.Errorf("fetch PR auth: %w", credErr)
+				return fmt.Errorf("fetch PR auth: %w", credErr)
 			}
 			opts.Auth = auth
 			err = r.repo.FetchContext(ctx, opts)
 		}
 		if err != nil && err != gogit.NoErrAlreadyUpToDate {
-			return "", fmt.Errorf("fetch PR ref: %w", err)
+			return fmt.Errorf("fetch PR ref: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// FetchPR fetches a pull request's head ref and creates a worktree for it.
+// Delegates ref fetching to FetchPRRef, then creates a worktree on the host.
+// Returns the path of the created worktree.
+func (r *Repository) FetchPR(prNumber int, branchName, remoteURL string) (string, error) {
+	if err := r.FetchPRRef(prNumber, branchName, remoteURL); err != nil {
+		return "", err
 	}
 
 	// Create the worktree using the git CLI.

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -1,0 +1,198 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Available returns true if the sbx binary is found in PATH.
+func Available() bool {
+	_, err := exec.LookPath("sbx")
+	return err == nil
+}
+
+// CreateArgs returns the arguments for creating a sandbox without attaching:
+// sbx create --name <name> <agent> <repoPath>
+func CreateArgs(name, agent, repoPath string) []string {
+	return []string{"sbx", "create", "--name", name, agent, repoPath}
+}
+
+// RunDetachedWithBranchArgs returns the arguments for creating a worktree
+// inside an existing sandbox (detached, non-interactive):
+// sbx run -d --branch <branch> <sandboxName>
+func RunDetachedWithBranchArgs(sandboxName, branch string) []string {
+	return []string{"sbx", "run", "-d", "--branch", branch, sandboxName}
+}
+
+// RunWithBranchArgs returns the arguments for attaching to a sandbox worktree
+// (interactive): sbx run --branch <branch> <sandboxName>
+func RunWithBranchArgs(sandboxName, branch string) []string {
+	return []string{"sbx", "run", "--branch", branch, sandboxName}
+}
+
+// RemoveArgs returns the arguments for removing a sandbox:
+// sbx rm --force <name>
+func RemoveArgs(name string) []string {
+	return []string{"sbx", "rm", "--force", name}
+}
+
+// Remove runs sbx rm to remove a sandbox. Returns output and any error.
+func Remove(name string) (string, error) {
+	cmd := exec.Command("sbx", "rm", "--force", name)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// Start runs sbx run -d to start a stopped sandbox (detached, no attach).
+func Start(name string) (string, error) {
+	cmd := exec.Command("sbx", "run", "-d", name)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// Stop runs sbx stop to stop a sandbox without removing it.
+func Stop(name string) (string, error) {
+	cmd := exec.Command("sbx", "stop", name)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// SanitizeName creates a safe sandbox name from parts.
+// Replaces slashes and spaces with dashes, lowercases.
+func SanitizeName(parts ...string) string {
+	name := strings.Join(parts, "-")
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, " ", "-")
+	name = strings.ToLower(name)
+	return name
+}
+
+// CommandString joins args into a single shell command string.
+func CommandString(args []string) string {
+	return strings.Join(args, " ")
+}
+
+// Create runs sbx create as a background process and returns when it completes.
+// Returns the combined stdout+stderr output and any error.
+func Create(args []string) (string, error) {
+	cmd := exec.Command(args[0], args[1:]...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// RunDetached runs an sbx command (typically run -d) as a background process.
+// Returns the combined stdout+stderr output and any error.
+func RunDetached(args []string) (string, error) {
+	cmd := exec.Command(args[0], args[1:]...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// Status represents the state of a sandbox.
+type Status int
+
+const (
+	StatusNotFound Status = iota // sandbox does not exist
+	StatusRunning                // sandbox exists and is running
+	StatusStopped                // sandbox exists but is stopped
+)
+
+// CheckAllStatuses returns a map of sandbox name → status for all known sandboxes.
+// Runs one "sbx ls --json" call. Names not in the result have StatusNotFound.
+func CheckAllStatuses() map[string]Status {
+	cmd := exec.Command("sbx", "ls", "--json")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil
+	}
+	var result struct {
+		Sandboxes []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"sandboxes"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil
+	}
+	m := make(map[string]Status, len(result.Sandboxes))
+	for _, s := range result.Sandboxes {
+		if s.Status == "running" {
+			m[s.Name] = StatusRunning
+		} else {
+			m[s.Name] = StatusStopped
+		}
+	}
+	return m
+}
+
+// CheckStatus returns the status of a sandbox by name.
+// Runs "sbx ls --json" and looks for a matching entry.
+func CheckStatus(name string) Status {
+	cmd := exec.Command("sbx", "ls", "--json")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return StatusNotFound
+	}
+	var result struct {
+		Sandboxes []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"sandboxes"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return StatusNotFound
+	}
+	for _, s := range result.Sandboxes {
+		if s.Name == name {
+			if s.Status == "running" {
+				return StatusRunning
+			}
+			return StatusStopped
+		}
+	}
+	return StatusNotFound
+}
+
+// VersionInfo holds sbx client and server version strings.
+type VersionInfo struct {
+	Client string
+	Server string
+}
+
+// Version returns the sbx client and server versions.
+func Version() VersionInfo {
+	cmd := exec.Command("sbx", "version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return VersionInfo{}
+	}
+	var info VersionInfo
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(line, "Client Version:"); ok {
+			info.Client = strings.TrimSpace(after)
+		}
+		if after, ok := strings.CutPrefix(line, "Server Version:"); ok {
+			info.Server = strings.TrimSpace(after)
+		}
+	}
+	return info
+}
+
+// Preflight checks whether sbx is fully bootstrapped (installed, authenticated,
+// daemon running, network policy set). Runs "sbx ls --json" which exercises
+// the full stack. Returns nil if ready, or an error with user-facing instructions.
+func Preflight() error {
+	if !Available() {
+		return fmt.Errorf("sbx CLI not found in PATH — install it from https://docs.docker.com/ai/sandboxes/")
+	}
+	cmd := exec.Command("sbx", "ls", "--json")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		output := strings.TrimSpace(string(out))
+		return fmt.Errorf("sbx not ready — run 'sbx ls' in a terminal to complete setup (auth, network policy).\nsbx output: %s", output)
+	}
+	return nil
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,0 +1,56 @@
+package sandbox
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCreateArgs(t *testing.T) {
+	got := CreateArgs("my-sandbox", "claude", "/tmp/repo")
+	want := []string{"sbx", "create", "--name", "my-sandbox", "claude", "/tmp/repo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("CreateArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestRunDetachedWithBranchArgs(t *testing.T) {
+	got := RunDetachedWithBranchArgs("my-sandbox", "feature/login")
+	want := []string{"sbx", "run", "-d", "--branch", "feature/login", "my-sandbox"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RunDetachedWithBranchArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestRunWithBranchArgs(t *testing.T) {
+	got := RunWithBranchArgs("my-sandbox", "feature/login")
+	want := []string{"sbx", "run", "--branch", "feature/login", "my-sandbox"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RunWithBranchArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		parts []string
+		want  string
+	}{
+		{[]string{"owner/repo"}, "owner-repo"},
+		{[]string{"owner/repo", "claude"}, "owner-repo-claude"},
+		{[]string{"My Repo", "gemini"}, "my-repo-gemini"},
+	}
+	for _, tt := range tests {
+		got := SanitizeName(tt.parts...)
+		if got != tt.want {
+			t.Errorf("SanitizeName(%v) = %q, want %q", tt.parts, got, tt.want)
+		}
+	}
+}
+
+func TestCommandString(t *testing.T) {
+	args := []string{"sbx", "run", "--branch", "feature", "my-sandbox"}
+	got := CommandString(args)
+	want := "sbx run --branch feature my-sandbox"
+	if got != want {
+		t.Errorf("CommandString() = %q, want %q", got, want)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mdelapenya/gwaim/internal/git"
 	"github.com/mdelapenya/gwaim/internal/ide"
 	"github.com/mdelapenya/gwaim/internal/process"
+	"github.com/mdelapenya/gwaim/internal/sandbox"
 )
 
 type focusPanel int
@@ -27,16 +28,21 @@ const (
 type appMode int
 
 const (
-	appModeNormal        appMode = iota
-	appModeAddRepo                      // text input for repo path
-	appModeConfirmRemove                // confirmation prompt for repo removal
+	appModeNormal          appMode = iota
+	appModeAddRepo                        // text input for repo path
+	appModeConfirmRemove                  // confirmation prompt for repo removal
+	appModeSelectRepoMode                 // choose regular vs sandbox after path validation
+	appModeEnrollAgent                    // text input for sandbox agent name (add-repo flow)
+	appModeAddSandboxMode                 // text input for agent to add sandbox mode to existing repo
 )
 
-// repoTab holds the state for a single registered repository.
-type repoTab struct {
-	path  string // repo root path (unique key)
-	name  string // display name
-	model Model  // per-repo worktree dashboard
+// repoGroup holds the state for a single registered repository with its modes.
+type repoGroup struct {
+	path       string             // repo root path (unique key)
+	name       string             // display name
+	modes      []config.ModeEntry // all modes for this repo
+	activeMode int                // index into modes
+	model      Model              // per-repo worktree dashboard
 }
 
 // panelScroll holds scroll state for a bordered panel's scrollbar.
@@ -46,7 +52,7 @@ type panelScroll struct {
 
 // App is the top-level bubbletea model that manages multiple repositories.
 type App struct {
-	repos            []*repoTab
+	repos            []*repoGroup
 	active           int        // selected repo index
 	focus            focusPanel // which panel has focus
 	detector         *agent.Detector
@@ -59,7 +65,12 @@ type App struct {
 	textInput        textinput.Model
 	statusMsg        string
 	refreshInterval  time.Duration
-	repoScrollOffset int // first visible repo card index
+	repoScrollOffset    int // first visible repo card index
+	pendingRepo         *repoValidatedMsg // holds validated repo during mode/agent selection
+	pendingAgent        string            // agent name during sandbox enrollment preflight
+	pendingEnrollPath   string            // repo path for from-card sandbox enrollment
+	pendingEnrollAgent  string            // agent for from-card sandbox enrollment
+	sbxStatuses         map[string]sandbox.Status // system-wide sandbox statuses for tree dots
 }
 
 // addRepoMsg is returned after validating and opening a new repo.
@@ -68,6 +79,7 @@ type addRepoMsg struct {
 	name string
 	repo *git.Repository
 	err  error
+	mode config.ModeEntry
 }
 
 // NewApp creates a new App model.
@@ -88,6 +100,7 @@ func NewApp(configPath string, detector *agent.Detector, ideDetector *ide.Detect
 		configPath:      configPath,
 		textInput:       ti,
 		refreshInterval: refreshInterval,
+		sbxStatuses:     make(map[string]sandbox.Status),
 	}
 }
 
@@ -105,13 +118,19 @@ func (a App) Init() tea.Cmd {
 			continue // skip repos that can't be opened
 		}
 		m := newEmbedded(repo, a.detector, a.ideDetector, a.procLister, a.refreshInterval)
+		modes := entry.Modes
+		if len(modes) == 0 {
+			modes = []config.ModeEntry{{Type: "regular"}}
+		}
+		m.activeMode = &modes[0]
 		if i != 0 {
 			// Non-active repos start paused — no tick chains.
 			m.paused = true
 		}
-		a.repos = append(a.repos, &repoTab{
+		a.repos = append(a.repos, &repoGroup{
 			path:  entry.Path,
 			name:  entry.Name,
+			modes: modes,
 			model: m,
 		})
 		if i == 0 {
@@ -120,17 +139,25 @@ func (a App) Init() tea.Cmd {
 		}
 	}
 
+	// Seed sandbox statuses so tree dots are correct from the start.
+	if statusMap := sandbox.CheckAllStatuses(); statusMap != nil {
+		for k, v := range statusMap {
+			a.sbxStatuses[k] = v
+		}
+	}
+
 	// Return the modified app as a cmd that sets up repos.
 	// Since Init() can't mutate the receiver, we use a message.
 	return func() tea.Msg {
-		return appInitMsg{repos: a.repos, cmds: cmds}
+		return appInitMsg{repos: a.repos, sbxStatuses: a.sbxStatuses, cmds: cmds}
 	}
 }
 
 // appInitMsg carries the repos loaded during Init.
 type appInitMsg struct {
-	repos []*repoTab
-	cmds  []tea.Cmd
+	repos       []*repoGroup
+	cmds        []tea.Cmd
+	sbxStatuses map[string]sandbox.Status
 }
 
 // childResizeMsg is a WindowSizeMsg targeted at the active child model only.
@@ -144,6 +171,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case appInitMsg:
 		a.repos = msg.repos
+		if msg.sbxStatuses != nil {
+			a.sbxStatuses = msg.sbxStatuses
+		}
 		if len(a.repos) > 0 {
 			a.focus = focusRight
 		}
@@ -186,6 +216,62 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 
+	case repoValidatedMsg:
+		return a.handleRepoValidatedMsg(msg)
+
+	case sandboxCreatedMsg:
+		if msg.err != nil {
+			a.statusMsg = errorStyle.Render("Sandbox: " + msg.err.Error())
+		} else {
+			a.statusMsg = cleanStyle.Render("Sandbox created: " + msg.repoName)
+		}
+		return a, nil
+
+	case enrollSandboxRequestMsg:
+		// Non-sandbox repo wants to enroll — run preflight.
+		a.pendingEnrollPath = msg.repoPath
+		a.pendingEnrollAgent = msg.mode.Agent
+		return a, doSandboxPreflight()
+
+	case sandboxPreflightMsg:
+		if msg.err != nil {
+			a.statusMsg = errorStyle.Render(msg.err.Error())
+			// Clear both enrollment flows.
+			if a.pendingEnrollPath != "" {
+				a.pendingEnrollPath = ""
+				a.pendingEnrollAgent = ""
+				// Update child status.
+				for i, rt := range a.repos {
+					if rt.path == a.pendingEnrollPath {
+						a.repos[i].model.statusMsg = errorStyle.Render(msg.err.Error())
+						break
+					}
+				}
+			} else {
+				a.mode = appModeNormal
+				a.pendingRepo = nil
+				a.pendingAgent = ""
+			}
+			return a, nil
+		}
+
+		// sbx is ready. Check which enrollment flow we're in.
+		if a.pendingEnrollPath != "" {
+			// From-card enrollment: update existing repo to sandbox mode.
+			return a.finalizeCardEnrollment()
+		}
+
+		// From add-repo enrollment.
+		pending := a.pendingRepo
+		agentName := a.pendingAgent
+		a.pendingRepo = nil
+		a.pendingAgent = ""
+		a.mode = appModeNormal
+		a.statusMsg = cleanStyle.Render("Adding sandbox repository...")
+		sbxName := sandbox.SanitizeName(pending.name, agentName)
+		mode := config.ModeEntry{Type: "sandbox", SandboxName: sbxName, Agent: agentName}
+		return a, doFinalizeAddRepo(pending, mode, a.configPath)
+
 	case addRepoMsg:
 		return a.handleAddRepoMsg(msg)
 
@@ -203,6 +289,17 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if rt.path == rp {
 				updated, cmd := rt.model.Update(msg)
 				a.repos[i].model = updated.(Model)
+
+				// Sync sandbox statuses from child to App level (system-wide data).
+				for k, v := range a.repos[i].model.modeStatuses {
+					a.sbxStatuses[k] = v
+				}
+
+				// After sandbox removal succeeds, remove the mode from the group.
+				if rm, ok := msg.(sandboxRemovedMsg); ok && rm.err == nil {
+					a.removeSandboxModeFromGroup(i, rm.sandboxName)
+				}
+
 				return a, cmd
 			}
 		}
@@ -231,9 +328,94 @@ func (a App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				a.statusMsg = ""
 				return a, nil
 			}
+			a.statusMsg = cleanStyle.Render("Validating repository...")
+			return a, doValidateRepo(input)
+		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+			a.mode = appModeNormal
+			a.statusMsg = ""
+			return a, nil
+		default:
+			var cmd tea.Cmd
+			a.textInput, cmd = a.textInput.Update(msg)
+			return a, cmd
+		}
+	}
+
+	// Handle repo mode selection (regular vs sandbox).
+	if a.mode == appModeSelectRepoMode {
+		switch {
+		case key.Matches(msg, key.NewBinding(key.WithKeys("r"))):
+			// Regular mode — finalize immediately.
+			pending := a.pendingRepo
+			a.pendingRepo = nil
 			a.mode = appModeNormal
 			a.statusMsg = cleanStyle.Render("Adding repository...")
-			return a, doAddRepo(input, a.configPath)
+			return a, doFinalizeAddRepo(pending, config.ModeEntry{Type: "regular"}, a.configPath)
+		case key.Matches(msg, key.NewBinding(key.WithKeys("s"))):
+			// Sandbox mode — prompt for agent name.
+			a.mode = appModeEnrollAgent
+			a.textInput.Reset()
+			a.textInput.Placeholder = "agent (claude, codex, copilot, gemini, kiro, opencode, shell)"
+			a.textInput.Focus()
+			a.statusMsg = ""
+			return a, a.textInput.Cursor.BlinkCmd()
+		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+			a.mode = appModeNormal
+			a.pendingRepo = nil
+			a.statusMsg = ""
+			return a, nil
+		}
+		return a, nil
+	}
+
+	// Handle sandbox agent name input.
+	if a.mode == appModeEnrollAgent {
+		switch {
+		case key.Matches(msg, key.NewBinding(key.WithKeys("enter"))):
+			agentName := strings.TrimSpace(a.textInput.Value())
+			if agentName == "" {
+				a.mode = appModeNormal
+				a.pendingRepo = nil
+				a.statusMsg = ""
+				return a, nil
+			}
+			// Store the agent while we run the preflight check.
+			a.pendingAgent = agentName
+			a.statusMsg = cleanStyle.Render("Checking sbx readiness...")
+			return a, doSandboxPreflight()
+		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+			a.mode = appModeNormal
+			a.pendingRepo = nil
+			a.statusMsg = ""
+			return a, nil
+		default:
+			var cmd tea.Cmd
+			a.textInput, cmd = a.textInput.Update(msg)
+			return a, cmd
+		}
+	}
+
+	// Handle add sandbox mode to existing repo.
+	if a.mode == appModeAddSandboxMode {
+		switch {
+		case key.Matches(msg, key.NewBinding(key.WithKeys("enter"))):
+			agentName := strings.TrimSpace(a.textInput.Value())
+			if agentName == "" {
+				a.mode = appModeNormal
+				a.statusMsg = ""
+				return a, nil
+			}
+			// Store for preflight flow.
+			if a.active < len(a.repos) {
+				rg := a.repos[a.active]
+				a.pendingEnrollPath = rg.path
+				a.pendingEnrollAgent = agentName
+				a.mode = appModeNormal
+				a.statusMsg = cleanStyle.Render("Checking sbx readiness...")
+				return a, doSandboxPreflight()
+			}
+			a.mode = appModeNormal
+			return a, nil
 		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
 			a.mode = appModeNormal
 			a.statusMsg = ""
@@ -250,15 +432,52 @@ func (a App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("y", "Y"))):
 			if a.active >= 0 && a.active < len(a.repos) {
-				rt := a.repos[a.active]
-				// Remove from config. Errors are non-fatal — the in-memory state is canonical.
-				cfg, err := config.Load(a.configPath)
-				if err == nil {
-					cfg.Remove(rt.path)
-					_ = config.Save(a.configPath, cfg)
+				rg := a.repos[a.active]
+				activeMode := rg.modes[rg.activeMode]
+
+				if len(rg.modes) > 1 {
+					// Multiple modes: remove just the active mode.
+					cfg, err := config.Load(a.configPath)
+					if err == nil {
+						cfg.RemoveMode(rg.path, activeMode)
+						_ = config.Save(a.configPath, cfg)
+					}
+					// Update in-memory modes.
+					rg.modes = append(rg.modes[:rg.activeMode], rg.modes[rg.activeMode+1:]...)
+					if rg.activeMode >= len(rg.modes) {
+						rg.activeMode = len(rg.modes) - 1
+					}
+					updated, cmd := rg.model.SetActiveMode(&rg.modes[rg.activeMode])
+					rg.model = updated
+					a.statusMsg = cleanStyle.Render("Mode removed")
+					a.mode = appModeNormal
+					return a, cmd
 				}
 
-				// Remove from repos slice.
+				if activeMode.Type == "sandbox" {
+					// Last mode is sandbox: convert to regular instead of removing.
+					regularMode := config.ModeEntry{Type: "regular"}
+					cfg, err := config.Load(a.configPath)
+					if err == nil {
+						cfg.RemoveMode(rg.path, activeMode)
+						cfg.Add(rg.path, rg.name, regularMode)
+						_ = config.Save(a.configPath, cfg)
+					}
+					rg.modes = []config.ModeEntry{regularMode}
+					rg.activeMode = 0
+					updated, cmd := rg.model.SetActiveMode(&rg.modes[0])
+					rg.model = updated
+					a.statusMsg = cleanStyle.Render("Sandbox removed — repo converted to host mode")
+					a.mode = appModeNormal
+					return a, cmd
+				}
+
+				// Last mode is regular: remove the entire repo.
+				cfg, err := config.Load(a.configPath)
+				if err == nil {
+					cfg.Remove(rg.path)
+					_ = config.Save(a.configPath, cfg)
+				}
 				a.repos = append(a.repos[:a.active], a.repos[a.active+1:]...)
 				if a.active >= len(a.repos) && len(a.repos) > 0 {
 					a.active = len(a.repos) - 1
@@ -369,15 +588,31 @@ func (a App) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	leftWidth := a.leftPanelWidth()
 
 	if msg.X < leftWidth {
-		// Click in left panel — focus it and select the repo at this row.
+		// Click in left panel — focus it and find which mode was clicked.
 		a.focus = focusLeft
-		// Repo cards start at: header height + 1 (panel border) + 1 ("Repos" label).
-		// Each card is repoCardHeight lines tall. Add scroll offset.
+		// Tree content starts at: header height + 1 (panel border) + 1 ("Repos" label).
 		contentY := msg.Y - hh - 2
 		if contentY >= 0 {
-			cardIdx := contentY/repoCardHeight + a.repoScrollOffset
-			if cardIdx >= 0 && cardIdx < len(a.repos) && cardIdx != a.active {
-				return a.switchRepo(cardIdx)
+			// Iterate through groups to find which line was clicked.
+			lineIdx := 0
+			for gi, rg := range a.repos {
+				// Clicking the group header selects its first mode.
+				if lineIdx == contentY {
+					if gi != a.active || rg.activeMode != 0 {
+						return a.switchMode(gi, 0)
+					}
+					return a, nil
+				}
+				lineIdx++ // group header line
+				for mi := range rg.modes {
+					if lineIdx == contentY {
+						if gi != a.active || mi != rg.activeMode {
+							return a.switchMode(gi, mi)
+						}
+						return a, nil
+					}
+					lineIdx++
+				}
 			}
 		}
 		return a, nil
@@ -399,13 +634,9 @@ func (a App) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 func (a App) handleLeftPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, key.NewBinding(key.WithKeys("up", "k"))):
-		if a.active > 0 {
-			return a.switchRepo(a.active - 1)
-		}
+		return a.moveModeUp()
 	case key.Matches(msg, key.NewBinding(key.WithKeys("down", "j"))):
-		if a.active < len(a.repos)-1 {
-			return a.switchRepo(a.active + 1)
-		}
+		return a.moveModeDown()
 	case key.Matches(msg, key.NewBinding(key.WithKeys("a"))):
 		a.mode = appModeAddRepo
 		a.textInput.Reset()
@@ -413,6 +644,16 @@ func (a App) handleLeftPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.textInput.Focus()
 		a.statusMsg = ""
 		return a, a.textInput.Cursor.BlinkCmd()
+	case key.Matches(msg, key.NewBinding(key.WithKeys("n"))):
+		if len(a.repos) > 0 && a.active < len(a.repos) {
+			a.mode = appModeAddSandboxMode
+			a.textInput.Reset()
+			a.textInput.Placeholder = "agent (claude, codex, copilot, gemini, kiro, opencode, shell)"
+			a.textInput.Focus()
+			a.statusMsg = ""
+			return a, a.textInput.Cursor.BlinkCmd()
+		}
+		return a, nil
 	case key.Matches(msg, key.NewBinding(key.WithKeys("x"))):
 		if len(a.repos) > 0 && a.active < len(a.repos) {
 			a.mode = appModeConfirmRemove
@@ -425,6 +666,97 @@ func (a App) handleLeftPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 	}
+	return a, nil
+}
+
+// removeSandboxModeFromGroup removes a sandbox mode by name from a group.
+// If it was the last sandbox, converts to regular. Updates config.
+func (a App) removeSandboxModeFromGroup(groupIdx int, sbxName string) {
+	rg := a.repos[groupIdx]
+
+	// Find and remove the mode.
+	var remaining []config.ModeEntry
+	for _, m := range rg.modes {
+		if m.Type == "sandbox" && m.SandboxName == sbxName {
+			continue
+		}
+		remaining = append(remaining, m)
+	}
+
+	if len(remaining) == len(rg.modes) {
+		return // mode not found, nothing to do
+	}
+
+	// If no modes left, convert to regular.
+	if len(remaining) == 0 {
+		remaining = []config.ModeEntry{{Type: "regular"}}
+	}
+
+	// Update config.
+	cfg, err := config.Load(a.configPath)
+	if err == nil {
+		cfg.RemoveMode(rg.path, config.ModeEntry{Type: "sandbox", SandboxName: sbxName})
+		if len(remaining) == 1 && remaining[0].Type == "regular" {
+			cfg.Add(rg.path, rg.name, remaining[0])
+		}
+		_ = config.Save(a.configPath, cfg)
+	}
+
+	// Update in-memory group.
+	rg.modes = remaining
+	if rg.activeMode >= len(rg.modes) {
+		rg.activeMode = len(rg.modes) - 1
+	}
+	updated, _ := rg.model.SetActiveMode(&rg.modes[rg.activeMode])
+	rg.model = updated
+}
+
+// finalizeCardEnrollment converts an existing regular repo to sandbox mode.
+func (a App) finalizeCardEnrollment() (tea.Model, tea.Cmd) {
+	repoPath := a.pendingEnrollPath
+	agentName := a.pendingEnrollAgent
+	a.pendingEnrollPath = ""
+	a.pendingEnrollAgent = ""
+
+	// Find the repo and update it.
+	for i, rt := range a.repos {
+		if rt.path == repoPath {
+			sbxName := sandbox.SanitizeName(rt.name, agentName)
+			newMode := config.ModeEntry{Type: "sandbox", SandboxName: sbxName, Agent: agentName}
+
+			// Update config: add sandbox mode (replaces regular if present).
+			cfg, _ := config.Load(a.configPath)
+			cfg.Add(repoPath, rt.name, newMode)
+			_ = config.Save(a.configPath, cfg)
+
+			// Reload modes from config (cfg.Add handles dedup/replace logic).
+			idx := cfg.IndexOf(repoPath)
+			if idx >= 0 {
+				a.repos[i].modes = cfg.Repos[idx].Modes
+			}
+			// Select the newly added mode.
+			newModeIdx := len(a.repos[i].modes) - 1
+			a.repos[i].activeMode = newModeIdx
+			a.repos[i].model.activeMode = &a.repos[i].modes[newModeIdx]
+			a.repos[i].model.statusMsg = cleanStyle.Render("Creating sandbox (this may take a few minutes)...")
+
+			// Create the sandbox.
+			sbxArgs := sandbox.CreateArgs(sbxName, agentName, repoPath)
+			return a, doCreateSandbox(sbxArgs, rt.name)
+		}
+	}
+	return a, nil
+}
+
+func (a App) handleRepoValidatedMsg(msg repoValidatedMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		a.statusMsg = errorStyle.Render("Error: " + msg.err.Error())
+		a.mode = appModeNormal
+		return a, nil
+	}
+	a.pendingRepo = &msg
+	a.mode = appModeSelectRepoMode
+	a.statusMsg = ""
 	return a, nil
 }
 
@@ -441,18 +773,30 @@ func (a App) handleAddRepoMsg(msg addRepoMsg) (tea.Model, tea.Cmd) {
 
 	// Create the child model (starts unpaused — it's the new active).
 	m := newEmbedded(msg.repo, a.detector, a.ideDetector, a.procLister, a.refreshInterval)
-	rt := &repoTab{
+	modes := []config.ModeEntry{msg.mode}
+	m.activeMode = &modes[0]
+	rg := &repoGroup{
 		path:  msg.path,
 		name:  msg.name,
+		modes: modes,
 		model: m,
 	}
-	a.repos = append(a.repos, rt)
+	a.repos = append(a.repos, rg)
 	a.active = len(a.repos) - 1
 	a.focus = focusRight
 	a.statusMsg = cleanStyle.Render("Repository added: " + msg.name)
 
-	// Resize the new child and start its refresh cycle.
-	return a, tea.Batch(rt.model.Init(), a.resizeActiveChild())
+	var cmds []tea.Cmd
+	cmds = append(cmds, rg.model.Init(), a.resizeActiveChild())
+
+	// For sandbox repos, create the sandbox in the background.
+	// The preflight check already confirmed sbx is ready (no interactive prompts).
+	if msg.mode.Type == "sandbox" && msg.mode.Agent != "" {
+		sbxArgs := sandbox.CreateArgs(msg.mode.SandboxName, msg.mode.Agent, msg.path)
+		cmds = append(cmds, doCreateSandbox(sbxArgs, msg.name))
+	}
+
+	return a, tea.Batch(cmds...)
 }
 
 // appTitleStyle is the title style for the App header — no MarginBottom,
@@ -511,12 +855,21 @@ func (a App) View() string {
 	b.WriteString("\n")
 	b.WriteString(columns)
 
-	if a.mode == appModeAddRepo {
+	switch a.mode {
+	case appModeAddRepo:
 		b.WriteString("\n")
 		b.WriteString(inputPromptStyle.Render("  Repository path: ") + a.textInput.View())
-	} else if a.statusMsg != "" {
+	case appModeSelectRepoMode:
 		b.WriteString("\n")
-		b.WriteString(a.statusMsg)
+		b.WriteString(inputPromptStyle.Render("  Mode: [s] Sandbox (recommended)  [r] Regular  [esc] Cancel"))
+	case appModeEnrollAgent, appModeAddSandboxMode:
+		b.WriteString("\n")
+		b.WriteString(inputPromptStyle.Render("  Agent: ") + a.textInput.View())
+	default:
+		if a.statusMsg != "" {
+			b.WriteString("\n")
+			b.WriteString(a.statusMsg)
+		}
 	}
 
 	result := b.String()
@@ -525,9 +878,19 @@ func (a App) View() string {
 	if a.mode == appModeConfirmRemove {
 		popup := a.renderConfirmRemovePopup()
 		result = overlayCenter(result, popup, a.width, a.height)
-	} else if a.active >= 0 && a.active < len(a.repos) && a.repos[a.active].model.mode == modeConfirmDelete {
-		popup := a.repos[a.active].model.renderConfirmPopup()
-		result = overlayCenter(result, popup, a.width, a.height)
+	} else if a.active >= 0 && a.active < len(a.repos) {
+		child := a.repos[a.active].model
+		switch child.mode {
+		case modeConfirmDelete:
+			popup := child.renderConfirmPopup()
+			result = overlayCenter(result, popup, a.width, a.height)
+		case modeConfirmCreateSandbox:
+			popup := child.renderConfirmCreateSandboxPopup()
+			result = overlayCenter(result, popup, a.width, a.height)
+		case modeConfirmRemoveSandbox:
+			popup := child.renderConfirmRemoveSandboxPopup()
+			result = overlayCenter(result, popup, a.width, a.height)
+		}
 	}
 
 	return result
@@ -547,8 +910,13 @@ func (a App) renderEmptyState() string {
 	title := titleStyle.Render("gwaim - Git Worktree Agent Manager")
 	body := "\n\nNo repositories registered.\nPress 'a' to add a repository.\n"
 
-	if a.mode == appModeAddRepo {
+	switch a.mode {
+	case appModeAddRepo:
 		body += "\n" + inputPromptStyle.Render("  Repository path: ") + a.textInput.View() + "\n"
+	case appModeSelectRepoMode:
+		body += "\n" + inputPromptStyle.Render("  Mode: [s] Sandbox (recommended)  [r] Regular  [esc] Cancel") + "\n"
+	case appModeEnrollAgent, appModeAddSandboxMode:
+		body += "\n" + inputPromptStyle.Render("  Agent: ") + a.textInput.View() + "\n"
 	}
 	if a.statusMsg != "" {
 		body += "\n" + a.statusMsg + "\n"
@@ -558,74 +926,96 @@ func (a App) renderEmptyState() string {
 	return title + body + "\n" + help
 }
 
-// repoCardHeight is the number of lines each repo card occupies
-// (top border + content + bottom border).
-const repoCardHeight = 3
+// repoGroupHeight returns the number of lines a group occupies in the tree:
+// 1 header line + 1 line per mode.
+func repoGroupHeight(rg *repoGroup) int {
+	return 1 + len(rg.modes)
+}
+
+// totalTreeLines returns the total number of lines all repo groups occupy.
+func (a App) totalTreeLines() int {
+	total := 0
+	for _, rg := range a.repos {
+		total += repoGroupHeight(rg)
+	}
+	return total
+}
 
 func (a App) renderRepoList(width, panelHeight int) string {
-	innerWidth := width - 4 // panel border + padding
+	innerWidth := width - 4
 	if innerWidth < 10 {
 		innerWidth = 10
 	}
-
-	// Card content width: innerWidth minus card border(2) and card padding(2).
-	cardContentWidth := innerWidth - 4
-	// Name max: card content minus marker(2).
-	maxNameWidth := cardContentWidth - 2
+	maxNameWidth := innerWidth - 4 // margin for marker + emoji
 	if maxNameWidth < 5 {
 		maxNameWidth = 5
 	}
 
-	// Calculate visible range based on scroll offset.
-	visibleCards := (panelHeight - 2) / repoCardHeight // -2 for header + help
-	if visibleCards < 1 {
-		visibleCards = 1
-	}
-	start := a.repoScrollOffset
-	end := start + visibleCards
-	if end > len(a.repos) {
-		end = len(a.repos)
-	}
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("245"))
+	repoNameStyle := lipgloss.NewStyle().Faint(true)
 
-	// Top section: header + visible repo cards.
 	var parts []string
-	parts = append(parts, lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("245")).Render("Repos"))
+	parts = append(parts, headerStyle.Render("Repos"))
 
-	for i := start; i < end; i++ {
-		rt := a.repos[i]
-		marker := "  "
-		if i == a.active {
-			marker = "▸ "
-		}
-
-		name := rt.name
+	for gi, rg := range a.repos {
+		// Group header: repo name (dimmed, not selectable).
+		name := rg.name
 		if len(name) > maxNameWidth {
 			name = name[:maxNameWidth-1] + "…"
 		}
+		parts = append(parts, repoNameStyle.Render(name))
 
-		nameStyle := unselectedRepoStyle
-		cs := repoCardStyle.Width(cardContentWidth)
-		if i == a.active {
-			nameStyle = selectedRepoStyle
-			cs = selectedRepoCardStyle.Width(cardContentWidth)
+		// Mode children: one line each.
+		for mi, mode := range rg.modes {
+			isSelected := gi == a.active && mi == rg.activeMode
+			marker := "  "
+			if isSelected {
+				marker = "▸ "
+			}
+
+			var label string
+			if mode.Type == "sandbox" {
+				agent := mode.Agent
+				if agent == "" {
+					agent = "sbx"
+				}
+				// Status dot: green=running, yellow=stopped, red=not found.
+				status := sandbox.StatusNotFound
+				if s, ok := a.sbxStatuses[mode.SandboxName]; ok {
+					status = s
+				}
+				var dot string
+				switch status {
+				case sandbox.StatusRunning:
+					dot = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Render("●")
+				case sandbox.StatusStopped:
+					dot = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("●")
+				default:
+					dot = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("●")
+				}
+				label = "🐳 [" + agent + "] " + dot
+			} else {
+				label = "📂 [host]"
+			}
+
+			style := unselectedRepoStyle
+			if isSelected {
+				style = selectedRepoStyle
+			}
+			parts = append(parts, style.Render(marker+label))
 		}
-
-		parts = append(parts, cs.Render(marker+nameStyle.Render(name)))
 	}
 
 	topContent := strings.Join(parts, "\n")
 
-	// Bottom section: help hint.
-	help := repoPanelHelpStyle.Render("[a]dd [x]rm")
+	help := repoPanelHelpStyle.Render("[a]dd [n]ew sandbox [x]rm")
 
-	// Combine top and bottom with fill space between them.
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		topContent,
 		lipgloss.NewStyle().Height(panelHeight-lipgloss.Height(topContent)-1).Render(""),
 		help,
 	)
 
-	// Hard-clamp to panelHeight lines so it never exceeds the panel.
 	lines := strings.Split(content, "\n")
 	if len(lines) > panelHeight {
 		lines = lines[:panelHeight]
@@ -640,46 +1030,128 @@ func (a App) renderDashboard(width int) string {
 	return ""
 }
 
-// switchRepo pauses the current repo's ticks, changes active, and resumes the new one.
-// Returns the App and a tea.Cmd that starts the new repo's tick chains + resize.
-func (a App) switchRepo(newIdx int) (App, tea.Cmd) {
-	if newIdx == a.active || newIdx < 0 || newIdx >= len(a.repos) {
+// moveModeDown moves to the next mode child in the tree. If at the last mode
+// of a group, moves to the first mode of the next group.
+func (a App) moveModeDown() (tea.Model, tea.Cmd) {
+	if len(a.repos) == 0 {
 		return a, nil
 	}
-	// Pause old.
+	gi := a.active
+	mi := a.repos[gi].activeMode
+
+	// Try next mode in current group.
+	if mi+1 < len(a.repos[gi].modes) {
+		return a.switchMode(gi, mi+1)
+	}
+	// Try first mode of next group.
+	if gi+1 < len(a.repos) {
+		return a.switchMode(gi+1, 0)
+	}
+	return a, nil
+}
+
+// moveModeUp moves to the previous mode child in the tree. If at the first mode
+// of a group, moves to the last mode of the previous group.
+func (a App) moveModeUp() (tea.Model, tea.Cmd) {
+	if len(a.repos) == 0 {
+		return a, nil
+	}
+	gi := a.active
+	mi := a.repos[gi].activeMode
+
+	// Try previous mode in current group.
+	if mi > 0 {
+		return a.switchMode(gi, mi-1)
+	}
+	// Try last mode of previous group.
+	if gi > 0 {
+		prevGroup := a.repos[gi-1]
+		return a.switchMode(gi-1, len(prevGroup.modes)-1)
+	}
+	return a, nil
+}
+
+// switchMode switches the active group and/or mode. If the group changes,
+// the old model is paused and the new one resumed.
+// seedModelStatuses copies App-level sandbox statuses into a model's modeStatuses
+// so SetActiveMode reads correct status without waiting for a refresh.
+func (a App) seedModelStatuses(groupIdx int) {
+	if groupIdx < 0 || groupIdx >= len(a.repos) {
+		return
+	}
+	for k, v := range a.sbxStatuses {
+		a.repos[groupIdx].model.modeStatuses[k] = v
+	}
+}
+
+func (a App) switchMode(groupIdx, modeIdx int) (tea.Model, tea.Cmd) {
+	if groupIdx < 0 || groupIdx >= len(a.repos) {
+		return a, nil
+	}
+	rg := a.repos[groupIdx]
+	if modeIdx < 0 || modeIdx >= len(rg.modes) {
+		return a, nil
+	}
+
+	// Seed the target model's modeStatuses from App-level cache so
+	// SetActiveMode reads correct status without waiting for a refresh.
+	a.seedModelStatuses(groupIdx)
+
+	if groupIdx == a.active {
+		// Same group: just update mode, no pause/resume.
+		a.repos[groupIdx].activeMode = modeIdx
+		updated, cmd := a.repos[groupIdx].model.SetActiveMode(&a.repos[groupIdx].modes[modeIdx])
+		a.repos[groupIdx].model = updated
+		a = a.ensureActiveRepoVisible()
+		return a, cmd
+	}
+
+	// Different group: pause old, resume new.
 	if a.active < len(a.repos) {
 		a.repos[a.active].model = a.repos[a.active].model.Pause()
 	}
-	a.active = newIdx
+	a.active = groupIdx
+	a.repos[groupIdx].activeMode = modeIdx
 	a = a.ensureActiveRepoVisible()
-	// Resume new.
-	resumed, cmd := a.repos[a.active].model.Resume()
-	a.repos[a.active].model = resumed
-	return a, tea.Batch(cmd, a.resizeActiveChild())
+	resumed, cmd := a.repos[groupIdx].model.Resume()
+	a.repos[groupIdx].model = resumed
+	updated, modeCmd := a.repos[groupIdx].model.SetActiveMode(&a.repos[groupIdx].modes[modeIdx])
+	a.repos[groupIdx].model = updated
+	return a, tea.Batch(cmd, modeCmd, a.resizeActiveChild())
 }
 
-// visibleRepoCards returns how many repo cards fit in the left panel.
-func (a App) visibleRepoCards() int {
+
+// visibleRepoLines returns how many content lines fit in the left panel.
+func (a App) visibleRepoLines() int {
 	contentH := a.height - a.headerHeight() - 2 // -2 for panel border
 	if contentH < 1 {
 		contentH = 1
 	}
 	// Subtract 2 for "Repos" header (1) + help footer (1).
-	v := (contentH - 2) / repoCardHeight
+	v := contentH - 2
 	if v < 1 {
 		v = 1
 	}
 	return v
 }
 
-// ensureActiveRepoVisible adjusts repoScrollOffset so the active repo is visible.
+// ensureActiveRepoVisible adjusts repoScrollOffset so the active group is visible.
 func (a App) ensureActiveRepoVisible() App {
-	visible := a.visibleRepoCards()
-	if a.active < a.repoScrollOffset {
-		a.repoScrollOffset = a.active
+	// Compute the line offset of the active group's active mode.
+	targetLine := 0
+	for i, rg := range a.repos {
+		if i == a.active {
+			targetLine += 1 + rg.activeMode // header + mode offset
+			break
+		}
+		targetLine += repoGroupHeight(rg)
 	}
-	if a.active >= a.repoScrollOffset+visible {
-		a.repoScrollOffset = a.active - visible + 1
+	visible := a.visibleRepoLines()
+	if targetLine < a.repoScrollOffset {
+		a.repoScrollOffset = targetLine
+	}
+	if targetLine >= a.repoScrollOffset+visible {
+		a.repoScrollOffset = targetLine - visible + 1
 	}
 	a = a.clampRepoScroll()
 	return a
@@ -687,8 +1159,8 @@ func (a App) ensureActiveRepoVisible() App {
 
 // clampRepoScroll ensures repoScrollOffset is within valid bounds.
 func (a App) clampRepoScroll() App {
-	visible := a.visibleRepoCards()
-	maxOffset := len(a.repos) - visible
+	visible := a.visibleRepoLines()
+	maxOffset := a.totalTreeLines() - visible
 	if maxOffset < 0 {
 		maxOffset = 0
 	}
@@ -704,8 +1176,8 @@ func (a App) clampRepoScroll() App {
 // repoScrollState returns the scroll state for the left panel scrollbar.
 func (a App) repoScrollState() panelScroll {
 	return panelScroll{
-		total:   len(a.repos),
-		visible: a.visibleRepoCards(),
+		total:   a.totalTreeLines(),
+		visible: a.visibleRepoLines(),
 		offset:  a.repoScrollOffset,
 	}
 }
@@ -882,32 +1354,79 @@ func extractRepoPath(msg tea.Msg) string {
 		return m.repoPath
 	case netFlashDoneMsg:
 		return m.repoPath
+	case sandboxCreatedFromCardMsg:
+		return m.repoPath
+	case sandboxStartedMsg:
+		return m.repoPath
+	case sandboxStoppedCmdMsg:
+		return m.repoPath
+	case sandboxRemovedMsg:
+		return m.repoPath
+	case enrollSandboxRequestMsg:
+		return m.repoPath
 	case cliCheckMsg:
 		return m.repoPath
 	}
 	return ""
 }
 
-// doAddRepo validates a path and opens it as a git repository.
-func doAddRepo(input, configPath string) tea.Cmd {
+// doValidateRepo validates a repo path without saving to config.
+// Returns a repoValidatedMsg so the user can choose regular/sandbox mode.
+func doValidateRepo(input string) tea.Cmd {
 	return func() tea.Msg {
 		root, err := git.RepoRoot(input)
 		if err != nil {
-			return addRepoMsg{err: fmt.Errorf("not a git repository: %s", input)}
+			return repoValidatedMsg{err: fmt.Errorf("not a git repository: %s", input)}
 		}
 
 		repo, err := git.OpenRepository(root)
 		if err != nil {
-			return addRepoMsg{err: fmt.Errorf("cannot open repository: %w", err)}
+			return repoValidatedMsg{err: fmt.Errorf("cannot open repository: %w", err)}
 		}
 
-		name := repo.RepoName()
+		return repoValidatedMsg{path: root, name: repo.RepoName(), repo: repo}
+	}
+}
 
-		// Persist to config.
+// doFinalizeAddRepo persists a validated repo to config and returns an addRepoMsg.
+func doFinalizeAddRepo(pending *repoValidatedMsg, mode config.ModeEntry, configPath string) tea.Cmd {
+	return func() tea.Msg {
 		cfg, _ := config.Load(configPath)
-		cfg.Add(root, name)
+		cfg.Add(pending.path, pending.name, mode)
 		_ = config.Save(configPath, cfg)
 
-		return addRepoMsg{path: root, name: name, repo: repo}
+		return addRepoMsg{
+			path: pending.path,
+			name: pending.name,
+			repo: pending.repo,
+			mode: mode,
+		}
+	}
+}
+
+// sandboxPreflightMsg carries the result of the sbx readiness check.
+type sandboxPreflightMsg struct {
+	err error // nil if sbx is ready
+}
+
+// doSandboxPreflight checks if sbx is bootstrapped (auth, daemon, policy).
+func doSandboxPreflight() tea.Cmd {
+	return func() tea.Msg {
+		return sandboxPreflightMsg{err: sandbox.Preflight()}
+	}
+}
+
+// sandboxCreatedMsg is sent after sbx create completes.
+type sandboxCreatedMsg struct {
+	repoName string
+	output   string
+	err      error
+}
+
+// doCreateSandbox runs sbx create in the background.
+func doCreateSandbox(args []string, repoName string) tea.Cmd {
+	return func() tea.Msg {
+		out, err := sandbox.Create(args)
+		return sandboxCreatedMsg{repoName: repoName, output: out, err: err}
 	}
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -11,10 +11,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/mdelapenya/gwaim/internal/agent"
+	"github.com/mdelapenya/gwaim/internal/config"
 	"github.com/mdelapenya/gwaim/internal/git"
 )
 
-// testApp creates an App with n pre-populated repoTabs using fake data.
+// testApp creates an App with n pre-populated repoGroups using fake data.
 func testApp(n int) App {
 	ti := textinput.New()
 	ti.Placeholder = "/path/to/repository"
@@ -34,9 +35,12 @@ func testApp(n int) App {
 		m := testModel(2)
 		m.embedded = true
 		m.worktrees[0].Path = path
-		app.repos = append(app.repos, &repoTab{
+		modes := []config.ModeEntry{{Type: "regular"}}
+		m.activeMode = &modes[0]
+		app.repos = append(app.repos, &repoGroup{
 			path:  path,
 			name:  "owner/repo-" + name,
+			modes: modes,
 			model: m,
 		})
 	}
@@ -441,7 +445,7 @@ func TestAppAddRepoMsg_Success(t *testing.T) {
 	app := updated.(App)
 
 	// Repo won't actually be added because msg.repo is nil and New(nil, ...) creates a model.
-	// But the repoTab will be created.
+	// But the repoGroup will be created.
 	if len(app.repos) != 1 {
 		t.Errorf("expected 1 repo after add, got %d", len(app.repos))
 	}
@@ -496,7 +500,7 @@ func TestAppInitMsg(t *testing.T) {
 	a.height = 40
 
 	// Simulate what Init() produces.
-	repos := []*repoTab{
+	repos := []*repoGroup{
 		{path: "/tmp/repo-a", name: "owner/repo-a", model: testModel(2)},
 		{path: "/tmp/repo-b", name: "owner/repo-b", model: testModel(3)},
 	}
@@ -517,7 +521,7 @@ func TestAppInitMsg_ResizesChildren(t *testing.T) {
 	a.width = 120
 	a.height = 40
 
-	repos := []*repoTab{
+	repos := []*repoGroup{
 		{path: "/tmp/repo-a", name: "owner/repo-a", model: testModel(2)},
 	}
 	msg := appInitMsg{repos: repos, cmds: nil}
@@ -594,7 +598,8 @@ func TestAppMouseClickLeftPanel_SelectsRepo(t *testing.T) {
 	a.focus = focusRight
 	a.active = 0
 
-	// Second repo card starts at Y=6 (header=1 + border=1 + "Repos"=1 + card0=3).
+	// Second repo's mode: Y = headerHeight(1) + panelBorder(1) + "Repos"(1) + group0_header(1) + group0_mode(1) + group1_header(1) = 6.
+	// contentY=3 maps to group1 mode0.
 	msg := tea.MouseMsg{X: 5, Y: 6, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress}
 	updated, _ := a.Update(msg)
 	app := updated.(App)
@@ -841,5 +846,163 @@ func TestAppConfirmDeleteRendersPopup(t *testing.T) {
 	}
 	if !strings.Contains(view, "[y] confirm") {
 		t.Errorf("App.View should show [y] confirm hint, got:\n%s", view)
+	}
+}
+
+// --- Sandbox enrollment flow tests ---
+
+func TestAppAddRepoValidation_EntersSelectRepoMode(t *testing.T) {
+	a := testApp(0)
+	a.mode = appModeAddRepo
+
+	// Simulate receiving a repoValidatedMsg.
+	validated := repoValidatedMsg{path: "/tmp/test-repo", name: "owner/test", repo: nil}
+	updated, _ := a.Update(validated)
+	app := updated.(App)
+
+	if app.mode != appModeSelectRepoMode {
+		t.Errorf("mode = %d, want appModeSelectRepoMode", app.mode)
+	}
+	if app.pendingRepo == nil {
+		t.Error("pendingRepo should be set after validation")
+	}
+}
+
+func TestAppAddRepoValidation_ErrorStaysNormal(t *testing.T) {
+	a := testApp(0)
+	a.mode = appModeAddRepo
+
+	validated := repoValidatedMsg{err: fmt.Errorf("not a git repo")}
+	updated, _ := a.Update(validated)
+	app := updated.(App)
+
+	if app.mode != appModeNormal {
+		t.Errorf("mode = %d, want appModeNormal on error", app.mode)
+	}
+	if !strings.Contains(app.statusMsg, "not a git repo") {
+		t.Errorf("statusMsg should contain error, got %q", app.statusMsg)
+	}
+}
+
+func TestAppSelectRepoMode_Regular(t *testing.T) {
+	a := testApp(0)
+	a.mode = appModeSelectRepoMode
+	a.pendingRepo = &repoValidatedMsg{path: "/tmp/repo", name: "owner/repo"}
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	updated, cmd := a.Update(msg)
+	app := updated.(App)
+
+	if app.mode != appModeNormal {
+		t.Errorf("mode = %d, want appModeNormal after 'r'", app.mode)
+	}
+	if app.pendingRepo != nil {
+		t.Error("pendingRepo should be cleared after selection")
+	}
+	if cmd == nil {
+		t.Error("expected a cmd to finalize repo addition")
+	}
+}
+
+func TestAppSelectRepoMode_Sandbox(t *testing.T) {
+	a := testApp(0)
+	a.mode = appModeSelectRepoMode
+	a.pendingRepo = &repoValidatedMsg{path: "/tmp/repo", name: "owner/repo"}
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}}
+	updated, _ := a.Update(msg)
+	app := updated.(App)
+
+	if app.mode != appModeEnrollAgent {
+		t.Errorf("mode = %d, want appModeEnrollAgent after 's'", app.mode)
+	}
+	if app.pendingRepo == nil {
+		t.Error("pendingRepo should still be set during agent input")
+	}
+}
+
+func TestAppSelectRepoMode_Escape(t *testing.T) {
+	a := testApp(0)
+	a.mode = appModeSelectRepoMode
+	a.pendingRepo = &repoValidatedMsg{path: "/tmp/repo", name: "owner/repo"}
+
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	updated, _ := a.Update(msg)
+	app := updated.(App)
+
+	if app.mode != appModeNormal {
+		t.Errorf("mode = %d, want appModeNormal after esc", app.mode)
+	}
+	if app.pendingRepo != nil {
+		t.Error("pendingRepo should be cleared after esc")
+	}
+}
+
+func TestAppEnrollAgent_Escape(t *testing.T) {
+	a := testApp(0)
+	a.mode = appModeEnrollAgent
+	a.pendingRepo = &repoValidatedMsg{path: "/tmp/repo", name: "owner/repo"}
+
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	updated, _ := a.Update(msg)
+	app := updated.(App)
+
+	if app.mode != appModeNormal {
+		t.Errorf("mode = %d, want appModeNormal after esc", app.mode)
+	}
+	if app.pendingRepo != nil {
+		t.Error("pendingRepo should be cleared after esc")
+	}
+}
+
+func TestAppAddRepoMsg_SandboxFlag(t *testing.T) {
+	a := testApp(0)
+
+	msg := addRepoMsg{
+		path: "/tmp/sbx-repo",
+		name: "owner/sbx-repo",
+		mode: config.ModeEntry{Type: "sandbox", SandboxName: "owner-sbx-repo-claude", Agent: "claude"},
+	}
+	updated, _ := a.Update(msg)
+	app := updated.(App)
+
+	if len(app.repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(app.repos))
+	}
+	if !app.repos[0].model.isSandbox() {
+		t.Error("model should be in sandbox mode")
+	}
+	if app.repos[0].model.sbxName() != "owner-sbx-repo-claude" {
+		t.Errorf("sbxName = %q, want %q", app.repos[0].model.sbxName(), "owner-sbx-repo-claude")
+	}
+}
+
+func TestAppRepoListShowsSandboxIndicator(t *testing.T) {
+	a := testApp(1)
+	a.repos[0].model.activeMode = &config.ModeEntry{Type: "sandbox", SandboxName: "my-sbx", Agent: "claude"}
+
+	view := a.View()
+	if !strings.Contains(view, "🐳") {
+		t.Errorf("repo list should show docker whale icon for sandbox repos, got:\n%s", view)
+	}
+}
+
+func TestAppSelectRepoModeRendering(t *testing.T) {
+	a := testApp(1)
+	a.mode = appModeSelectRepoMode
+
+	view := a.View()
+	if !strings.Contains(view, "Regular") || !strings.Contains(view, "Sandbox") {
+		t.Errorf("should show Regular/Sandbox choices, got:\n%s", view)
+	}
+}
+
+func TestAppEnrollAgentRendering(t *testing.T) {
+	a := testApp(1)
+	a.mode = appModeEnrollAgent
+
+	view := a.View()
+	if !strings.Contains(view, "Agent:") {
+		t.Errorf("should show Agent: prompt, got:\n%s", view)
 	}
 }

--- a/internal/tui/card/card.go
+++ b/internal/tui/card/card.go
@@ -38,14 +38,36 @@ var (
 
 	cliUnavailStyle = lipgloss.NewStyle().Faint(true).Foreground(lipgloss.Color("214"))
 
+	sandboxRunStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))  // green
+	sandboxStopStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // yellow
+	sandboxWarnStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196")) // red
+
 	syncUpToDateStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
 	syncNeedSyncStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	syncDivergedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
 	syncUnknownStyle  = lipgloss.NewStyle().Faint(true)
 )
 
+// SandboxStatus represents the state of a sandbox for display.
+type SandboxStatus int
+
+const (
+	SandboxNotFound SandboxStatus = iota // sandbox does not exist
+	SandboxRunning                       // sandbox is running
+	SandboxStopped                       // sandbox exists but is stopped
+)
+
+// SandboxInfo holds sandbox-specific display data for a card.
+// When Name is non-empty, the card shows a sandbox badge.
+type SandboxInfo struct {
+	Name          string        // sandbox name (derived from repo + agent)
+	Status        SandboxStatus // current sandbox status
+	ClientVersion string        // sbx client version
+	ServerVersion string        // sbx server version
+}
+
 // Render produces the content for a single worktree card.
-func Render(wt git.Worktree, agents []agent.Info, ides []ide.Info, pr *provider.PRInfo, cliAvail provider.CLIAvailability, prov provider.Provider) string {
+func Render(wt git.Worktree, agents []agent.Info, ides []ide.Info, pr *provider.PRInfo, cliAvail provider.CLIAvailability, prov provider.Provider, sbx *SandboxInfo) string {
 	var b strings.Builder
 
 	// Branch line
@@ -61,7 +83,30 @@ func Render(wt git.Worktree, agents []agent.Info, ides []ide.Info, pr *provider.
 
 	// Path
 	b.WriteString(pathStyle.Render(wt.Path))
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+
+	// Sandbox info
+	if sbx != nil && sbx.Name != "" {
+		switch sbx.Status {
+		case SandboxRunning:
+			b.WriteString(sandboxRunStyle.Render("🐳 sandbox: " + sbx.Name + " (running)"))
+		case SandboxStopped:
+			b.WriteString(sandboxStopStyle.Render("🐳 sandbox: " + sbx.Name + " (stopped)"))
+		case SandboxNotFound:
+			b.WriteString(sandboxWarnStyle.Render("🐳 sandbox: " + sbx.Name + " (not found)"))
+		}
+		b.WriteString("\n")
+		if sbx.ClientVersion != "" {
+			ver := "sbx: client " + sbx.ClientVersion
+			if sbx.ServerVersion != "" {
+				ver += "  server " + sbx.ServerVersion
+			}
+			b.WriteString(pathStyle.Render(ver))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
 
 	// PR/MR status
 	prLabel := "PR"

--- a/internal/tui/card/card_test.go
+++ b/internal/tui/card/card_test.go
@@ -17,7 +17,7 @@ func TestRender_CleanNoAgent(t *testing.T) {
 		IsMain: true,
 	}
 
-	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "main") {
 		t.Error("expected branch name in output")
@@ -40,7 +40,7 @@ func TestRender_DirtyWithAgent(t *testing.T) {
 		{Kind: agent.Claude, PID: "12345"},
 	}
 
-	got := Render(wt, agents, nil, nil, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, agents, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "feature-auth") {
 		t.Error("expected branch name in output")
@@ -66,7 +66,7 @@ func TestRender_MultipleAgents(t *testing.T) {
 		{Kind: agent.Copilot, PID: "200"},
 	}
 
-	got := Render(wt, agents, nil, nil, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, agents, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "claude") {
 		t.Error("expected claude in output")
@@ -86,7 +86,7 @@ func TestRender_SubAgent(t *testing.T) {
 		{Kind: agent.Claude, PID: "200", IsSubAgent: true},
 	}
 
-	got := Render(wt, agents, nil, nil, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, agents, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "↳") {
 		t.Error("expected subagent indent marker '↳' in output")
@@ -103,7 +103,7 @@ func TestRender_DetachedHead(t *testing.T) {
 		Detached: true,
 	}
 
-	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "detached") {
 		t.Error("expected 'detached' in output")
@@ -122,7 +122,7 @@ func TestRender_WithPR(t *testing.T) {
 		CheckStatus: "success",
 	}
 
-	got := Render(wt, nil, nil, pr, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, nil, nil, pr, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "#42") {
 		t.Error("expected PR number in output")
@@ -151,7 +151,7 @@ func TestRender_WithDraftPR(t *testing.T) {
 		CheckStatus: "pending",
 	}
 
-	got := Render(wt, nil, nil, pr, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, nil, nil, pr, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "draft") {
 		t.Error("expected 'draft' state in output")
@@ -167,7 +167,7 @@ func TestRender_CLINotFound(t *testing.T) {
 		Branch: "feature-x",
 	}
 
-	got := Render(wt, nil, nil, nil, provider.CLINotFound, provider.ProviderGitHub)
+	got := Render(wt, nil, nil, nil, provider.CLINotFound, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "gh not installed") {
 		t.Error("expected 'gh not installed' message")
@@ -183,7 +183,7 @@ func TestRender_CLINotAuthenticated(t *testing.T) {
 		Branch: "feature-x",
 	}
 
-	got := Render(wt, nil, nil, nil, provider.CLINotAuthenticated, provider.ProviderGitHub)
+	got := Render(wt, nil, nil, nil, provider.CLINotAuthenticated, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "gh not authenticated") {
 		t.Error("expected 'gh not authenticated' message")
@@ -205,7 +205,7 @@ func TestRender_PRTakesPrecedenceOverCLIStatus(t *testing.T) {
 	}
 
 	// Even with CLINotAuthenticated, if we somehow have a PR, show it.
-	got := Render(wt, nil, nil, pr, provider.CLINotAuthenticated, provider.ProviderGitHub)
+	got := Render(wt, nil, nil, pr, provider.CLINotAuthenticated, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "#7") {
 		t.Error("expected PR number in output")
@@ -221,7 +221,7 @@ func TestRender_UnsupportedProvider_ShowsMessage(t *testing.T) {
 		Branch: "feature-x",
 	}
 
-	got := Render(wt, nil, nil, nil, provider.CLIUnsupportedProvider, provider.ProviderUnknown)
+	got := Render(wt, nil, nil, nil, provider.CLIUnsupportedProvider, provider.ProviderUnknown, nil)
 
 	if !strings.Contains(got, "not yet supported") {
 		t.Error("expected 'not yet supported' message, got: " + got)
@@ -239,7 +239,7 @@ func TestRender_GitLabProvider_UsesMRLabel(t *testing.T) {
 		State:  "open",
 	}
 
-	got := Render(wt, nil, nil, mr, provider.CLIAvailable, provider.ProviderGitLab)
+	got := Render(wt, nil, nil, mr, provider.CLIAvailable, provider.ProviderGitLab, nil)
 
 	if !strings.Contains(got, "MR") {
 		t.Error("expected MR label for GitLab provider")
@@ -255,7 +255,7 @@ func TestRender_GitLabNotFound(t *testing.T) {
 		Branch: "feature-x",
 	}
 
-	got := Render(wt, nil, nil, nil, provider.CLINotFound, provider.ProviderGitLab)
+	got := Render(wt, nil, nil, nil, provider.CLINotFound, provider.ProviderGitLab, nil)
 
 	if !strings.Contains(got, "glab not installed") {
 		t.Error("expected 'glab not installed' message, got: " + got)
@@ -271,7 +271,7 @@ func TestRender_GitLabNotAuthenticated(t *testing.T) {
 		Branch: "feature-x",
 	}
 
-	got := Render(wt, nil, nil, nil, provider.CLINotAuthenticated, provider.ProviderGitLab)
+	got := Render(wt, nil, nil, nil, provider.CLINotAuthenticated, provider.ProviderGitLab, nil)
 
 	if !strings.Contains(got, "glab not authenticated") {
 		t.Error("expected 'glab not authenticated' message, got: " + got)
@@ -290,7 +290,7 @@ func TestRender_WithIDE(t *testing.T) {
 		{Kind: ide.VSCode, PID: 42},
 	}
 
-	got := Render(wt, nil, ides, nil, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, nil, ides, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "vscode") {
 		t.Error("expected IDE kind in output")
@@ -307,7 +307,7 @@ func TestRender_NoIDE(t *testing.T) {
 		IsMain: true,
 	}
 
-	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "no IDE") {
 		t.Error("expected 'no IDE' indicator")
@@ -324,12 +324,74 @@ func TestRender_MultipleIDEs(t *testing.T) {
 		{Kind: ide.Neovim, PID: 200},
 	}
 
-	got := Render(wt, nil, ides, nil, provider.CLIAvailable, provider.ProviderGitHub)
+	got := Render(wt, nil, ides, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
 
 	if !strings.Contains(got, "vscode") {
 		t.Error("expected vscode in output")
 	}
 	if !strings.Contains(got, "neovim") {
 		t.Error("expected neovim in output")
+	}
+}
+
+func TestRender_SandboxRunning(t *testing.T) {
+	wt := git.Worktree{
+		Path:   "/home/user/project",
+		Branch: "main",
+		IsMain: true,
+	}
+	sbx := &SandboxInfo{Name: "owner-repo", Status: SandboxRunning}
+
+	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, sbx)
+
+	if !strings.Contains(got, "sandbox: owner-repo") {
+		t.Error("expected sandbox name in output")
+	}
+	if !strings.Contains(got, "running") {
+		t.Error("expected 'running' status")
+	}
+}
+
+func TestRender_SandboxStopped(t *testing.T) {
+	wt := git.Worktree{
+		Path:   "/home/user/project",
+		Branch: "main",
+		IsMain: true,
+	}
+	sbx := &SandboxInfo{Name: "owner-repo", Status: SandboxStopped}
+
+	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, sbx)
+
+	if !strings.Contains(got, "stopped") {
+		t.Error("expected 'stopped' status")
+	}
+}
+
+func TestRender_SandboxNotFound(t *testing.T) {
+	wt := git.Worktree{
+		Path:   "/home/user/project",
+		Branch: "main",
+		IsMain: true,
+	}
+	sbx := &SandboxInfo{Name: "owner-repo", Status: SandboxNotFound}
+
+	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, sbx)
+
+	if !strings.Contains(got, "not found") {
+		t.Error("expected 'not found' status")
+	}
+}
+
+func TestRender_NoSandboxInfo(t *testing.T) {
+	wt := git.Worktree{
+		Path:   "/home/user/project",
+		Branch: "main",
+		IsMain: true,
+	}
+
+	got := Render(wt, nil, nil, nil, provider.CLIAvailable, provider.ProviderGitHub, nil)
+
+	if strings.Contains(got, "sandbox:") {
+		t.Error("should not show sandbox info when nil")
 	}
 }

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -3,19 +3,22 @@ package tui
 import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
-	Left     key.Binding
-	Right    key.Binding
-	Up       key.Binding
-	Down     key.Binding
-	Create   key.Binding
-	FetchPR  key.Binding
-	Delete   key.Binding
-	Pull     key.Binding
-	Refresh  key.Binding
-	Editor   key.Binding
-	Mouse    key.Binding
-	Enter    key.Binding
-	Quit     key.Binding
+	Left           key.Binding
+	Right          key.Binding
+	Up             key.Binding
+	Down           key.Binding
+	Create         key.Binding
+	FetchPR        key.Binding
+	Delete         key.Binding
+	Pull           key.Binding
+	Refresh        key.Binding
+	Editor         key.Binding
+	Mouse          key.Binding
+	Enter          key.Binding
+	Quit           key.Binding
+	CreateSandbox  key.Binding
+	StartSandbox   key.Binding
+	StopSandbox    key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -71,6 +74,18 @@ func defaultKeyMap() keyMap {
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
 			key.WithHelp("q", "quit"),
+		),
+		CreateSandbox: key.NewBinding(
+			key.WithKeys("n"),
+			key.WithHelp("n", "new sandbox"),
+		),
+		StartSandbox: key.NewBinding(
+			key.WithKeys("s"),
+			key.WithHelp("s", "start sandbox"),
+		),
+		StopSandbox: key.NewBinding(
+			key.WithKeys("S"),
+			key.WithHelp("S", "stop sandbox"),
 		),
 	}
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"github.com/mdelapenya/gwaim/internal/agent"
+	"github.com/mdelapenya/gwaim/internal/config"
 	"github.com/mdelapenya/gwaim/internal/git"
 	"github.com/mdelapenya/gwaim/internal/ide"
 	"github.com/mdelapenya/gwaim/internal/provider"
@@ -18,15 +19,19 @@ const (
 
 // refreshMsg carries updated worktree and agent data.
 type refreshMsg struct {
-	repoPath  string // identifies which repo this message belongs to
-	source    refreshSource
-	worktrees []git.Worktree
-	agents    agent.DetectionResult
-	ides      ide.DetectionResult
-	prs       provider.PRResult
-	hasPRs    bool // true only when a network refresh attempted PR lookup
-	err       error
-	fetchErr  error
+	repoPath       string // identifies which repo this message belongs to
+	source         refreshSource
+	worktrees      []git.Worktree
+	agents         agent.DetectionResult
+	ides           ide.DetectionResult
+	prs            provider.PRResult
+	hasPRs         bool   // true only when a network refresh attempted PR lookup
+	err            error
+	fetchErr       error
+	sandboxStatus  int                // sandbox.Status value for active mode
+	allSbxStatuses map[string]int    // all sandbox name → status (for tree dots)
+	sbxClientVer   string            // sbx client version
+	sbxServerVer   string            // sbx server version
 }
 
 // worktreeCreatedMsg is sent after a worktree is successfully created.
@@ -34,6 +39,7 @@ type worktreeCreatedMsg struct {
 	repoPath   string
 	branchName string
 	err        error
+	sbxOutput  string // output from sbx create (empty for regular worktrees)
 }
 
 // worktreeRemovedMsg is sent after a worktree is removed.
@@ -103,4 +109,50 @@ type netFlashDoneMsg struct {
 type cliCheckMsg struct {
 	repoPath string
 	avail    provider.CLIAvailability
+}
+
+// sandboxStartedMsg is sent after sbx run -d (start) completes.
+type sandboxStartedMsg struct {
+	repoPath    string
+	sandboxName string
+	err         error
+}
+
+// sandboxStoppedCmdMsg is sent after sbx stop completes.
+type sandboxStoppedCmdMsg struct {
+	repoPath    string
+	sandboxName string
+	err         error
+}
+
+// sandboxRemovedMsg is sent after sbx rm completes.
+type sandboxRemovedMsg struct {
+	repoPath    string
+	sandboxName string
+	output      string
+	err         error
+}
+
+// sandboxCreatedFromCardMsg is sent after sbx create completes from the main card.
+type sandboxCreatedFromCardMsg struct {
+	repoPath    string
+	sandboxName string
+	output      string
+	err         error
+}
+
+// enrollSandboxRequestMsg is sent by the model when a non-sandbox repo
+// wants to enroll in sandbox mode from the main card.
+type enrollSandboxRequestMsg struct {
+	repoPath string
+	mode     config.ModeEntry
+}
+
+// repoValidatedMsg is sent after a repo path has been validated
+// but before the user selects regular/sandbox mode.
+type repoValidatedMsg struct {
+	path string
+	name string
+	repo *git.Repository
+	err  error
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -16,11 +15,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/mdelapenya/gwaim/internal/agent"
+	"github.com/mdelapenya/gwaim/internal/config"
 	"github.com/mdelapenya/gwaim/internal/git"
 	"github.com/mdelapenya/gwaim/internal/github"
 	"github.com/mdelapenya/gwaim/internal/ide"
 	"github.com/mdelapenya/gwaim/internal/process"
 	"github.com/mdelapenya/gwaim/internal/provider"
+	"github.com/mdelapenya/gwaim/internal/sandbox"
 	"github.com/mdelapenya/gwaim/internal/tui/card"
 	"github.com/mdelapenya/gwaim/internal/warp"
 )
@@ -44,6 +45,9 @@ const (
 	modeCreate
 	modeFetchPR
 	modeConfirmDelete
+	modeConfirmCreateSandbox
+	modeConfirmRemoveSandbox
+	modeEnrollSandboxFromCard // non-sandbox repo: prompt for agent to enroll
 )
 
 // Model is the top-level bubbletea model for gwaim.
@@ -82,6 +86,11 @@ type Model struct {
 	paused            bool      // true when repo is not the active tab; ticks stop self-scheduling
 	fixedTopHeight  int    // lines occupied by the fixed top section (main card + input)
 	fixedTopContent string // cached render of fixed top (set in syncViewport, read in viewContent)
+	activeMode     *config.ModeEntry    // current mode (nil means regular)
+	allWorktrees   []git.Worktree       // unfiltered worktree list from git
+	sandboxStatus  sandbox.Status              // active mode's sandbox status
+	sandboxVersion sandbox.VersionInfo         // sbx client/server versions
+	modeStatuses   map[string]sandbox.Status   // all sandbox name → status (for tree dots)
 }
 
 type zone struct {
@@ -120,6 +129,10 @@ func New(repo *git.Repository, detector *agent.Detector, ideDetector *ide.Detect
 		mouseOn:         true,
 		refreshInterval: refreshInterval,
 		prProv:          prProv,
+		agents:          make(agent.DetectionResult),
+		ides:            make(ide.DetectionResult),
+		prs:             make(provider.PRResult),
+		modeStatuses:    make(map[string]sandbox.Status),
 	}
 }
 
@@ -145,7 +158,7 @@ func (m Model) Resume() (Model, tea.Cmd) {
 	rp := m.repoPath()
 	return m, tea.Batch(
 		doQuickRefresh(m.repo, rp),
-		doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp),
+		doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName()),
 		m.doLocalTick(),
 		m.doTick(),
 	)
@@ -179,6 +192,96 @@ func (m Model) repoPath() string {
 	return ""
 }
 
+func (m Model) repoName() string {
+	if m.repo != nil {
+		return m.repo.RepoName()
+	}
+	return ""
+}
+
+// isSandbox returns true if the current mode is sandbox.
+func (m Model) isSandbox() bool {
+	return m.activeMode != nil && m.activeMode.Type == "sandbox"
+}
+
+// sbxName returns the sandbox name from the active mode, or empty string.
+func (m Model) sbxName() string {
+	if m.activeMode != nil {
+		return m.activeMode.SandboxName
+	}
+	return ""
+}
+
+// sbxAgent returns the agent name from the active mode, or empty string.
+func (m Model) sbxAgent() string {
+	if m.activeMode != nil {
+		return m.activeMode.Agent
+	}
+	return ""
+}
+
+// ModeStatus returns the sandbox status for a given sandbox name.
+// Returns StatusNotFound if the name is not in the map.
+func (m Model) ModeStatus(sbxName string) sandbox.Status {
+	if s, ok := m.modeStatuses[sbxName]; ok {
+		return s
+	}
+	return sandbox.StatusNotFound
+}
+
+// SetActiveMode updates the active mode, re-filters worktrees, and fires
+// sandbox check if needed. Returns the updated model and a cmd.
+func (m Model) SetActiveMode(mode *config.ModeEntry) (Model, tea.Cmd) {
+	m.activeMode = mode
+	m.filterWorktrees()
+	// Use cached status from modeStatuses if available, so the tree dot
+	// doesn't flash red on every mode switch.
+	if mode != nil && mode.Type == "sandbox" {
+		m.sandboxStatus = m.ModeStatus(mode.SandboxName)
+	} else {
+		m.sandboxStatus = sandbox.StatusNotFound
+	}
+	m.sandboxVersion = sandbox.VersionInfo{}
+	// Clear stale status messages from the previous mode.
+	m.statusMsg = ""
+	if m.isSandbox() {
+		rp := m.repoPath()
+		return m, doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName())
+	}
+	return m, nil
+}
+
+// filterWorktrees filters allWorktrees into worktrees based on activeMode.
+// Main worktree is always included.
+// Regular mode (or nil): include all worktrees NOT in a .sbx/ directory.
+// Sandbox mode: include only paths containing ".sbx/<sandboxName>-worktrees/".
+func (m *Model) filterWorktrees() {
+	if len(m.allWorktrees) == 0 {
+		m.worktrees = nil
+		return
+	}
+	if !m.isSandbox() {
+		// Regular mode: include everything that isn't in a sandbox directory.
+		var filtered []git.Worktree
+		for _, wt := range m.allWorktrees {
+			if wt.IsMain || !strings.Contains(wt.Path, ".sbx/") {
+				filtered = append(filtered, wt)
+			}
+		}
+		m.worktrees = filtered
+		return
+	}
+	// Sandbox mode: only include main + matching sandbox worktrees.
+	needle := ".sbx/" + m.sbxName() + "-worktrees/"
+	var filtered []git.Worktree
+	for _, wt := range m.allWorktrees {
+		if wt.IsMain || strings.Contains(wt.Path, needle) {
+			filtered = append(filtered, wt)
+		}
+	}
+	m.worktrees = filtered
+}
+
 func (m Model) Init() tea.Cmd {
 	// Fast initial load: branch names only, no dirty/agents/network.
 	// Local refresh (dirty + agents) and network refresh (fetch + PRs) follow immediately.
@@ -187,8 +290,8 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		doCheckCLI(m.prProv, rp),
 		doQuickRefresh(m.repo, rp),
-		doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp),
-		doNetworkRefresh(m.repo, m.detector, m.ideDetector, m.procLister, m.prProv, m.cliAvail, rp),
+		doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName()),
+		doNetworkRefresh(m.repo, m.detector, m.ideDetector, m.procLister, m.prProv, m.cliAvail, rp, m.sbxName()),
 		m.doLocalTick(),
 		m.doTick(),
 	)
@@ -208,6 +311,54 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncViewport()
 		return m, nil
 
+	case sandboxCreatedFromCardMsg:
+		if m.isStale(msg.repoPath) {
+			return m, nil
+		}
+		rp := m.repoPath()
+		if msg.err != nil {
+			m.statusMsg = errorStyle.Render("Sandbox create failed: " + msg.err.Error())
+		} else {
+			m.statusMsg = cleanStyle.Render("Sandbox created: " + msg.sandboxName)
+		}
+		return m, doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName())
+
+	case sandboxStartedMsg:
+		if m.isStale(msg.repoPath) {
+			return m, nil
+		}
+		rp := m.repoPath()
+		if msg.err != nil {
+			m.statusMsg = errorStyle.Render("Start failed: " + msg.err.Error())
+		} else {
+			m.statusMsg = cleanStyle.Render("Sandbox started: " + msg.sandboxName)
+		}
+		return m, doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName())
+
+	case sandboxStoppedCmdMsg:
+		if m.isStale(msg.repoPath) {
+			return m, nil
+		}
+		rp := m.repoPath()
+		if msg.err != nil {
+			m.statusMsg = errorStyle.Render("Stop failed: " + msg.err.Error())
+		} else {
+			m.statusMsg = cleanStyle.Render("Sandbox stopped: " + msg.sandboxName)
+		}
+		return m, doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName())
+
+	case sandboxRemovedMsg:
+		if m.isStale(msg.repoPath) {
+			return m, nil
+		}
+		rp := m.repoPath()
+		if msg.err != nil {
+			m.statusMsg = errorStyle.Render("Sandbox remove failed: " + msg.err.Error())
+		} else {
+			m.statusMsg = cleanStyle.Render("Sandbox removed: " + msg.sandboxName)
+		}
+		return m, doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName())
+
 	case cliCheckMsg:
 		if m.isStale(msg.repoPath) {
 			return m, nil
@@ -220,14 +371,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil // don't re-schedule: breaks the tick chain
 		}
 		rp := m.repoPath()
-		return m, tea.Batch(doNetworkRefresh(m.repo, m.detector, m.ideDetector, m.procLister, m.prProv, m.cliAvail, rp), m.doTick())
+		return m, tea.Batch(doNetworkRefresh(m.repo, m.detector, m.ideDetector, m.procLister, m.prProv, m.cliAvail, rp, m.sbxName()), m.doTick())
 
 	case localTickMsg:
 		if m.isStale(msg.repoPath) || m.paused {
 			return m, nil // don't re-schedule: breaks the tick chain
 		}
 		rp := m.repoPath()
-		return m, tea.Batch(doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp), m.doLocalTick())
+		return m, tea.Batch(
+			doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName()),
+			m.doLocalTick(),
+		)
 
 	case refreshMsg:
 		if m.isStale(msg.repoPath) {
@@ -236,7 +390,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.err = msg.err
 		} else {
-			m.worktrees = msg.worktrees
+			m.allWorktrees = msg.worktrees
+			m.filterWorktrees()
 			m.agents = msg.agents
 			m.ides = msg.ides
 			if msg.hasPRs {
@@ -246,6 +401,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.fetchErr != nil {
 			m.statusMsg = errorStyle.Render("Fetch: " + msg.fetchErr.Error())
+		}
+		// Only update sandbox status when the refresh actually checked it.
+		// Quick refreshes don't check sandbox status (allSbxStatuses is nil).
+		if msg.allSbxStatuses != nil {
+			for k, v := range msg.allSbxStatuses {
+				m.modeStatuses[k] = sandbox.Status(v)
+			}
+			if m.sbxName() != "" {
+				if msg.sbxClientVer != "" {
+					m.sandboxVersion = sandbox.VersionInfo{Client: msg.sbxClientVer, Server: msg.sbxServerVer}
+				}
+				prev := m.sandboxStatus
+				m.sandboxStatus = sandbox.Status(msg.sandboxStatus)
+				switch m.sandboxStatus {
+				case sandbox.StatusNotFound:
+					m.statusMsg = errorStyle.Render("Sandbox not found — press 'n' to create it")
+				case sandbox.StatusStopped:
+					m.statusMsg = sandboxStoppedStyle.Render("Sandbox stopped — run: sbx run " + m.sbxName())
+				case sandbox.StatusRunning:
+					if prev != sandbox.StatusRunning {
+						m.statusMsg = ""
+					}
+				}
+			}
 		}
 		if m.cursor >= len(m.worktrees) && len(m.worktrees) > 0 {
 			m.cursor = len(m.worktrees) - 1
@@ -290,16 +469,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.statusMsg = errorStyle.Render("Error: " + msg.err.Error())
 			m.mode = modeNormal
-			return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp))
+			return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName()))
 		}
-		m.statusMsg = cleanStyle.Render("Worktree created — opening panel...")
 		m.mode = modeNormal
-		// Open a Warp panel in the new worktree with the agent command.
-		newWtPath := filepath.Join(m.repo.Root(), ".gwaim-worktrees", msg.branchName)
+		m.statusMsg = cleanStyle.Render("Worktree created")
 		return m, tea.Batch(
 			doQuickRefresh(m.repo, rp),
-			doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp),
-			doOpenWarpPanel(m.repo.RepoName(), git.Worktree{Path: newWtPath, Branch: msg.branchName}, nil),
+			doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName()),
 		)
 
 	case prFetchedMsg:
@@ -310,15 +486,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.statusMsg = errorStyle.Render("Error: " + msg.err.Error())
 			m.mode = modeNormal
-			return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp))
+			return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName()))
 		}
-		m.statusMsg = cleanStyle.Render("PR fetched — opening panel...")
 		m.mode = modeNormal
-		// Trigger a network refresh so the new worktree's PR badge appears immediately.
+		m.statusMsg = cleanStyle.Render("PR fetched")
 		return m, tea.Batch(
 			doQuickRefresh(m.repo, rp),
-			doNetworkRefresh(m.repo, m.detector, m.ideDetector, m.procLister, m.prProv, m.cliAvail, rp),
-			doOpenWarpPanel(m.repo.RepoName(), git.Worktree{Path: msg.wtPath, Branch: msg.branchName}, nil),
+			doNetworkRefresh(m.repo, m.detector, m.ideDetector, m.procLister, m.prProv, m.cliAvail, rp, m.sbxName()),
 		)
 
 	case worktreeRemovedMsg:
@@ -332,7 +506,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMsg = cleanStyle.Render("Worktree removed")
 		}
 		m.mode = modeNormal
-		return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp))
+		return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName()))
 
 	case warpOpenedMsg:
 		if msg.err != nil {
@@ -361,7 +535,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMsg = cleanStyle.Render("Pull complete")
 		}
 		// Pull changes local state only; sync status will update on next network tick.
-		return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp))
+		return m, tea.Batch(doQuickRefresh(m.repo, rp), doLocalRefresh(m.repo, m.detector, m.ideDetector, m.procLister, rp, m.sbxName()))
 
 	case cardRefreshMsg:
 		if m.isStale(msg.repoPath) {
@@ -377,7 +551,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMsg = cleanStyle.Render("Refreshed")
 		}
 		// Update worktree list (needed for dirty/sync status).
-		m.worktrees = msg.worktrees
+		m.allWorktrees = msg.worktrees
+		m.filterWorktrees()
 		// Merge per-card agent/IDE/PR data into existing maps.
 		for k, v := range msg.agents {
 			m.agents[k] = v
@@ -420,7 +595,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if m.mode == modeCreate || m.mode == modeFetchPR {
+	if m.mode == modeCreate || m.mode == modeFetchPR || m.mode == modeEnrollSandboxFromCard {
 		var cmd tea.Cmd
 		m.textInput, cmd = m.textInput.Update(msg)
 		return m, cmd
@@ -440,6 +615,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.mode = modeNormal
+			if m.isSandbox() {
+				// Sandbox mode: create worktree inside existing sandbox.
+				m.statusMsg = cleanStyle.Render("Creating sandbox worktree...")
+				return m, doCreateSandboxWorktree(m.sbxName(), m.repoPath(), name)
+			}
 			return m, doCreateWorktree(m.repo, name, m.repoPath())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
 			m.mode = modeNormal
@@ -462,6 +642,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.mode = modeNormal
 			m.statusMsg = cleanStyle.Render("Fetching PR...")
+			if m.isSandbox() {
+				return m, doFetchPRSandbox(m.repo, input, m.repoPath(), m.sbxName())
+			}
 			return m, doFetchPR(m.repo, input, m.repoPath())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
 			m.mode = modeNormal
@@ -497,6 +680,76 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		default:
 			m.deleteConfirmed = false
+			m.mode = modeNormal
+			m.statusMsg = ""
+			return m, nil
+		}
+	}
+
+	// Handle enroll sandbox from card (non-sandbox repo).
+	if m.mode == modeEnrollSandboxFromCard {
+		switch {
+		case key.Matches(msg, key.NewBinding(key.WithKeys("enter"))):
+			agentName := strings.TrimSpace(m.textInput.Value())
+			if agentName == "" {
+				m.mode = modeNormal
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.statusMsg = cleanStyle.Render("Checking sbx readiness...")
+			sbxName := sandbox.SanitizeName(m.repoName(), agentName)
+			return m, func() tea.Msg {
+				return enrollSandboxRequestMsg{
+					repoPath: m.repoPath(),
+					mode: config.ModeEntry{
+						Type:        "sandbox",
+						SandboxName: sbxName,
+						Agent:       agentName,
+					},
+				}
+			}
+		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+			m.mode = modeNormal
+			m.statusMsg = ""
+			return m, nil
+		default:
+			var cmd tea.Cmd
+			m.textInput, cmd = m.textInput.Update(msg)
+			return m, cmd
+		}
+	}
+
+	// Handle confirm create sandbox mode.
+	if m.mode == modeConfirmCreateSandbox {
+		switch {
+		case key.Matches(msg, key.NewBinding(key.WithKeys("y", "Y"))):
+			m.mode = modeNormal
+			m.statusMsg = cleanStyle.Render("Creating sandbox (this may take a few minutes)...")
+			sbxArgs := sandbox.CreateArgs(m.sbxName(), m.sbxAgent(), m.repoPath())
+			return m, doCreateSandboxFromCard(sbxArgs, m.sbxName(), m.repoPath())
+		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+			m.mode = modeNormal
+			m.statusMsg = ""
+			return m, nil
+		default:
+			m.mode = modeNormal
+			m.statusMsg = ""
+			return m, nil
+		}
+	}
+
+	// Handle confirm remove sandbox mode.
+	if m.mode == modeConfirmRemoveSandbox {
+		switch {
+		case key.Matches(msg, key.NewBinding(key.WithKeys("y", "Y"))):
+			m.mode = modeNormal
+			m.statusMsg = cleanStyle.Render("Removing sandbox...")
+			return m, doRemoveSandbox(m.sbxName(), m.repoPath())
+		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+			m.mode = modeNormal
+			m.statusMsg = ""
+			return m, nil
+		default:
 			m.mode = modeNormal
 			m.statusMsg = ""
 			return m, nil
@@ -611,19 +864,61 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Enter):
 		if m.cursor >= 0 && m.cursor < len(m.worktrees) {
 			wt := m.worktrees[m.cursor]
+			if m.isSandbox() {
+				// Sandbox mode: sbx run --branch knows which sandbox to enter, no cd needed.
+				args := sandbox.RunWithBranchArgs(m.sbxName(), wt.Branch)
+				sbxCmd := sandbox.CommandString(args)
+				return m, doOpenSandboxTab(m.repoName(), sbxCmd)
+			}
 			agents := m.agents[wt.Path]
-			return m, doOpenWarpPanel(m.repo.RepoName(), wt, agents)
+			return m, doOpenWarpPanel(m.repoName(), wt, agents)
 		}
 
 	case key.Matches(msg, m.keys.Delete):
 		if m.cursor >= 0 && m.cursor < len(m.worktrees) {
 			wt := m.worktrees[m.cursor]
 			if wt.IsMain {
+				if m.isSandbox() && m.sandboxStatus != sandbox.StatusNotFound {
+					// Sandbox mode: offer to remove the sandbox.
+					m.mode = modeConfirmRemoveSandbox
+					return m, nil
+				}
 				m.statusMsg = errorStyle.Render("Cannot delete the main worktree")
 				return m, nil
 			}
 			m.mode = modeConfirmDelete
 			m.deleteConfirmed = false
+		}
+
+	case key.Matches(msg, m.keys.CreateSandbox):
+		if m.cursor == 0 {
+			if m.isSandbox() {
+				if m.sandboxStatus == sandbox.StatusNotFound {
+					m.mode = modeConfirmCreateSandbox
+					return m, nil
+				}
+				m.statusMsg = cleanStyle.Render("Sandbox already exists — use 'c' to create a worktree")
+				return m, nil
+			}
+			// Non-sandbox repo: offer to enroll.
+			m.mode = modeEnrollSandboxFromCard
+			m.textInput.Reset()
+			m.textInput.Placeholder = "agent (claude, codex, copilot, gemini, kiro, opencode, shell)"
+			m.textInput.Focus()
+			m.statusMsg = ""
+			return m, m.textInput.Cursor.BlinkCmd()
+		}
+
+	case key.Matches(msg, m.keys.StartSandbox):
+		if m.cursor == 0 && m.isSandbox() && m.sandboxStatus == sandbox.StatusStopped {
+			m.statusMsg = cleanStyle.Render("Starting sandbox...")
+			return m, doStartSandbox(m.sbxName(), m.repoPath())
+		}
+
+	case key.Matches(msg, m.keys.StopSandbox):
+		if m.cursor == 0 && m.isSandbox() && m.sandboxStatus == sandbox.StatusRunning {
+			m.statusMsg = cleanStyle.Render("Stopping sandbox...")
+			return m, doStopSandbox(m.sbxName(), m.repoPath())
 		}
 	}
 
@@ -676,7 +971,16 @@ func (m *Model) renderFixedTop() string {
 		mainWt := m.worktrees[0]
 		agents := m.agents[mainWt.Path]
 		mainIDEs := m.ides[mainWt.Path]
-		content := card.Render(mainWt, agents, mainIDEs, m.prs[mainWt.Branch], m.cliAvail, prov)
+		var sbxInfo *card.SandboxInfo
+		if m.isSandbox() {
+			sbxInfo = &card.SandboxInfo{
+				Name:          m.sbxName(),
+				Status:        card.SandboxStatus(m.sandboxStatus),
+				ClientVersion: m.sandboxVersion.Client,
+				ServerVersion: m.sandboxVersion.Server,
+			}
+		}
+		content := card.Render(mainWt, agents, mainIDEs, m.prs[mainWt.Branch], m.cliAvail, prov, sbxInfo)
 
 		mainWidth := m.width - 4
 		if mainWidth < 40 {
@@ -704,6 +1008,12 @@ func (m *Model) renderFixedTop() string {
 		}
 		if m.mode == modeFetchPR {
 			body.WriteString(inputPromptStyle.Render("  Fetch PR: "))
+			body.WriteString(m.textInput.View())
+			body.WriteString("\n")
+			currentY += 2
+		}
+		if m.mode == modeEnrollSandboxFromCard {
+			body.WriteString(inputPromptStyle.Render("  Sandbox agent: "))
 			body.WriteString(m.textInput.View())
 			body.WriteString("\n")
 			currentY += 2
@@ -743,7 +1053,11 @@ func (m *Model) renderLinkedCards() string {
 		for i, wt := range linked {
 			agents := m.agents[wt.Path]
 			wtIDEs := m.ides[wt.Path]
-			content := card.Render(wt, agents, wtIDEs, m.prs[wt.Branch], m.cliAvail, prov)
+			var linkedSbx *card.SandboxInfo
+			if m.isSandbox() {
+				linkedSbx = &card.SandboxInfo{Name: m.sbxName(), Status: card.SandboxStatus(m.sandboxStatus)}
+			}
+			content := card.Render(wt, agents, wtIDEs, m.prs[wt.Branch], m.cliAvail, prov, linkedSbx)
 
 			globalIdx := i + 1
 			style := cardStyle.Width(cardWidth)
@@ -880,7 +1194,20 @@ func (m Model) viewContent() string {
 	if m.mouseOn {
 		mouseLabel = "m mouse:on"
 	}
-	helpText := "←→↑↓ navigate • ↵ open tab • e editor • p pull • r refresh • c create • f fetch PR • d delete • " + mouseLabel + " • q quit"
+	var sbxLabel string
+	if m.isSandbox() {
+		switch m.sandboxStatus {
+		case sandbox.StatusRunning:
+			sbxLabel = "S stop • "
+		case sandbox.StatusStopped:
+			sbxLabel = "s start • "
+		case sandbox.StatusNotFound:
+			sbxLabel = "n new sandbox • "
+		}
+	} else {
+		sbxLabel = "n new sandbox • "
+	}
+	helpText := "←→↑↓ navigate • ↵ open tab • e editor • p pull • r refresh • " + sbxLabel + "c create • f fetch PR • d delete • " + mouseLabel + " • q quit"
 	help := helpStyle.MaxWidth(m.width).Render(helpText)
 
 	if m.ready {
@@ -888,6 +1215,19 @@ func (m Model) viewContent() string {
 	}
 
 	return m.fixedTopContent + m.renderLinkedCards() + "\n" + help
+}
+
+// renderConfirmCreateSandboxPopup renders a confirmation popup for sandbox creation.
+func (m Model) renderConfirmCreateSandboxPopup() string {
+	cmd := strings.Join(sandbox.CreateArgs(m.sbxName(), m.sbxAgent(), m.repoPath()), " ")
+	msg := fmt.Sprintf("Create sandbox %q?\n\nThis may take a few minutes.\n\n%s\n\n[y] confirm  [Esc] cancel", m.sbxName(), cmd)
+	return popupStyle.Render(msg)
+}
+
+// renderConfirmRemoveSandboxPopup renders a confirmation popup for sandbox removal.
+func (m Model) renderConfirmRemoveSandboxPopup() string {
+	msg := fmt.Sprintf("Remove sandbox %q?\n\nThis will stop the sandbox, remove all\nits containers and worktrees.\n\nsbx rm --force %s\n\n[y] confirm  [Esc] cancel", m.sbxName(), m.sbxName())
+	return popupStyle.Render(msg)
 }
 
 // renderConfirmPopup renders a centered confirmation popup for worktree deletion.
@@ -1011,7 +1351,7 @@ func doQuickRefresh(repo *git.Repository, repoPath string) tea.Cmd {
 
 // doLocalRefresh reads dirty status and detects agents and IDEs — no network I/O.
 // Fires every LocalRefreshInterval and after any state-modifying operation.
-func doLocalRefresh(repo *git.Repository, detector *agent.Detector, ideDetector *ide.Detector, procLister process.Lister, repoPath string) tea.Cmd {
+func doLocalRefresh(repo *git.Repository, detector *agent.Detector, ideDetector *ide.Detector, procLister process.Lister, repoPath string, sbxName string) tea.Cmd {
 	return func() tea.Msg {
 		wts, err := repo.ListWorktrees()
 		if err != nil {
@@ -1032,13 +1372,31 @@ func doLocalRefresh(repo *git.Repository, detector *agent.Detector, ideDetector 
 			ides = ideDetector.DetectFromProcesses(procs, paths)
 		}
 
-		return refreshMsg{repoPath: repoPath, source: refreshSourceLocal, worktrees: wts, agents: agents, ides: ides}
+		// Check all sandbox statuses and version with one sbx ls call.
+		var sbxStatus sandbox.Status
+		var sbxVer sandbox.VersionInfo
+		var allStatuses map[string]int
+		if sbxName != "" {
+			statusMap := sandbox.CheckAllStatuses()
+			if statusMap != nil {
+				allStatuses = make(map[string]int, len(statusMap))
+				for k, v := range statusMap {
+					allStatuses[k] = int(v)
+				}
+				if s, ok := statusMap[sbxName]; ok {
+					sbxStatus = s
+				}
+			}
+			sbxVer = sandbox.Version()
+		}
+
+		return refreshMsg{repoPath: repoPath, source: refreshSourceLocal, worktrees: wts, agents: agents, ides: ides, sandboxStatus: int(sbxStatus), allSbxStatuses: allStatuses, sbxClientVer: sbxVer.Client, sbxServerVer: sbxVer.Server}
 	}
 }
 
 // doNetworkRefresh fetches remote refs and looks up PR status.
 // Fires every refreshInterval (controlled by --refresh / GWAIM_REFRESH).
-func doNetworkRefresh(repo *git.Repository, detector *agent.Detector, ideDetector *ide.Detector, procLister process.Lister, prProv provider.PRProvider, cliAvail provider.CLIAvailability, repoPath string) tea.Cmd {
+func doNetworkRefresh(repo *git.Repository, detector *agent.Detector, ideDetector *ide.Detector, procLister process.Lister, prProv provider.PRProvider, cliAvail provider.CLIAvailability, repoPath string, sbxName string) tea.Cmd {
 	return func() tea.Msg {
 		fetchErr := repo.Fetch()
 
@@ -1070,7 +1428,14 @@ func doNetworkRefresh(repo *git.Repository, detector *agent.Detector, ideDetecto
 		} else {
 			prs = make(provider.PRResult)
 		}
-		return refreshMsg{repoPath: repoPath, source: refreshSourceNetwork, worktrees: wts, agents: agents, ides: ides, prs: prs, hasPRs: true, fetchErr: fetchErr}
+
+		// Check sandbox status if configured.
+		var sbxStatus sandbox.Status
+		if sbxName != "" {
+			sbxStatus = sandbox.CheckStatus(sbxName)
+		}
+
+		return refreshMsg{repoPath: repoPath, source: refreshSourceNetwork, worktrees: wts, agents: agents, ides: ides, prs: prs, hasPRs: true, fetchErr: fetchErr, sandboxStatus: int(sbxStatus)}
 	}
 }
 
@@ -1205,5 +1570,107 @@ func doOpenWarpPanel(repoName string, wt git.Worktree, agents []agent.Info) tea.
 		}
 		err := warp.OpenTab(repoName, wt.Path, agentCmd)
 		return warpOpenedMsg{err: err}
+	}
+}
+
+// doCreateSandboxWorktree creates a worktree inside an existing sandbox
+// using sbx run -d --branch (detached). No terminal tab is opened —
+// the user attaches later by pressing Enter on the card.
+func doCreateSandboxWorktree(sandboxName, repoPath, branch string) tea.Cmd {
+	return func() tea.Msg {
+		// Create the worktree in detached mode.
+		args := sandbox.RunDetachedWithBranchArgs(sandboxName, branch)
+		out, err := sandbox.RunDetached(args)
+		if err != nil {
+			return worktreeCreatedMsg{
+				repoPath:   repoPath,
+				branchName: branch,
+				err:        err,
+				sbxOutput:  out,
+			}
+		}
+
+		return worktreeCreatedMsg{
+			repoPath:   repoPath,
+			branchName: branch,
+			sbxOutput:  out,
+		}
+	}
+}
+
+// doOpenSandboxTab opens a terminal tab running an sbx command (no cd prefix).
+func doOpenSandboxTab(repoName, sbxCmd string) tea.Cmd {
+	return func() tea.Msg {
+		err := warp.OpenTab(repoName, "", sbxCmd)
+		return warpOpenedMsg{err: err}
+	}
+}
+
+// doFetchPRSandbox fetches a PR ref and creates the worktree inside the existing sandbox.
+// No terminal tab is opened — the user attaches later by pressing Enter on the card.
+func doFetchPRSandbox(repo *git.Repository, input, repoPath, sandboxName string) tea.Cmd {
+	return func() tea.Msg {
+		ref, err := github.ParsePRRef(input)
+		if err != nil {
+			return prFetchedMsg{repoPath: repoPath, err: err}
+		}
+
+		headBranch, err := github.ValidatePR(repo.Root(), ref)
+		if err != nil {
+			return prFetchedMsg{repoPath: repoPath, err: err}
+		}
+
+		branchName := headBranch
+		remoteURL := ""
+		if ref.Repo != "" {
+			remoteURL = "https://github.com/" + ref.Repo + ".git"
+		}
+
+		// Fetch the PR ref to a local branch (no worktree creation on host).
+		if err := repo.FetchPRRef(ref.Number, branchName, remoteURL); err != nil {
+			return prFetchedMsg{repoPath: repoPath, err: err}
+		}
+
+		// Create the worktree inside the sandbox (detached).
+		args := sandbox.RunDetachedWithBranchArgs(sandboxName, branchName)
+		out, err := sandbox.RunDetached(args)
+		if err != nil {
+			return prFetchedMsg{repoPath: repoPath, err: fmt.Errorf("sbx worktree: %w: %s", err, out)}
+		}
+		_ = out
+
+		return prFetchedMsg{repoPath: repoPath, branchName: branchName}
+	}
+}
+
+// doCreateSandboxFromCard runs sbx create from the main card (after confirmation).
+func doCreateSandboxFromCard(args []string, sandboxName, repoPath string) tea.Cmd {
+	return func() tea.Msg {
+		out, err := sandbox.Create(args)
+		return sandboxCreatedFromCardMsg{repoPath: repoPath, sandboxName: sandboxName, output: out, err: err}
+	}
+}
+
+// doRemoveSandbox runs sbx rm to remove a sandbox.
+func doRemoveSandbox(sandboxName, repoPath string) tea.Cmd {
+	return func() tea.Msg {
+		out, err := sandbox.Remove(sandboxName)
+		return sandboxRemovedMsg{repoPath: repoPath, sandboxName: sandboxName, output: out, err: err}
+	}
+}
+
+// doStartSandbox runs sbx run -d to start a stopped sandbox.
+func doStartSandbox(sandboxName, repoPath string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := sandbox.Start(sandboxName)
+		return sandboxStartedMsg{repoPath: repoPath, sandboxName: sandboxName, err: err}
+	}
+}
+
+// doStopSandbox runs sbx stop to stop a sandbox without removing it.
+func doStopSandbox(sandboxName, repoPath string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := sandbox.Stop(sandboxName)
+		return sandboxStoppedCmdMsg{repoPath: repoPath, sandboxName: sandboxName, err: err}
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/mdelapenya/gwaim/internal/agent"
+	"github.com/mdelapenya/gwaim/internal/config"
 	"github.com/mdelapenya/gwaim/internal/git"
 	"github.com/mdelapenya/gwaim/internal/ide"
 	"github.com/mdelapenya/gwaim/internal/provider"
@@ -835,3 +836,39 @@ func TestOverlayCenter(t *testing.T) {
 }
 
 // TestConfirmDeleteRendersPopup is in app_test.go since the popup is rendered at the App level.
+
+// --- Sandbox worktree creation tests ---
+
+func TestSandboxCreateGoesDirectlyToCmd(t *testing.T) {
+	m := testModel(2)
+	m.activeMode = &config.ModeEntry{Type: "sandbox", SandboxName: "owner-repo-claude", Agent: "claude"}
+	m.mode = modeCreate
+	m.textInput.SetValue("feature/my-branch")
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, cmd := m.Update(msg)
+	model := updated.(Model)
+
+	// Sandbox mode goes straight to modeNormal and creates worktree (no agent prompt).
+	if model.mode != modeNormal {
+		t.Errorf("mode = %d, want modeNormal", model.mode)
+	}
+	if cmd == nil {
+		t.Error("expected a cmd to create sandbox worktree")
+	}
+}
+
+func TestRegularCreateDoesNotUseSandbox(t *testing.T) {
+	m := testModel(2)
+	m.activeMode = nil
+	m.mode = modeCreate
+	m.textInput.SetValue("feature/my-branch")
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+
+	if model.mode != modeNormal {
+		t.Errorf("mode = %d, want modeNormal", model.mode)
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -33,7 +33,8 @@ var (
 
 	helpStyle = lipgloss.NewStyle().Faint(true).MarginTop(1)
 
-	errorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196")) // red
+	errorStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("196")) // red
+	sandboxStoppedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // yellow/orange — matches card sandbox stopped color
 
 	inputPromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
 
@@ -44,13 +45,6 @@ var (
 				Foreground(lipgloss.Color("39")) // cyan
 
 	unselectedRepoStyle = lipgloss.NewStyle().Faint(true)
-
-	repoCardStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			Padding(0, 1)
-
-	selectedRepoCardStyle = repoCardStyle.
-				BorderForeground(lipgloss.Color("39")) // cyan
 
 	repoPanelHelpStyle = lipgloss.NewStyle().Faint(true)
 

--- a/internal/warp/warp.go
+++ b/internal/warp/warp.go
@@ -80,9 +80,14 @@ func splitPanel(dir, agentCmd string) error {
 // --- macOS ---
 
 func darwinNewTab(dir, agentCmd string) error {
-	text := "cd " + escAS(dir)
-	if agentCmd != "" {
-		text += " && " + agentCmd
+	var text string
+	if dir != "" {
+		text = "cd " + escAS(dir)
+		if agentCmd != "" {
+			text += " && " + agentCmd
+		}
+	} else {
+		text = agentCmd
 	}
 
 	return osascript([]string{
@@ -122,9 +127,14 @@ func darwinFocusTab(repoName string) error {
 }
 
 func darwinSplitPanel(dir, agentCmd string) error {
-	text := "cd " + escAS(dir)
-	if agentCmd != "" {
-		text += " && " + agentCmd
+	var text string
+	if dir != "" {
+		text = "cd " + escAS(dir)
+		if agentCmd != "" {
+			text += " && " + agentCmd
+		}
+	} else {
+		text = agentCmd
 	}
 
 	return osascript([]string{
@@ -185,9 +195,14 @@ func linuxNewTab(repoName, dir string) error {
 }
 
 func linuxSplitPanel(dir, agentCmd string) error {
-	shellCmd := "cd " + shellQuote(dir)
-	if agentCmd != "" {
-		shellCmd += " && " + agentCmd
+	var shellCmd string
+	if dir != "" {
+		shellCmd = "cd " + shellQuote(dir)
+		if agentCmd != "" {
+			shellCmd += " && " + agentCmd
+		}
+	} else {
+		shellCmd = agentCmd
 	}
 	shellCmd += "; exec $SHELL"
 


### PR DESCRIPTION
## What's changed

Integrate [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) (`sbx` CLI) as the recommended way to manage coding agent worktrees. Each repo can now have multiple enrollment modes — regular host worktrees alongside one or more isolated sandbox environments (e.g. one for Claude, another for Gemini). The left panel becomes a tree showing repo groups with their modes, and the right panel filters worktrees by the selected mode.

This is a large feature that touches config persistence, the TUI layout, worktree lifecycle, and a new `internal/sandbox` package.

## Why is this important?

Sandbox mode gives each worktree an isolated Docker environment with its own filesystem, Docker daemon, and network. Agents can install packages, build containers, and modify files without touching the host. This is safer and more reproducible than running agents directly on the host, which is why sandbox mode is now the default and recommended choice when enrolling a repo.

## Changes

### New package: `internal/sandbox`
- Wraps the `sbx` CLI: `Create`, `Start`, `Stop`, `Remove`, `RunDetached`
- `Preflight()` validates sbx is bootstrapped (auth, daemon, network policy) before enrollment
- `CheckAllStatuses()` parses `sbx ls --json` for system-wide sandbox status (running/stopped/not found)
- `Version()` parses `sbx version` for client/server version display

### Config (`internal/config`)
- **Breaking**: `RepoEntry` now has `Modes []ModeEntry` instead of flat `Sandbox bool` fields
- `ModeEntry` has `Type` ("regular"/"sandbox"), `SandboxName`, `Agent`
- Old config format auto-migrates on load; duplicate paths are merged
- `Add()` takes a `ModeEntry`; adding sandbox replaces regular mode
- New `RemoveMode()` removes a specific mode; removing the last sandbox converts to regular

### Left panel: tree layout (`internal/tui/app.go`)
- `repoTab` → `repoGroup` with `modes []config.ModeEntry` and `activeMode int`
- Repo names render as dimmed headers (clickable → selects first mode); modes render as indented children (`📂 [host]` or `🐳 [agent] ●`)
- Colored status dots per sandbox: green (running), yellow (stopped), red (not found)
- `switchMode()` handles same-group (no pause/resume) vs cross-group (pause/resume) transitions
- App-level `sbxStatuses` map ensures dots persist across repo switches

### Model: filtered views (`internal/tui/model.go`)
- `activeMode *config.ModeEntry` replaces `sandbox bool` / `sandboxName` / `sandboxAgent`
- `allWorktrees` (unfiltered from git) → `worktrees` (filtered by mode path pattern)
- Regular mode shows `.gwaim-worktrees/` paths; sandbox shows `.sbx/<name>-worktrees/`
- `SetActiveMode()` re-filters worktrees and applies cached sandbox status (no red flash)
- Sandbox status check integrated into local refresh (5s cycle) via `CheckAllStatuses()`

### Sandbox lifecycle keys (right panel, main card)
- `n` — new sandbox (when not found or non-sandbox repo)
- `s` — start stopped sandbox (`sbx run -d`)
- `S` — stop running sandbox (`sbx stop`)
- `d` — remove sandbox (`sbx rm --force`, confirmation popup, converts to regular if last)
- `c` — create worktree inside existing sandbox (`sbx run -d --branch`)
- `Enter` — attach to sandbox worktree (`sbx run --branch`, no `cd` prefix)
- `f` — fetch PR into sandbox (`FetchPRRef` + `sbx run -d --branch`)

### Card rendering (`internal/tui/card`)
- `SandboxInfo` struct with `Name`, `Status` (running/stopped/not found), `ClientVersion`, `ServerVersion`
- Three status colors: green (running), yellow (stopped), red (not found)
- sbx version line shown on main card

### Warp (`internal/warp`)
- `darwinNewTab`, `darwinSplitPanel`, `linuxSplitPanel` skip `cd` prefix when dir is empty

### Git (`internal/git/worktree.go`)
- New `FetchPRRef()` fetches a PR ref without creating a host worktree (used by sandbox mode)
- `FetchPR()` refactored to delegate ref fetching to `FetchPRRef()`

### Bug fix
- Initialize `agents`, `ides`, `prs` maps in `New()` to prevent nil-map panic on card refresh

## Test plan

- `task test-race` — all existing + new tests pass with race detector
- `task lint` — 0 issues
- Config: migration from old format, mode merging, dedup, RemoveMode
- Sandbox: `CreateArgs`, `RunDetachedWithBranchArgs`, `RunWithBranchArgs`, `SanitizeName`
- App: tree navigation across groups, mode switching, mouse clicks on tree, sandbox enrollment flows
- Model: worktree filtering by mode, `SetActiveMode`, `isSandbox` helpers
- Card: sandbox status rendering (running/stopped/not found)
- Manual: enroll repo in sandbox mode, create worktrees, start/stop/remove sandbox, switch between modes
