### PR TITLE
fix(build): macOS 26 Gatekeeper rejects --release ad-hoc signed bundle

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -136,20 +136,23 @@ tasks:
     cmds:
       - mkdir -p bin
       - rm -rf bin/{{.APP_NAME}}.app
+      # --release enables hardened runtime, rejected with ad-hoc sign on macOS 26+.
       - >-
         fyne package
+        --source-dir ./cmd/biomelab
         --executable {{.BIN}}
         --name {{.APP_NAME}}
         --app-id {{.APP_ID}}
         --app-version {{.SEMVER}}
-        --icon cmd/biomelab/icon.png
-        --release
+        --icon icon.png
       - mv {{.APP_NAME}}.app bin/
+      - codesign --force --deep --sign - bin/{{.APP_NAME}}.app
 
   install-macos:
     desc: Package and install Biomelab.app to /Applications
     deps: [package-darwin-universal]
     cmds:
+      - rm -rf /Applications/{{.APP_NAME}}.app
       - cp -R bin/{{.APP_NAME}}.app /Applications/
       - echo "Installed to /Applications/{{.APP_NAME}}.app — find it in Spotlight"
 


### PR DESCRIPTION
On macOS 26+, hardened runtime (CS_RUNTIME) combined with an ad-hoc signature triggers Taskgated "Invalid Signature" SIGKILL. fyne package --release enables hardened runtime, but without an Apple Developer ID  we can only ad-hoc sign. Drop --release and explicitly codesign --sign -to produce a plain ad-hoc bundle that macOS accepts.

Also: rm the old /Applications/Biomelab.app before cp -R so stale files from a previous install do not invalidate the new signature seal.

Worked on macOS 26.4 (codeSigningFlags=0x01000200 before, 0x2 after).
