### PR TITLE
fix(repos): do not reload app when new repos are enrolled

### DIFF
--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -135,84 +135,97 @@ func (a *App) buildContent() fyne.CanvasObject {
 		}
 	}
 
-	// Build repo groups and entries.
-	var groups []*RepoGroup
 	for _, entry := range cfg.Repos {
-		repo, err := git.OpenRepository(entry.Path)
-		if err != nil {
-			continue
+		if re := a.buildRepoEntry(entry); re != nil {
+			a.repos = append(a.repos, re)
 		}
-
-		group := &RepoGroup{
-			Path:  entry.Path,
-			Name:  entry.Name,
-			Modes: entry.Modes,
-		}
-		groups = append(groups, group)
-
-		prov := provider.DetectProvider(repo.OriginURL())
-		prProv := provider.NewProvider(repo.OriginURL())
-
-		worktrees, _ := repo.ListWorktrees()
-
-		state := &RepoState{
-			Provider: prov,
-		}
-		state.SetWorktrees(worktrees)
-
-		var sbxName string
-		if len(entry.Modes) > 0 {
-			mode := entry.Modes[0]
-			state.ActiveMode = &mode
-			if mode.Type == "sandbox" {
-				sbxName = mode.SandboxName
-				if s, ok := a.sbxStatuses[sbxName]; ok {
-					state.SandboxStatus = s
-				}
-			}
-		}
-
-		dash := NewDashboard(state)
-		dash.OnCardSelected = func(_ int) {
-			a.focus = focusRight // clicking a card means right panel has focus
-		}
-
-		rm := NewRefreshManager(repo, a.detector, a.ideDetector, a.procLister, prProv, a.refreshInterval)
-		rm.SetSandboxName(sbxName)
-
-		re := &repoEntry{
-			group:      group,
-			repo:       repo,
-			prProv:     prProv,
-			state:      state,
-			dashboard:  dash,
-			refreshMgr: rm,
-		}
-
-		// Wire refresh callback.
-		rm.OnRefresh = func(result ops.RefreshResult) {
-			fyne.Do(func() {
-				re.dashboard.ApplyRefresh(result)
-				if result.AllSbxStatuses != nil {
-					for k, v := range result.AllSbxStatuses {
-						a.sbxStatuses[k] = v
-					}
-					if a.repoPanel != nil {
-						a.repoPanel.UpdateStatuses(a.sbxStatuses)
-					}
-				}
-			})
-		}
-
-		a.repos = append(a.repos, re)
 	}
 
 	if len(a.repos) == 0 {
 		return a.emptyState()
 	}
 
+	return a.buildMainLayout()
+}
+
+// buildRepoEntry constructs a repoEntry (go-git repo, provider, dashboard,
+// refresh manager) for a single config entry. Returns nil if the repo can't
+// be opened. The refresh manager is created but not started; the caller
+// decides when to Start it (e.g., buildMainLayout starts only the first).
+func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
+	repo, err := git.OpenRepository(entry.Path)
+	if err != nil {
+		return nil
+	}
+
+	group := &RepoGroup{
+		Path:  entry.Path,
+		Name:  entry.Name,
+		Modes: entry.Modes,
+	}
+
+	prov := provider.DetectProvider(repo.OriginURL())
+	prProv := provider.NewProvider(repo.OriginURL())
+
+	worktrees, _ := repo.ListWorktrees()
+
+	state := &RepoState{
+		Provider: prov,
+	}
+	state.SetWorktrees(worktrees)
+
+	var sbxName string
+	if len(entry.Modes) > 0 {
+		mode := entry.Modes[0]
+		state.ActiveMode = &mode
+		if mode.Type == "sandbox" {
+			sbxName = mode.SandboxName
+			if s, ok := a.sbxStatuses[sbxName]; ok {
+				state.SandboxStatus = s
+			}
+		}
+	}
+
+	dash := NewDashboard(state)
+	dash.OnCardSelected = func(_ int) {
+		a.focus = focusRight // clicking a card means right panel has focus
+	}
+
+	rm := NewRefreshManager(repo, a.detector, a.ideDetector, a.procLister, prProv, a.refreshInterval)
+	rm.SetSandboxName(sbxName)
+
+	re := &repoEntry{
+		group:      group,
+		repo:       repo,
+		prProv:     prProv,
+		state:      state,
+		dashboard:  dash,
+		refreshMgr: rm,
+	}
+
+	rm.OnRefresh = func(result ops.RefreshResult) {
+		fyne.Do(func() {
+			re.dashboard.ApplyRefresh(result)
+			if result.AllSbxStatuses != nil {
+				for k, v := range result.AllSbxStatuses {
+					a.sbxStatuses[k] = v
+				}
+				if a.repoPanel != nil {
+					a.repoPanel.UpdateStatuses(a.sbxStatuses)
+				}
+			}
+		})
+	}
+
+	return re
+}
+
+// buildMainLayout assembles the two-panel window layout from the current
+// a.repos slice. Assumes len(a.repos) >= 1. Starts the first repo's refresh
+// manager and initializes the title bar, repo panel, and dashboard slot.
+func (a *App) buildMainLayout() fyne.CanvasObject {
 	// Build repo panel (left side).
-	a.repoPanel = NewRepoPanel(groups, a.sbxStatuses)
+	a.repoPanel = NewRepoPanel(a.collectGroups(), a.sbxStatuses)
 	a.repoPanel.OnModeSelected = func(gi, mi int) {
 		a.focus = focusLeft // clicking the tree means left panel has focus
 		a.switchMode(gi, mi)

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -931,10 +931,57 @@ func (a *App) handleAddRepo() {
 
 func (a *App) addRepoToConfig(repoRoot, repoName string, mode config.ModeEntry) {
 	cfg, _ := config.Load(a.configPath)
-	if cfg.Add(repoRoot, repoName, mode) {
-		_ = config.Save(a.configPath, cfg)
+	if !cfg.Add(repoRoot, repoName, mode) {
+		dialog.ShowInformation("Repository Added", repoName+" is already registered with this mode.", a.window)
+		return
 	}
-	dialog.ShowInformation("Repository Added", repoName+" added.\nRestart biomelab to see it.", a.window)
+	_ = config.Save(a.configPath, cfg)
+
+	// Mirror the persisted entry so in-memory modes match config semantics
+	// (e.g., sandbox mode replacing a prior regular mode).
+	idx := cfg.IndexOf(repoRoot)
+	if idx < 0 {
+		return
+	}
+	persisted := cfg.Repos[idx]
+
+	// Case 1: repo is already in the UI — just sync its modes and switch to
+	// the newly added one.
+	for gi, re := range a.repos {
+		if re.group.Path == repoRoot {
+			re.group.Modes = persisted.Modes
+			if a.repoPanel != nil {
+				a.repoPanel.groups = a.collectGroups()
+				a.repoPanel.rebuildList()
+			}
+			newModeIdx := len(persisted.Modes) - 1
+			a.switchMode(gi, newModeIdx)
+			return
+		}
+	}
+
+	// Case 2: brand new repo — build an entry and append it.
+	re := a.buildRepoEntry(persisted)
+	if re == nil {
+		a.setStatus("failed to open "+repoName, true)
+		return
+	}
+
+	wasEmpty := len(a.repos) == 0
+	a.repos = append(a.repos, re)
+
+	// Transitioning from empty state requires a full layout swap because
+	// repoPanel, dashboard, title bar, and dashSlot don't exist yet.
+	if wasEmpty {
+		a.window.SetContent(a.buildMainLayout())
+		return
+	}
+
+	if a.repoPanel != nil {
+		a.repoPanel.groups = a.collectGroups()
+		a.repoPanel.rebuildList()
+	}
+	a.switchMode(len(a.repos)-1, 0)
 }
 
 func (a *App) handleRemoveMode() {


### PR DESCRIPTION
## What's changed

Adding a repository through the `[a]dd` shortcut now reflects immediately in
the left panel instead of showing a "Restart biomelab to see it" dialog. The
new repo (or new mode on an existing repo) is appended to the in-memory
state, the repo panel is rebuilt in place, and focus switches to the newly
added entry. If the app was previously in the empty state, the full
two-panel layout is swapped in via `window.SetContent`.

If the exact repo + mode is already registered, a short informational
dialog is shown instead of silently no-oping.

## Why is this important?

The previous flow persisted the config but never mutated the running app's
repo list, so users had to quit and relaunch to see their repository — a
jarring workflow for what should be a lightweight action. This closes the
loop between "add repo" and "see repo" without a restart.

## Changes

- `internal/gui/app.go` — extract `buildRepoEntry` and `buildMainLayout`
  helpers out of `buildContent` so the same construction logic can be
  reused at runtime.
- `internal/gui/shortcuts.go` — rewrite `addRepoToConfig` to sync
  in-memory state, rebuild the repo panel, and `switchMode` to the new
  entry. Handle the empty-state → populated transition with a full
  content swap. Replace the restart dialog with a "mode already
  registered" notice on duplicate adds.

## Test plan

- [ ] Add the first repo from an empty state — left panel appears
      populated without restart.
- [ ] Add a second repo while one is already registered — new entry
      shows up in the panel and becomes the active selection.
- [ ] Add a sandbox mode to an existing repo — new mode appears under
      the existing group and becomes active.
- [ ] Re-add the same path + mode — "already registered" dialog appears
      and config is unchanged.
