### PR TITLE
feat(gui): add kanban board view for worktree lifecycle tracking

### DIFF
--- a/.claude/skills/product-owner/SKILL.md
+++ b/.claude/skills/product-owner/SKILL.md
@@ -254,6 +254,48 @@ If biomelab is launched from inside a git repository, that repo is automatically
 registered in regular mode. If launched from a non-git directory, biomelab shows
 an empty state with instructions to add a repo.
 
+### 18. Kanban Board View
+
+The default view groups linked worktrees into four columns by PR/MR lifecycle stage:
+
+| Column | Condition |
+|---|---|
+| **Created** | No PR associated, or PR is closed |
+| **PR Sent** | Open PR (including drafts) with no review activity yet |
+| **PR In Review** | Open PR that has received at least one review (approved, changes requested, or commented) |
+| **PR Merged** | PR has been merged |
+
+The main worktree card remains pinned at the top regardless of view.
+
+**Toggling views:** Press `g` to switch to the responsive card grid. Press `g` again
+to return to the kanban board. The preference is per repo/mode.
+
+**Kanban card layout:** Each card in the kanban view is compact and shows only
+essential information in up to four rows:
+
+| Row | Content | Visibility |
+|---|---|---|
+| 1 | `●` (stage-coloured dot) + bold branch name | Always |
+| 2 | `● agent-name` in green | Only when an agent is running |
+| 3 | underlined `#42` (tappable PR link) + `🔍` review icon + `🤖` CI icon | Only when a PR exists |
+| 4 | `~ dirty` in yellow | Only when worktree has uncommitted changes |
+
+Review and CI icons use distinct symbols to avoid confusion even when both are
+the same colour. Hovering over either shows a tooltip explaining its meaning:
+
+| Category | Approved/Success | Changes Requested/Failure | Commented/Pending |
+|---|---|---|---|
+| Review (🔍) | `✓` green | `!` red | `~` yellow |
+| CI (🤖) | `✓` green | `✗` red | `○` yellow |
+
+This data is fetched from `gh pr view --json reviews` (GitHub) and `glab mr view --json approvedBy` (GitLab).
+
+**Kanban navigation:**
+- `↑ / k`: move up within the current column (from first card → back to main)
+- `↓ / j`: move down within the current column (from main → first card of first non-empty column)
+- `← / h`: jump to the same-row card in the previous non-empty column
+- `→ / l`: jump to the same-row card in the next non-empty column
+
 ---
 
 ## Keyboard Reference
@@ -276,8 +318,8 @@ an empty state with instructions to add a repo.
 |---|---|---|
 | `Up` / `k` | Navigate up | Any card |
 | `Down` / `j` | Navigate down | Any card |
-| `Left` / `h` | Navigate left in grid | Linked cards |
-| `Right` / `l` | Navigate right in grid | Linked cards |
+| `Left` / `h` | Navigate left (grid: move left; kanban: previous column) | Linked cards |
+| `Right` / `l` | Navigate right (grid: move right; kanban: next column) | Linked cards |
 | `c` | Create worktree | Main card only |
 | `f` | Fetch PR/MR | Main card only |
 | `n` | New sandbox / create sandbox | Main card only |
@@ -288,6 +330,7 @@ an empty state with instructions to add a repo.
 | `Enter` | Open in terminal | Any card |
 | `p` | Pull from remote | Any card |
 | `r` | Refresh selected card | Any card |
+| `g` | Toggle kanban ↔ grid view | Global |
 | `m` | Toggle mouse mode | Global |
 | `q` / `Ctrl+C` | Quit | Global |
 | `Tab` / `Shift+Tab` | Switch panel focus | Global |
@@ -572,3 +615,30 @@ failing silently.
 requires a dedicated CLI integration (`gh`, `glab`). The "not yet supported"
 message signals that the limitation is known and intentional, not a bug, and
 leaves the door open for future providers (Bitbucket, Gitea, etc.).
+
+### DL-021: Kanban board is the default view
+
+**Decision:** When a repo/mode is first displayed, the linked worktrees are
+shown in the kanban board (four PR lifecycle columns) rather than the
+responsive card grid. Press `g` to toggle between views. The preference is
+stored per repo/mode in `RepoState.ViewMode`.
+
+**Why:** The primary use-case for biomelab is running multiple AI agents on
+multiple branches simultaneously. The most important question is "what state is
+each branch in?" — not "what are all my branches?" The kanban board answers
+that question at a glance: Created → PR Sent → PR In Review → PR Merged. The
+card grid remains available for users who prefer a flat, alphabetical view or
+who have many branches at the same stage.
+
+### DL-022: Review status fetched from provider and shown on cards
+
+**Decision:** `PRInfo` carries a `ReviewStatus` field ("approved",
+"changes_requested", "commented", or ""). This is fetched via
+`gh pr view --json reviews` (GitHub) and `glab mr view --json approvedBy`
+(GitLab). Cards show a small icon: green ✓ approved, red ! changes requested,
+yellow ● commented.
+
+**Why:** Review status is what determines whether a branch is in "PR Sent" vs
+"PR In Review" in the kanban board. It also provides a quick signal on cards in
+the grid view so users know whether action is needed without opening the PR URL.
+The icon is kept minimal (single character) to avoid crowding the card line.

--- a/internal/gui/card.go
+++ b/internal/gui/card.go
@@ -218,7 +218,17 @@ func buildPRLine(pr *provider.PRInfo, prov provider.Provider) fyne.CanvasObject 
 	}
 
 	text := fmt.Sprintf("%s #%d %s (%s)", label, pr.Number, title, stateLabel)
-	parts := []fyne.CanvasObject{monoText(truncateStr(text, 40), c, false)}
+	parts := []fyne.CanvasObject{monoText(truncateStr(text, 36), c, false)}
+
+	// Review status icon (shown before the CI icon).
+	switch pr.ReviewStatus {
+	case "approved":
+		parts = append(parts, monoText(" ✓", colorGreen, false))
+	case "changes_requested":
+		parts = append(parts, monoText(" !", colorRed, false))
+	case "commented":
+		parts = append(parts, monoText(" ●", colorYellow, false))
+	}
 
 	if pr.CheckStatus != "" {
 		icon := provider.StatusIcon(pr.CheckStatus)

--- a/internal/gui/dashboard.go
+++ b/internal/gui/dashboard.go
@@ -320,6 +320,15 @@ func (d *Dashboard) build() fyne.CanvasObject {
 		return container.NewBorder(topSection, d.helpBar(), nil, nil, nil)
 	}
 
+	// Kanban board view.
+	if d.state.ViewMode == ViewKanban {
+		d.scroll = nil
+		d.cards = nil
+		kanbanView := d.buildKanbanView()
+		return container.NewBorder(topSection, d.helpBar(), nil, nil, kanbanView)
+	}
+
+	// Grid view (default).
 	var cards []fyne.CanvasObject
 	for i, wt := range linked {
 		wtIdx := i + 1 // offset by 1 because main card is index 0
@@ -361,7 +370,11 @@ func (d *Dashboard) helpBar() fyne.CanvasObject {
 	bg := canvas.NewRectangle(colorPanelBg)
 	bg.CornerRadius = 0
 
-	help := monoText("↑↓ nav  [Tab] panel  [⏎] open  [e] editor  [r] refresh  [d] delete  [p] pull  [P] PR", colorDimGray, false)
+	viewHint := "[g] board"
+	if d.state.ViewMode == ViewKanban {
+		viewHint = "[g] grid"
+	}
+	help := monoText("↑↓ nav  [Tab] panel  [⏎] open  [e] editor  [r] refresh  [d] delete  [p] pull  [P] PR  "+viewHint, colorDimGray, false)
 	help.TextSize = scaledSize(9)
 
 	return container.NewStack(bg, container.NewPadded(help))

--- a/internal/gui/kanban.go
+++ b/internal/gui/kanban.go
@@ -1,0 +1,380 @@
+package gui
+
+import (
+	"fmt"
+	"image/color"
+	"net/url"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/mdelapenya/biomelab/internal/agent"
+	"github.com/mdelapenya/biomelab/internal/git"
+	"github.com/mdelapenya/biomelab/internal/provider"
+)
+
+// prLink is a tappable monospace label that opens the PR/MR URL in the default
+// browser when clicked.
+type prLink struct {
+	widget.BaseWidget
+	txt *canvas.Text
+	u   *url.URL
+}
+
+func newPRLink(label, rawURL string, c color.Color) *prLink {
+	u, _ := url.Parse(rawURL)
+	txt := monoText(label, c, false)
+	txt.TextStyle.Underline = true
+	pl := &prLink{txt: txt, u: u}
+	pl.ExtendBaseWidget(pl)
+	return pl
+}
+
+func (pl *prLink) Tapped(_ *fyne.PointEvent) {
+	if pl.u != nil {
+		fyne.CurrentApp().OpenURL(pl.u)
+	}
+}
+func (pl *prLink) TappedSecondary(_ *fyne.PointEvent) {}
+func (pl *prLink) CreateRenderer() fyne.WidgetRenderer { return widget.NewSimpleRenderer(pl.txt) }
+
+// hintIcon wraps a coloured label and shows a tooltip popup on mouse hover.
+type hintIcon struct {
+	widget.BaseWidget
+	txt  *canvas.Text
+	hint string
+	pop  *widget.PopUp
+}
+
+func newHintIcon(label string, c color.Color, hint string) *hintIcon {
+	h := &hintIcon{
+		txt:  monoText(label, c, false),
+		hint: hint,
+	}
+	h.ExtendBaseWidget(h)
+	return h
+}
+
+func (h *hintIcon) CreateRenderer() fyne.WidgetRenderer { return widget.NewSimpleRenderer(h.txt) }
+
+func (h *hintIcon) MouseIn(_ *desktop.MouseEvent) {
+	cnv := fyne.CurrentApp().Driver().CanvasForObject(h)
+	if cnv == nil {
+		return
+	}
+	label := widget.NewLabel(h.hint)
+	h.pop = widget.NewPopUp(label, cnv)
+	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(h)
+	h.pop.ShowAtPosition(fyne.NewPos(pos.X, pos.Y+h.Size().Height))
+}
+
+func (h *hintIcon) MouseOut() {
+	if h.pop != nil {
+		h.pop.Hide()
+		h.pop = nil
+	}
+}
+
+func (h *hintIcon) MouseMoved(_ *desktop.MouseEvent) {}
+
+// buildKanbanCardContent builds a compact card matching the website's kb-card
+// layout:
+//
+//	Row 1:  ● (stage-coloured dot)  branch-name
+//	Row 2:  ● agent-name            (omitted when no agent is running)
+//	Row 3:  #42 ↗  review-icon  CI-icon   (omitted when no PR)
+//	Row 4:  ~ dirty                 (omitted when clean)
+//
+// The PR number is a tappable link (↗ suffix signals this). Review and CI icons
+// are prefixed with emojis (🔍 / 🤖) and show a tooltip on hover:
+//
+//	review  🔍✓ green   🔍! red   🔍~ yellow
+//	CI      🤖✓ green   🤖✗ red   🤖○ yellow
+func buildKanbanCardContent(
+	wt git.Worktree,
+	agents []agent.Info,
+	pr *provider.PRInfo,
+	selected bool,
+) fyne.CanvasObject {
+	var rows []fyne.CanvasObject
+
+	stage := kanbanStageOf(pr)
+	dotColor := kanbanColumnColor(stage)
+
+	// ── Row 1: ● branch-name ────────────────────────────────────────────
+	dot := monoText("●", dotColor, false)
+	dot.TextSize = scaledSize(8)
+	branchColor := colorBranch
+	prefix := ""
+	if selected {
+		branchColor = colorSelected
+		prefix = "▸ "
+	}
+	branchLabel := monoText(prefix+wt.Branch, branchColor, true)
+	branchLabel.TextSize = scaledSize(12)
+	rows = append(rows, container.NewHBox(dot, branchLabel))
+
+	// ── Row 2: ● agent-name (omitted when no agent) ─────────────────────
+	if len(agents) > 0 {
+		agentLine := monoText("● "+string(agents[0].Kind), colorGreen, false)
+		agentLine.TextSize = scaledSize(10)
+		rows = append(rows, agentLine)
+	}
+
+	// ── Row 3: #42 ↗  review  CI  (omitted when no PR) ─────────────────
+	if pr != nil {
+		// PR number as a tappable link; ↗ makes clickability explicit.
+		prNum := newPRLink(fmt.Sprintf("#%d", pr.Number), pr.URL, colorBlue)
+
+		var statusParts []fyne.CanvasObject
+		statusParts = append(statusParts, prNum)
+
+		// Review icon — 🔍 prefix, tooltip on hover.
+		switch pr.ReviewStatus {
+		case "approved":
+			statusParts = append(statusParts, newHintIcon("🔍✓", colorGreen, "Review: approved"))
+		case "changes_requested":
+			statusParts = append(statusParts, newHintIcon("🔍!", colorRed, "Review: changes requested"))
+		case "commented":
+			statusParts = append(statusParts, newHintIcon("🔍~", colorYellow, "Review: commented"))
+		}
+
+		// CI icon — 🤖 prefix, tooltip on hover.
+		switch pr.CheckStatus {
+		case "success":
+			statusParts = append(statusParts, newHintIcon("🤖✓", colorGreen, "CI: success"))
+		case "failure":
+			statusParts = append(statusParts, newHintIcon("🤖✗", colorRed, "CI: failure"))
+		case "pending":
+			statusParts = append(statusParts, newHintIcon("🤖○", colorYellow, "CI: pending"))
+		}
+
+		rows = append(rows, container.NewHBox(statusParts...))
+	}
+
+	// ── Row 4: ~ dirty (omitted when clean) ─────────────────────────────
+	if wt.IsDirty {
+		dirty := monoText("~ dirty", colorYellow, false)
+		dirty.TextSize = scaledSize(10)
+		rows = append(rows, dirty)
+	}
+
+	return container.NewVBox(rows...)
+}
+
+// kanbanCardWrapper wraps a tappableCard and reports MinSize.Width = 1 so that
+// container.NewVScroll always sizes the card to the column width rather than to
+// the natural text-content width (which can exceed the narrow kanban column).
+type kanbanCardWrapper struct {
+	widget.BaseWidget
+	inner *tappableCard
+}
+
+func newKanbanCardWrapper(inner *tappableCard) *kanbanCardWrapper {
+	w := &kanbanCardWrapper{inner: inner}
+	w.ExtendBaseWidget(w)
+	return w
+}
+
+func (w *kanbanCardWrapper) Tapped(e *fyne.PointEvent)          { w.inner.Tapped(e) }
+func (w *kanbanCardWrapper) TappedSecondary(_ *fyne.PointEvent) {}
+func (w *kanbanCardWrapper) CreateRenderer() fyne.WidgetRenderer {
+	return &kanbanCardWrapperRenderer{w: w}
+}
+
+type kanbanCardWrapperRenderer struct{ w *kanbanCardWrapper }
+
+func (r *kanbanCardWrapperRenderer) Layout(size fyne.Size) {
+	r.w.inner.Move(fyne.NewPos(0, 0))
+	r.w.inner.Resize(size)
+}
+func (r *kanbanCardWrapperRenderer) MinSize() fyne.Size {
+	// Report width=1 so the VScroll gives the VBox the scroll (column) width,
+	// not the widest text element. Height stays natural so rows don't collapse.
+	return fyne.NewSize(1, r.w.inner.MinSize().Height)
+}
+func (r *kanbanCardWrapperRenderer) Refresh()                     { r.w.inner.Refresh() }
+func (r *kanbanCardWrapperRenderer) Destroy()                     {}
+func (r *kanbanCardWrapperRenderer) Objects() []fyne.CanvasObject { return []fyne.CanvasObject{r.w.inner} }
+
+// kanbanStageOf returns the kanban column index (0–3) for a worktree based on
+// its PR/MR state and review status.
+//
+//	0 = Created   — no PR, or PR is closed
+//	1 = PR Sent   — open PR with no review activity yet
+//	2 = PR In Review — open PR that has at least one review
+//	3 = PR Merged — PR has been merged
+func kanbanStageOf(pr *provider.PRInfo) int {
+	if pr == nil || pr.State == "closed" {
+		return 0
+	}
+	switch pr.State {
+	case "merged":
+		return 3
+	case "open":
+		if pr.ReviewStatus != "" {
+			return 2
+		}
+		return 1
+	default:
+		return 0
+	}
+}
+
+var kanbanColumnTitles = [4]string{
+	"Created",
+	"PR Sent",
+	"PR In Review",
+	"PR Merged",
+}
+
+// kanbanColumnColor returns the header accent color for a kanban stage.
+func kanbanColumnColor(stage int) color.Color {
+	switch stage {
+	case 0:
+		return colorGray
+	case 1:
+		return colorBlue
+	case 2:
+		return colorYellow
+	case 3:
+		return colorPurple
+	default:
+		return colorGray
+	}
+}
+
+// kanbanColumnBgColor returns a subtle body-tint for the column background.
+func kanbanColumnBgColor(stage int) color.Color {
+	switch stage {
+	case 1:
+		return color.NRGBA{R: 0x69, G: 0xa7, B: 0xff, A: 0x1a} // blue  ~10 %
+	case 2:
+		return color.NRGBA{R: 0xf3, G: 0xd6, B: 0x6b, A: 0x1a} // yellow ~10 %
+	case 3:
+		return color.NRGBA{R: 0xca, G: 0x79, B: 0xff, A: 0x1a} // purple ~10 %
+	default:
+		return color.NRGBA{R: 0x70, G: 0x83, B: 0x94, A: 0x12} // gray   ~ 7 %
+	}
+}
+
+// kanbanColumnHeaderBgColor returns a stronger header tint for a kanban column.
+func kanbanColumnHeaderBgColor(stage int) color.Color {
+	switch stage {
+	case 1:
+		return color.NRGBA{R: 0x69, G: 0xa7, B: 0xff, A: 0x38} // blue  ~22 %
+	case 2:
+		return color.NRGBA{R: 0xf3, G: 0xd6, B: 0x6b, A: 0x38} // yellow ~22 %
+	case 3:
+		return color.NRGBA{R: 0xca, G: 0x79, B: 0xff, A: 0x38} // purple ~22 %
+	default:
+		return color.NRGBA{R: 0x70, G: 0x83, B: 0x94, A: 0x28} // gray  ~16 %
+	}
+}
+
+// KanbanStages groups the 1-based linked-worktree indices (matching SelectedCard)
+// into four slices, one per kanban column. Index 0 (main) is never included.
+func (d *Dashboard) KanbanStages() [4][]int {
+	var stages [4][]int
+	linked := d.state.LinkedWorktrees()
+	for i, wt := range linked {
+		idx := i + 1 // 1-based: index 0 is the main worktree
+		pr := d.prFor(wt.Branch)
+		stage := kanbanStageOf(pr)
+		stages[stage] = append(stages[stage], idx)
+	}
+	return stages
+}
+
+// KanbanColumnOf returns the stage (0–3) for the given 1-based worktree index.
+func (d *Dashboard) KanbanColumnOf(cardIdx int) int {
+	if cardIdx <= 0 || cardIdx >= len(d.state.Worktrees) {
+		return 0
+	}
+	wt := d.state.Worktrees[cardIdx]
+	pr := d.prFor(wt.Branch)
+	return kanbanStageOf(pr)
+}
+
+// KanbanRowOf returns the 0-based row within the column for the given 1-based
+// worktree index. Returns 0 if the card is not found in the column.
+func (d *Dashboard) KanbanRowOf(cardIdx int, stages [4][]int) int {
+	col := d.KanbanColumnOf(cardIdx)
+	for row, idx := range stages[col] {
+		if idx == cardIdx {
+			return row
+		}
+	}
+	return 0
+}
+
+// buildKanbanView constructs the four-column kanban board for linked worktrees.
+// Each column is wrapped in a coloured border rectangle (matching the website
+// kb-col design): subtle body tint + stronger header tint + coloured stroke.
+// Cards scroll vertically inside each column via NewVScroll, which constrains
+// card width to the column width so nothing overflows sideways.
+func (d *Dashboard) buildKanbanView() fyne.CanvasObject {
+	stages := d.KanbanStages()
+
+	cols := make([]fyne.CanvasObject, 4)
+	for si, stageIndices := range stages {
+		accentColor := kanbanColumnColor(si)
+
+		// ── Header (pinned, stronger tint) ──────────────────────────────
+		headerText := fmt.Sprintf("%s  %d", kanbanColumnTitles[si], len(stageIndices))
+		headerLabel := monoText(headerText, accentColor, true)
+		headerLabel.TextSize = scaledSize(11)
+
+		headerBg := canvas.NewRectangle(kanbanColumnHeaderBgColor(si))
+		headerBg.CornerRadius = 4
+		header := container.NewStack(headerBg, container.NewPadded(headerLabel))
+		headerSection := container.NewVBox(header, widget.NewSeparator())
+
+		// ── Cards (vertically scrollable, width-constrained) ─────────────
+		var cardArea fyne.CanvasObject
+		if len(stageIndices) == 0 {
+			empty := monoText("—", colorDimGray, false)
+			cardArea = container.NewPadded(empty)
+		} else {
+			var cardItems []fyne.CanvasObject
+			for _, wtIdx := range stageIndices {
+				wt := d.state.Worktrees[wtIdx]
+				isSelected := d.state.SelectedCard == wtIdx
+				content := buildKanbanCardContent(
+					wt,
+					d.agentsFor(wt.Path),
+					d.prFor(wt.Branch),
+					isSelected,
+				)
+				cardWtIdx := wtIdx // capture for closure
+				card := makeCard(content, isSelected, false, func() {
+					d.state.SelectedCard = cardWtIdx
+					if d.OnCardSelected != nil {
+						d.OnCardSelected(cardWtIdx)
+					}
+					d.Rebuild()
+				})
+				// Wrap each card so its MinSize.Width = 1, forcing the VScroll to
+				// size it to the column width rather than the natural text width.
+				cardItems = append(cardItems, newKanbanCardWrapper(card))
+			}
+			cardArea = container.NewVScroll(container.NewVBox(cardItems...))
+		}
+
+		// ── Column border + background rectangle ─────────────────────────
+		// Mirrors the website's .kb-col: coloured stroke + subtle body tint.
+		colBg := canvas.NewRectangle(kanbanColumnBgColor(si))
+		colBg.CornerRadius = 6
+		colBg.StrokeColor = accentColor
+		colBg.StrokeWidth = 1.5
+
+		// NewPadded keeps the content (header + cards) away from the border stroke.
+		colContent := container.NewBorder(headerSection, nil, nil, nil, cardArea)
+		cols[si] = container.NewStack(colBg, container.NewPadded(colContent))
+	}
+
+	return container.NewGridWithColumns(4, cols...)
+}

--- a/internal/gui/kanban.go
+++ b/internal/gui/kanban.go
@@ -35,7 +35,7 @@ func newPRLink(label, rawURL string, c color.Color) *prLink {
 
 func (pl *prLink) Tapped(_ *fyne.PointEvent) {
 	if pl.u != nil {
-		fyne.CurrentApp().OpenURL(pl.u)
+		_ = fyne.CurrentApp().OpenURL(pl.u)
 	}
 }
 func (pl *prLink) TappedSecondary(_ *fyne.PointEvent) {}

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -67,6 +67,12 @@ func (a *App) handleKeyName(key fyne.KeyName) {
 	// Letter keys — handled here instead of SetOnTypedRune because
 	// onTypedRune only fires when canvas.Focused()==nil, which can
 	// silently break after dialog dismissal. SetOnKeyDown always fires.
+	// View toggle is global across both panels.
+	if key == fyne.KeyG {
+		a.toggleView()
+		return
+	}
+
 	if a.focus == focusLeft {
 		switch key {
 		case fyne.KeyJ:
@@ -177,6 +183,10 @@ func (a *App) navigateUp() {
 	if a.dashboard == nil {
 		return
 	}
+	if a.dashboard.state.ViewMode == ViewKanban {
+		a.navigateKanbanUp()
+		return
+	}
 	s := a.dashboard.state
 	if s.SelectedCard == 0 {
 		return // already at main
@@ -198,6 +208,10 @@ func (a *App) navigateDown() {
 		return
 	}
 	if a.dashboard == nil {
+		return
+	}
+	if a.dashboard.state.ViewMode == ViewKanban {
+		a.navigateKanbanDown()
 		return
 	}
 	s := a.dashboard.state
@@ -227,6 +241,10 @@ func (a *App) navigateLeft() {
 	if a.focus != focusRight || a.dashboard == nil {
 		return
 	}
+	if a.dashboard.state.ViewMode == ViewKanban {
+		a.navigateKanbanLeft()
+		return
+	}
 	s := a.dashboard.state
 	if s.SelectedCard > 1 {
 		s.SelectedCard--
@@ -242,6 +260,10 @@ func (a *App) navigateRight() {
 	if a.focus != focusRight || a.dashboard == nil {
 		return
 	}
+	if a.dashboard.state.ViewMode == ViewKanban {
+		a.navigateKanbanRight()
+		return
+	}
 	s := a.dashboard.state
 	if s.SelectedCard == 0 {
 		if len(s.Worktrees) > 1 {
@@ -255,6 +277,116 @@ func (a *App) navigateRight() {
 		s.SelectedCard++
 		a.dashboard.Rebuild()
 		a.dashboard.EnsureVisible()
+	}
+}
+
+// --- View toggle ---
+
+func (a *App) toggleView() {
+	re := a.activeRepo()
+	if re == nil {
+		return
+	}
+	if re.state.ViewMode == ViewKanban {
+		re.state.ViewMode = ViewGrid
+	} else {
+		re.state.ViewMode = ViewKanban
+	}
+	if a.dashboard != nil {
+		a.dashboard.Rebuild()
+		if re.state.ViewMode == ViewGrid {
+			a.dashboard.EnsureVisible()
+		}
+	}
+}
+
+// --- Kanban navigation ---
+
+func (a *App) navigateKanbanUp() {
+	s := a.dashboard.state
+	if s.SelectedCard == 0 {
+		return
+	}
+	stages := a.dashboard.KanbanStages()
+	col := a.dashboard.KanbanColumnOf(s.SelectedCard)
+	row := a.dashboard.KanbanRowOf(s.SelectedCard, stages)
+	if row > 0 {
+		s.SelectedCard = stages[col][row-1]
+	} else {
+		s.SelectedCard = 0 // top of column → back to main
+	}
+	a.dashboard.Rebuild()
+}
+
+func (a *App) navigateKanbanDown() {
+	s := a.dashboard.state
+	stages := a.dashboard.KanbanStages()
+	if s.SelectedCard == 0 {
+		// From main, enter the first non-empty column.
+		for _, colCards := range stages {
+			if len(colCards) > 0 {
+				s.SelectedCard = colCards[0]
+				a.dashboard.Rebuild()
+				return
+			}
+		}
+		return
+	}
+	col := a.dashboard.KanbanColumnOf(s.SelectedCard)
+	row := a.dashboard.KanbanRowOf(s.SelectedCard, stages)
+	if row < len(stages[col])-1 {
+		s.SelectedCard = stages[col][row+1]
+		a.dashboard.Rebuild()
+	}
+}
+
+func (a *App) navigateKanbanLeft() {
+	s := a.dashboard.state
+	if s.SelectedCard <= 0 {
+		return
+	}
+	stages := a.dashboard.KanbanStages()
+	col := a.dashboard.KanbanColumnOf(s.SelectedCard)
+	row := a.dashboard.KanbanRowOf(s.SelectedCard, stages)
+	for c := col - 1; c >= 0; c-- {
+		if len(stages[c]) > 0 {
+			targetRow := row
+			if targetRow >= len(stages[c]) {
+				targetRow = len(stages[c]) - 1
+			}
+			s.SelectedCard = stages[c][targetRow]
+			a.dashboard.Rebuild()
+			return
+		}
+	}
+}
+
+func (a *App) navigateKanbanRight() {
+	s := a.dashboard.state
+	stages := a.dashboard.KanbanStages()
+	if s.SelectedCard == 0 {
+		// From main, enter the first non-empty column.
+		for _, colCards := range stages {
+			if len(colCards) > 0 {
+				s.SelectedCard = colCards[0]
+				a.dashboard.Rebuild()
+				return
+			}
+		}
+		return
+	}
+	col := a.dashboard.KanbanColumnOf(s.SelectedCard)
+	row := a.dashboard.KanbanRowOf(s.SelectedCard, stages)
+	for c := col + 1; c < 4; c++ {
+		if len(stages[c]) > 0 {
+			targetRow := row
+			if targetRow >= len(stages[c]) {
+				targetRow = len(stages[c]) - 1
+			}
+			s.SelectedCard = stages[c][targetRow]
+			a.dashboard.Rebuild()
+			return
+		}
 	}
 }
 

--- a/internal/gui/state.go
+++ b/internal/gui/state.go
@@ -13,6 +13,17 @@ import (
 	"github.com/mdelapenya/biomelab/internal/sandbox"
 )
 
+// ViewMode controls how the linked worktrees are displayed.
+type ViewMode int
+
+const (
+	// ViewKanban groups worktrees into columns by PR lifecycle stage.
+	// It is the default view (zero value).
+	ViewKanban ViewMode = iota
+	// ViewGrid is the responsive card grid layout.
+	ViewGrid
+)
+
 // RepoState holds all UI-relevant state for a single repo+mode.
 type RepoState struct {
 	// Domain data from business logic.
@@ -28,6 +39,7 @@ type RepoState struct {
 	ActiveMode       *config.ModeEntry
 
 	// UI state.
+	ViewMode           ViewMode
 	SelectedCard       int
 	LastLocalRefresh   time.Time
 	LastNetworkRefresh time.Time

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -64,7 +64,7 @@ func (g *GitHubProvider) CreatePR(repoDir, branch, targetRepo string) (*PRInfo, 
 
 func fetchGitHubPR(repoDir, branch string) *PRInfo {
 	cmd := exec.Command("gh", "pr", "view", branch,
-		"--json", "number,title,state,isDraft,url,statusCheckRollup",
+		"--json", "number,title,state,isDraft,url,statusCheckRollup,reviews",
 	)
 	cmd.Dir = repoDir
 	out, err := cmd.Output()
@@ -83,6 +83,9 @@ func fetchGitHubPR(repoDir, branch string) *PRInfo {
 			Status     string `json:"status"`
 			Conclusion string `json:"conclusion"`
 		} `json:"statusCheckRollup"`
+		Reviews []struct {
+			State string `json:"state"`
+		} `json:"reviews"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
 		return nil
@@ -97,7 +100,36 @@ func fetchGitHubPR(repoDir, branch string) *PRInfo {
 	}
 
 	pr.CheckStatus = rollupStatus(raw.StatusCheckRollup)
+	pr.ReviewStatus = githubReviewStatus(raw.Reviews)
 	return pr
+}
+
+// githubReviewStatus returns the most significant review state from a list of
+// GitHub reviews. Priority: approved > changes_requested > commented.
+func githubReviewStatus(reviews []struct{ State string `json:"state"` }) string {
+	hasApproved := false
+	hasChanges := false
+	hasComment := false
+	for _, r := range reviews {
+		switch strings.ToUpper(r.State) {
+		case "APPROVED":
+			hasApproved = true
+		case "CHANGES_REQUESTED":
+			hasChanges = true
+		case "COMMENTED":
+			hasComment = true
+		}
+	}
+	switch {
+	case hasApproved:
+		return "approved"
+	case hasChanges:
+		return "changes_requested"
+	case hasComment:
+		return "commented"
+	default:
+		return ""
+	}
 }
 
 func rollupStatus(checks []struct {

--- a/internal/provider/gitlab.go
+++ b/internal/provider/gitlab.go
@@ -62,7 +62,7 @@ func (g *GitLabProvider) CreatePR(repoDir, branch, targetRepo string) (*PRInfo, 
 
 func fetchGitLabMR(repoDir, branch string) *PRInfo {
 	cmd := exec.Command("glab", "mr", "view", branch,
-		"--json", "iid,title,state,draft,webUrl,headPipeline",
+		"--json", "iid,title,state,draft,webUrl,headPipeline,approvedBy",
 	)
 	cmd.Dir = repoDir
 	out, err := cmd.Output()
@@ -79,6 +79,9 @@ func fetchGitLabMR(repoDir, branch string) *PRInfo {
 		HeadPipeline *struct {
 			Status string `json:"status"`
 		} `json:"headPipeline"`
+		ApprovedBy []struct {
+			Username string `json:"username"`
+		} `json:"approvedBy"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
 		return nil
@@ -94,6 +97,9 @@ func fetchGitLabMR(repoDir, branch string) *PRInfo {
 
 	if raw.HeadPipeline != nil {
 		pr.CheckStatus = mapGitLabPipelineStatus(raw.HeadPipeline.Status)
+	}
+	if len(raw.ApprovedBy) > 0 {
+		pr.ReviewStatus = "approved"
 	}
 
 	return pr

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -69,6 +69,10 @@ type PRInfo struct {
 
 	// CI check status: "success", "failure", "pending", or "" if unknown.
 	CheckStatus string
+
+	// ReviewStatus is the most significant review state on the PR/MR.
+	// Values: "approved", "changes_requested", "commented", or "" (no reviews).
+	ReviewStatus string
 }
 
 // PRResult maps branch names to their PR info.

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1630,3 +1630,314 @@ footer {
     text-align: center
   }
 }
+
+/* ── Kanban Board Section ────────────────────────────────── */
+.kanban-board {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--bg-secondary) 90%, transparent),
+    color-mix(in srgb, var(--bg-secondary) 95%, transparent));
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent)
+}
+
+.kb-accent {
+  background: linear-gradient(135deg, var(--blue), var(--yellow) 55%, var(--magenta));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent !important;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 2px 12px rgba(0,0,0,.35))
+}
+
+.kanban-intro {
+  font-size: 1.12rem;
+  margin-top: 1rem;
+  margin-bottom: 3rem
+}
+
+.kanban-features {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 3rem
+}
+
+.kanban-feat-card {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--bg-card) 100%, transparent),
+    color-mix(in srgb, var(--bg-tertiary) 100%, transparent));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  padding: 2rem 1.5rem;
+  text-align: center;
+  transition: .22s transform ease, .22s border-color ease, .22s box-shadow ease
+}
+
+.kanban-feat-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-card)
+}
+
+.kanban-feat-card .icon {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  display: block
+}
+
+.kanban-feat-card p {
+  font-size: .93rem;
+  line-height: 1.55
+}
+
+.kanban-feat-card kbd {
+  display: inline-block;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-bottom: 2px solid var(--border-strong);
+  border-radius: 6px;
+  padding: .08rem .42rem;
+  font-size: .8rem;
+  color: var(--cyan)
+}
+
+/* ── Kanban Diagram ──────────────────────────────────────── */
+.kanban-diagram-html {
+  margin-top: 1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--bg-card) 92%, transparent),
+    color-mix(in srgb, var(--bg-tertiary) 94%, transparent));
+  box-shadow: var(--shadow-card)
+}
+
+/* Board: four columns + three flow arrows, laid out in a row */
+.kb-board {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr;
+  gap: .75rem;
+  align-items: start
+}
+
+/* Flow arrow between columns */
+.kb-flow-arrow {
+  display: flex;
+  align-items: flex-start;
+  padding-top: .9rem;
+  font-size: 1.4rem;
+  color: var(--border-strong);
+  user-select: none
+}
+
+/* Individual column */
+.kb-col {
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  padding-bottom: .5rem
+}
+
+.kb-col-created  { border-color: var(--text-muted); background: color-mix(in srgb, var(--text-muted) 7%,  var(--bg-card)) }
+.kb-col-sent     { border-color: var(--blue);        background: color-mix(in srgb, var(--blue)       9%,  var(--bg-card)) }
+.kb-col-in-review { border-color: var(--yellow);      background: color-mix(in srgb, var(--yellow)     9%,  var(--bg-card)) }
+.kb-col-merged   { border-color: var(--magenta);     background: color-mix(in srgb, var(--magenta)    9%,  var(--bg-card)) }
+
+/* Pulse glow on the active column */
+@keyframes kbColPulse {
+  0%, 100% { box-shadow: 0 0 0 transparent }
+  50%       { box-shadow: 0 0 22px color-mix(in srgb, var(--yellow) 38%, transparent) }
+}
+
+.kb-col-active {
+  animation: kbColPulse 2.8s ease-in-out infinite
+}
+
+/* Column header */
+.kb-col-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .6rem .9rem;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: .85rem;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent)
+}
+
+.kb-col-created  .kb-col-header { background: color-mix(in srgb, var(--text-muted) 20%, var(--bg-card)); color: var(--text-muted) }
+.kb-col-sent     .kb-col-header { background: color-mix(in srgb, var(--blue)       22%, var(--bg-card)); color: var(--blue) }
+.kb-col-in-review .kb-col-header { background: color-mix(in srgb, var(--yellow)     22%, var(--bg-card)); color: var(--yellow) }
+.kb-col-merged   .kb-col-header { background: color-mix(in srgb, var(--magenta)    22%, var(--bg-card)); color: var(--magenta) }
+
+.kb-col-badge {
+  font-size: .75rem;
+  padding: .12rem .5rem;
+  border-radius: 999px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  color: var(--text-muted)
+}
+
+.kb-badge-blue   { border-color: var(--blue);    color: var(--blue) }
+.kb-badge-yellow { border-color: var(--yellow);  color: var(--yellow) }
+.kb-badge-purple { border-color: var(--magenta); color: var(--magenta) }
+
+/* Cards inside a column */
+.kb-card {
+  margin: .6rem .6rem;
+  padding: .6rem .75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-primary) 90%, transparent);
+  font-family: var(--font-mono);
+  font-size: .78rem;
+  transition: .18s border-color ease, .18s box-shadow ease
+}
+
+.kb-card-top {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  margin-bottom: .3rem
+}
+
+.kb-card-meta {
+  margin-bottom: .3rem
+}
+
+.kb-card-status {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+  font-size: .73rem
+}
+
+/* Status dot */
+.kb-dot {
+  flex-shrink: 0;
+  width: .45rem;
+  height: .45rem;
+  border-radius: 50%
+}
+
+.kb-dot-gray   { background: var(--text-muted) }
+.kb-dot-blue   { background: var(--blue) }
+.kb-dot-yellow { background: var(--yellow) }
+.kb-dot-purple { background: var(--magenta) }
+.kb-dot-dim    { background: var(--border-strong) }
+
+/* Branch name */
+.kb-branch       { color: var(--text-primary) }
+.kb-branch-dim   { color: var(--text-muted) }
+.kb-branch-merged{ color: var(--text-muted) }
+
+/* Agent line */
+.kb-agent-green { color: var(--green) }
+.kb-agent-dim   { color: var(--text-muted) }
+
+/* PR labels */
+.kb-no-pr        { color: var(--text-muted) }
+.kb-pr-label     { color: var(--text-secondary) }
+.kb-pr-num       { color: var(--cyan) }
+.kb-pr-state-open   { color: var(--blue) }
+.kb-pr-state-draft  { color: var(--text-muted) }
+.kb-pr-state-merged { color: var(--magenta) }
+
+/* CI / review icons */
+.kb-ci-pass    { color: var(--green) }
+.kb-ci-fail    { color: var(--red) }
+.kb-ci-pending { color: var(--yellow) }
+
+.kb-review-approved { color: var(--green) }
+.kb-review-changes  { color: var(--red) }
+
+/* Merged card tint */
+.kb-card-merged {
+  opacity: .72
+}
+
+/* Approved card glow */
+@keyframes kbCardApproved {
+  0%, 100% { box-shadow: 0 0 0 transparent }
+  50%       { box-shadow: 0 0 10px color-mix(in srgb, var(--green) 30%, transparent) }
+}
+
+.kb-card-approved {
+  border-color: color-mix(in srgb, var(--green) 45%, var(--border));
+  animation: kbCardApproved 2.4s ease-in-out infinite
+}
+
+.kb-card-changes {
+  border-color: color-mix(in srgb, var(--red) 40%, var(--border))
+}
+
+/* Hover glow — each column uses its own accent colour */
+.kb-col-created  .kb-card-hover { border-color: var(--text-muted); box-shadow: 0 0 12px color-mix(in srgb, var(--text-muted) 28%, transparent) }
+.kb-col-sent     .kb-card-hover { border-color: var(--blue);       box-shadow: 0 0 12px color-mix(in srgb, var(--blue)       22%, transparent) }
+.kb-col-in-review .kb-card-hover { border-color: var(--yellow);     box-shadow: 0 0 12px color-mix(in srgb, var(--yellow)     22%, transparent) }
+.kb-col-merged   .kb-card-hover { border-color: var(--magenta);    box-shadow: 0 0 12px color-mix(in srgb, var(--magenta)    22%, transparent) }
+
+/* Footer hint */
+.kb-footer-hint {
+  margin-top: 1.25rem;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: .78rem;
+  color: var(--text-muted)
+}
+
+.kb-footer-hint kbd {
+  display: inline-block;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-bottom: 2px solid var(--border-strong);
+  border-radius: 5px;
+  padding: .05rem .38rem;
+  font-size: .75rem;
+  color: var(--cyan)
+}
+
+/* Mobile: stack columns vertically */
+@media (max-width: 1080px) {
+  .kb-board {
+    grid-template-columns: 1fr auto 1fr
+  }
+
+  /* Hide arrows 2 and 4 (between cols 2→3 and 3→4) */
+  .kb-flow-arrow:nth-child(4),
+  .kb-flow-arrow:nth-child(6) {
+    display: none
+  }
+
+  /* Col 3 (in review) and col 4 (merged) each start on a new row */
+  .kb-col-in-review,
+  .kb-col-merged {
+    grid-column: 1
+  }
+
+  .kb-col-merged {
+    grid-column: 3
+  }
+}
+
+@media (max-width: 640px) {
+  .kb-board {
+    grid-template-columns: 1fr
+  }
+
+  .kb-flow-arrow {
+    display: none
+  }
+
+  .kb-col-in-review,
+  .kb-col-merged {
+    grid-column: auto
+  }
+
+  .kanban-features {
+    grid-template-columns: 1fr
+  }
+}

--- a/website/index.html
+++ b/website/index.html
@@ -53,6 +53,7 @@
         <li><a href="#dashboard">Dashboard</a></li>
         <li><a href="#sandboxes">Sandboxes</a></li>
         <li><a href="#workflow">Workflow</a></li>
+        <li><a href="#kanban">Kanban</a></li>
         <li><a href="#install">Install</a></li>
         <li>
           <a href="https://github.com/mdelapenya/biomelab" class="nav-github" target="_blank" rel="noopener">
@@ -329,6 +330,182 @@
     </div>
   </section>
 
+  <section id="kanban" class="kanban-board">
+    <div class="container">
+      <span class="section-label">Kanban Board</span>
+      <h2>See every PR's lifecycle <span class="kb-accent">at a glance</span></h2>
+      <p class="kanban-intro">The default view groups your worktrees into four columns — from fresh branch to merged PR. One keystroke switches to the flat grid and back.</p>
+      <div class="kanban-features">
+        <div class="kanban-feat-card"><span class="icon">📋</span>
+          <h3>Four lifecycle stages</h3>
+          <p>Created → PR Sent → PR In Review → PR Merged. Branches self-sort as CI runs and reviewers respond.</p>
+        </div>
+        <div class="kanban-feat-card"><span class="icon">🔍</span>
+          <h3>Review status on every card</h3>
+          <p>Approved ✓, changes requested !, or commented ● — fetched live from GitHub reviews or GitLab approvals.</p>
+        </div>
+        <div class="kanban-feat-card"><span class="icon">⌨️</span>
+          <h3>Press <kbd>g</kbd> for grid view</h3>
+          <p>Toggle to the classic responsive card grid whenever you want a flat alphabetical view. Toggle back with <kbd>g</kbd>.</p>
+        </div>
+      </div>
+
+      <div class="kanban-diagram-html">
+        <h4 class="diagram-title">PR Lifecycle Board</h4>
+
+        <div class="kb-board">
+
+          <!-- Column 0: Created -->
+          <div class="kb-col kb-col-created">
+            <div class="kb-col-header">
+              <span class="kb-col-title">Created</span>
+              <span class="kb-col-badge">2</span>
+            </div>
+            <div class="kb-card" data-kb="feat/new-signup">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-gray"></span>
+                <span class="kb-branch">feat/new-signup</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-green">● claude</span></div>
+              <div class="kb-card-status"><span class="kb-no-pr">no PR</span><span class="kb-ci-empty">&nbsp;</span></div>
+            </div>
+            <div class="kb-card" data-kb="fix/sidebar">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-gray"></span>
+                <span class="kb-branch">fix/sidebar</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+              <div class="kb-card-status"><span class="kb-no-pr">no PR</span></div>
+            </div>
+          </div>
+
+          <div class="kb-flow-arrow">&#x276F;</div>
+
+          <!-- Column 1: PR Sent -->
+          <div class="kb-col kb-col-sent">
+            <div class="kb-col-header">
+              <span class="kb-col-title">PR Sent</span>
+              <span class="kb-col-badge kb-badge-blue">3</span>
+            </div>
+            <div class="kb-card" data-kb="feat/auth-flow">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-blue"></span>
+                <span class="kb-branch">feat/auth-flow</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-green">● claude</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#42</span> <span class="kb-pr-state-open">open</span></span>
+                <span class="kb-ci kb-ci-pending" title="CI pending">●</span>
+              </div>
+            </div>
+            <div class="kb-card" data-kb="fix/memory-leak">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-blue"></span>
+                <span class="kb-branch">fix/memory-leak</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#38</span> <span class="kb-pr-state-open">open</span></span>
+                <span class="kb-ci kb-ci-pass" title="CI passed">✓</span>
+              </div>
+            </div>
+            <div class="kb-card kb-card-draft" data-kb="refactor/db">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-dim"></span>
+                <span class="kb-branch kb-branch-dim">refactor/db</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-green">● codex</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#35</span> <span class="kb-pr-state-draft">draft</span></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="kb-flow-arrow">&#x276F;</div>
+
+          <!-- Column 2: PR In Review -->
+          <div class="kb-col kb-col-in-review kb-col-active">
+            <div class="kb-col-header">
+              <span class="kb-col-title">PR In Review</span>
+              <span class="kb-col-badge kb-badge-yellow">2</span>
+            </div>
+            <div class="kb-card kb-card-approved" data-kb="feat/api-v2">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-yellow"></span>
+                <span class="kb-branch">feat/api-v2</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-green">● claude</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#31</span> <span class="kb-pr-state-open">open</span></span>
+                <span class="kb-review kb-review-approved" title="Approved">✓</span>
+                <span class="kb-ci kb-ci-pass" title="CI passed">✓</span>
+              </div>
+            </div>
+            <div class="kb-card kb-card-changes" data-kb="fix/login">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-yellow"></span>
+                <span class="kb-branch">fix/login</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#29</span> <span class="kb-pr-state-open">open</span></span>
+                <span class="kb-review kb-review-changes" title="Changes requested">!</span>
+                <span class="kb-ci kb-ci-fail" title="CI failed">✗</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="kb-flow-arrow">&#x276F;</div>
+
+          <!-- Column 3: PR Merged -->
+          <div class="kb-col kb-col-merged">
+            <div class="kb-col-header">
+              <span class="kb-col-title">PR Merged</span>
+              <span class="kb-col-badge kb-badge-purple">3</span>
+            </div>
+            <div class="kb-card kb-card-merged" data-kb="feat/dark-mode">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-purple"></span>
+                <span class="kb-branch kb-branch-merged">feat/dark-mode</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#28</span> <span class="kb-pr-state-merged">merged</span></span>
+                <span class="kb-ci kb-ci-pass">✓</span>
+              </div>
+            </div>
+            <div class="kb-card kb-card-merged" data-kb="fix/typo">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-purple"></span>
+                <span class="kb-branch kb-branch-merged">fix/typo</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#27</span> <span class="kb-pr-state-merged">merged</span></span>
+                <span class="kb-ci kb-ci-pass">✓</span>
+              </div>
+            </div>
+            <div class="kb-card kb-card-merged" data-kb="feat/ui-refresh">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-purple"></span>
+                <span class="kb-branch kb-branch-merged">feat/ui-refresh</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#24</span> <span class="kb-pr-state-merged">merged</span></span>
+                <span class="kb-ci kb-ci-pass">✓</span>
+              </div>
+            </div>
+          </div>
+
+        </div><!-- /.kb-board -->
+
+        <div class="kb-footer-hint">
+          <span>↑↓ navigate column · ←→ switch column · <kbd>g</kbd> toggle grid view</span>
+        </div>
+      </div><!-- /.kanban-diagram-html -->
+    </div>
+  </section>
 
   <section id="install">
     <div class="container text-center">
@@ -388,24 +565,19 @@
       <h2>Mouse optional, keyboard mandatory</h2>
       <p class="mx-auto">Every action is a single keystroke. Toggle mouse mode with <kbd>m</kbd> when you want it.</p>
       <div class="keyboard-grid">
-        <div class="key-item"><span class="key-cap key-green">c</span><span class="key-action">Create worktree</span>
-        </div>
+        <div class="key-item"><span class="key-cap key-green">c</span><span class="key-action">Create worktree</span></div>
+        <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span></div>
+        <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span></div>
         <div class="key-item"><span class="key-cap key-blue">f</span><span class="key-action">Fetch PR / MR</span></div>
-        <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span>
-        </div>
-        <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span>
-        </div>
-        <div class="key-item"><span class="key-cap key-yellow">⏎</span><span class="key-action">Open in terminal</span>
-        </div>
-        <div class="key-item"><span class="key-cap key-orange">p</span><span class="key-action">Pull from remote</span>
-        </div>
-        <div class="key-item"><span class="key-cap key-magenta">P</span><span class="key-action">Send PR</span></div>
-        <div class="key-item"><span class="key-cap">r</span><span class="key-action">Refresh card</span></div>
+        <div class="key-item"><span class="key-cap key-cyan">g</span><span class="key-action">Toggle kanban / grid</span></div>
         <div class="key-item"><span class="key-cap">m</span><span class="key-action">Toggle mouse</span></div>
         <div class="key-item"><span class="key-cap">n</span><span class="key-action">New sandbox</span></div>
-        <div class="key-item"><span class="key-cap key-green">s</span><span class="key-action">Start sandbox</span>
-        </div>
+        <div class="key-item"><span class="key-cap key-orange">p</span><span class="key-action">Pull from remote</span></div>
+        <div class="key-item"><span class="key-cap key-magenta">P</span><span class="key-action">Send PR</span></div>
+        <div class="key-item"><span class="key-cap">r</span><span class="key-action">Refresh card</span></div>
+        <div class="key-item"><span class="key-cap key-green">s</span><span class="key-action">Start sandbox</span></div>
         <div class="key-item"><span class="key-cap key-red">S</span><span class="key-action">Stop sandbox</span></div>
+        <div class="key-item"><span class="key-cap key-yellow">⏎</span><span class="key-action">Open in terminal</span></div>
       </div>
     </div>
   </section>
@@ -568,6 +740,16 @@
           wt.classList.remove('sbx-wt-active');
           match.classList.remove('sbx-octo-active');
         }
+      });
+    });
+
+    // Kanban diagram: hover a card → subtle glow effect
+    document.querySelectorAll('.kb-card[data-kb]').forEach(function (card) {
+      card.addEventListener('mouseenter', function () {
+        card.classList.add('kb-card-hover');
+      });
+      card.addEventListener('mouseleave', function () {
+        card.classList.remove('kb-card-hover');
       });
     });
 


### PR DESCRIPTION
## What's changed

Add a kanban board view that groups linked worktrees into four PR lifecycle
columns: **Created → PR Sent → PR In Review → PR Merged**. Branches
automatically sort into the correct column based on their PR state and review
activity. The board is the default view; press `g` to toggle back to the
responsive card grid.

## Why is this important?

When running multiple AI agents across many branches, the key question is
"what state is each branch in?" The kanban layout answers that at a glance —
no scanning through a flat list to figure out which PRs need attention, which
are waiting on CI, and which have been merged.

## Changes

### GUI — kanban board (`internal/gui/kanban.go`, new file)
- Four-column layout using `container.NewGridWithColumns(4)`, each column with
  a coloured border rectangle (stroke + body tint + header tint) matching the
  website's `.kb-col` design
- Compact kanban cards showing only essential info in up to 4 rows:
  stage dot + branch, agent name, underlined PR link + review/CI icons, dirty status
- `prLink` widget: tappable underlined label that opens the PR URL in the default browser
- `hintIcon` widget: emoji-prefixed status icons (🔍 review, 🤖 CI) with
  tooltip popups on hover via `desktop.Hoverable`
- `kanbanCardWrapper` reporting `MinSize.Width = 1` so cards fill column width
  instead of overflowing
- `kanbanStageOf(pr)` classifier: maps PR state + review status → column index
- Column colour helpers: accent, body tint (~10 % alpha), header tint (~22 % alpha)

### GUI — navigation and view toggle (`internal/gui/shortcuts.go`, `dashboard.go`)
- `g` key toggles between kanban and grid views (global, works in both panels)
- Kanban-aware arrow key navigation: up/down within a column, left/right across columns
- Help bar shows `[g] board` / `[g] grid` depending on current view

### GUI — review status on grid cards (`internal/gui/card.go`)
- Grid view cards now show review status icons (✓ approved, ! changes requested,
  ● commented) alongside CI status

### Website (`website/index.html`, `website/css/style.css`)
- New "Kanban Board" section with interactive demo showing all four columns
- Per-column hover colours matching each stage's accent
- Responsive layout: 4-col → 2×2 → single column on narrow screens
- Keyboard bindings sorted alphabetically

### Documentation (`.claude/skills/product-owner/SKILL.md`)
- Section 18: Kanban Board View — column definitions, compact card layout
  with row-by-row breakdown, icon/emoji reference table, navigation keys
- Decision log entries DL-021 (kanban as default) and DL-022 (review status)
- Updated keyboard reference with `g` toggle and kanban-aware left/right

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Look & Feel

<img width="2094" height="1352" alt="Screenshot 2026-04-20 at 18 09 31" src="https://github.com/user-attachments/assets/110473c9-bd8a-4894-9fe4-a02e2815da7c" />

<img width="2092" height="1356" alt="Screenshot 2026-04-20 at 18 09 39" src="https://github.com/user-attachments/assets/77c4858c-636a-4f3e-bd64-91dd9b53989a" />
