### PR TITLE
fix(gui): render main card and match sandboxes for freshly-enrolled repos

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,6 +215,31 @@ func (c *Config) RemoveMode(path string, mode ModeEntry) bool {
 	return false
 }
 
+// UpdateSandboxName rewrites any sandbox mode on the repo at path whose
+// SandboxName equals oldName to use newName instead. Returns true if any
+// mode was changed. Used to reconcile config when sbx reports a sandbox
+// under a different name than what biomelab stored (e.g. when the user
+// created the sandbox manually outside biomelab).
+func (c *Config) UpdateSandboxName(path, oldName, newName string) bool {
+	if newName == "" || oldName == newName {
+		return false
+	}
+	changed := false
+	for i := range c.Repos {
+		if c.Repos[i].Path != path {
+			continue
+		}
+		for j := range c.Repos[i].Modes {
+			m := &c.Repos[i].Modes[j]
+			if m.Type == "sandbox" && m.SandboxName == oldName {
+				m.SandboxName = newName
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
 // Remove removes a repo entry by path (all modes).
 // Returns true if the entry was found and removed.
 func (c *Config) Remove(path string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,6 +60,90 @@ func TestSaveAndLoad(t *testing.T) {
 	}
 }
 
+func TestUpdateSandboxName(t *testing.T) {
+	newCfg := func() *Config {
+		return &Config{
+			Repos: []RepoEntry{
+				{
+					Path: "/tmp/repo1",
+					Name: "owner/repo1",
+					Modes: []ModeEntry{
+						{Type: "sandbox", SandboxName: "old-name", Agent: "claude"},
+					},
+				},
+				{
+					Path: "/tmp/repo2",
+					Name: "owner/repo2",
+					Modes: []ModeEntry{
+						{Type: "regular"},
+						{Type: "sandbox", SandboxName: "shared-name", Agent: "claude"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("renames matching sandbox mode", func(t *testing.T) {
+		cfg := newCfg()
+		if !cfg.UpdateSandboxName("/tmp/repo1", "old-name", "new-name") {
+			t.Fatal("expected change")
+		}
+		if got := cfg.Repos[0].Modes[0].SandboxName; got != "new-name" {
+			t.Errorf("SandboxName = %q, want new-name", got)
+		}
+	})
+
+	t.Run("leaves other repos untouched", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.UpdateSandboxName("/tmp/repo1", "old-name", "new-name")
+		if got := cfg.Repos[1].Modes[1].SandboxName; got != "shared-name" {
+			t.Errorf("other repo SandboxName = %q, want shared-name", got)
+		}
+	})
+
+	t.Run("leaves regular modes untouched", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.UpdateSandboxName("/tmp/repo2", "old-name", "new-name")
+		if cfg.Repos[1].Modes[0].Type != "regular" {
+			t.Error("regular mode type changed")
+		}
+	})
+
+	t.Run("no match returns false and makes no changes", func(t *testing.T) {
+		cfg := newCfg()
+		if cfg.UpdateSandboxName("/tmp/repo1", "no-such-name", "new-name") {
+			t.Fatal("expected no change")
+		}
+		if got := cfg.Repos[0].Modes[0].SandboxName; got != "old-name" {
+			t.Errorf("SandboxName = %q, want old-name (unchanged)", got)
+		}
+	})
+
+	t.Run("no-op when old == new", func(t *testing.T) {
+		cfg := newCfg()
+		if cfg.UpdateSandboxName("/tmp/repo1", "old-name", "old-name") {
+			t.Fatal("expected no change")
+		}
+	})
+
+	t.Run("no-op when newName empty", func(t *testing.T) {
+		cfg := newCfg()
+		if cfg.UpdateSandboxName("/tmp/repo1", "old-name", "") {
+			t.Fatal("expected no change")
+		}
+		if got := cfg.Repos[0].Modes[0].SandboxName; got != "old-name" {
+			t.Errorf("SandboxName = %q, want old-name (unchanged)", got)
+		}
+	})
+
+	t.Run("repo not in config is a no-op", func(t *testing.T) {
+		cfg := newCfg()
+		if cfg.UpdateSandboxName("/tmp/unknown", "old-name", "new-name") {
+			t.Fatal("expected no change")
+		}
+	})
+}
+
 func TestSaveAtomic(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "repos.json")

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -104,14 +105,40 @@ func (r *Repository) OriginURL() string {
 }
 
 // RepoName returns the "owner/repo" name derived from the origin remote URL.
-// Falls back to the directory name if no remote is configured.
+// Falls back to the directory name if no remote is configured. When no origin
+// is set but the repo lives under a forge-style path (e.g.
+// ".../github.com/<owner>/<repo>"), returns "<owner>/<repo>" so that repos
+// without a configured remote (like an empty, freshly-init'd repo) still get
+// a consistent name.
 func (r *Repository) RepoName() string {
 	if url := r.OriginURL(); url != "" {
 		if name := parseRepoName(url); name != "" {
 			return name
 		}
 	}
-	return filepath.Base(r.repoRoot)
+	return inferRepoNameFromPath(r.repoRoot)
+}
+
+// inferRepoNameFromPath returns "<owner>/<repo>" when repoRoot lives under a
+// directory that looks like a forge hostname (contains a dot, e.g.
+// "github.com", "gitlab.com", "bitbucket.org"). Otherwise returns the
+// directory basename.
+func inferRepoNameFromPath(repoRoot string) string {
+	base := filepath.Base(repoRoot)
+	parent := filepath.Dir(repoRoot)
+	if parent == repoRoot || parent == "." || parent == "/" {
+		return base
+	}
+	parentName := filepath.Base(parent)
+	grandparent := filepath.Dir(parent)
+	if grandparent == parent {
+		return base
+	}
+	grandparentName := filepath.Base(grandparent)
+	if strings.Contains(grandparentName, ".") && parentName != "" && parentName != "." && parentName != "/" {
+		return parentName + "/" + base
+	}
+	return base
 }
 
 // parseRepoName extracts "owner/repo" from a git remote URL.
@@ -178,6 +205,24 @@ func (r *Repository) Fetch() error {
 	return firstErr
 }
 
+// parseHeadFile reads a git HEAD file and reports the short branch name or
+// short detached hash. Returns ok=false if the file is missing or empty.
+func parseHeadFile(path string) (branch string, detached bool, ok bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, false
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return "", false, false
+	}
+	if strings.HasPrefix(s, "ref: ") {
+		ref := strings.TrimPrefix(s, "ref: ")
+		return strings.TrimPrefix(ref, "refs/heads/"), false, true
+	}
+	return s[:min(7, len(s))], true, true
+}
+
 // ListWorktreesQuick returns worktrees with only branch info — no dirty/sync checks.
 // Used for fast initial render.
 func (r *Repository) ListWorktreesQuick() ([]Worktree, error) {
@@ -191,16 +236,27 @@ func (r *Repository) ListWorktreesQuick() ([]Worktree, error) {
 	var result []Worktree
 
 	// Main worktree — branch only.
-	head, err := r.repo.Head()
-	if err != nil {
-		return nil, err
-	}
 	mainWt := Worktree{Path: r.repoRoot, IsMain: true}
-	if head.Name().IsBranch() {
-		mainWt.Branch = head.Name().Short()
-	} else {
-		mainWt.Detached = true
-		mainWt.Branch = head.Hash().String()[:7]
+	head, err := r.repo.Head()
+	switch {
+	case err == nil:
+		if head.Name().IsBranch() {
+			mainWt.Branch = head.Name().Short()
+		} else {
+			mainWt.Detached = true
+			mainWt.Branch = head.Hash().String()[:7]
+		}
+	case errors.Is(err, plumbing.ErrReferenceNotFound):
+		// Unborn HEAD: repo has no commits yet. Read .git/HEAD directly so
+		// the main card still shows up for a freshly enrolled empty repo.
+		branch, detached, ok := parseHeadFile(filepath.Join(r.repoRoot, ".git", "HEAD"))
+		if !ok {
+			return nil, err
+		}
+		mainWt.Branch = branch
+		mainWt.Detached = detached
+	default:
+		return nil, err
 	}
 	result = append(result, mainWt)
 
@@ -270,21 +326,31 @@ func (r *Repository) ListWorktrees() ([]Worktree, error) {
 
 // mainWorktree returns info about the main worktree.
 func (r *Repository) mainWorktree() (*Worktree, error) {
-	head, err := r.repo.Head()
-	if err != nil {
-		return nil, err
-	}
-
 	wt := &Worktree{
 		Path:   r.repoRoot,
 		IsMain: true,
 	}
 
-	if head.Name().IsBranch() {
-		wt.Branch = head.Name().Short()
-	} else {
-		wt.Detached = true
-		wt.Branch = head.Hash().String()[:7]
+	head, err := r.repo.Head()
+	switch {
+	case err == nil:
+		if head.Name().IsBranch() {
+			wt.Branch = head.Name().Short()
+		} else {
+			wt.Detached = true
+			wt.Branch = head.Hash().String()[:7]
+		}
+	case errors.Is(err, plumbing.ErrReferenceNotFound):
+		// Unborn HEAD: repo has no commits yet. Read .git/HEAD directly so
+		// the main card still shows up for a freshly enrolled empty repo.
+		branch, detached, ok := parseHeadFile(filepath.Join(r.repoRoot, ".git", "HEAD"))
+		if !ok {
+			return nil, err
+		}
+		wt.Branch = branch
+		wt.Detached = detached
+	default:
+		return nil, err
 	}
 
 	goWt, err := r.repo.Worktree()

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -110,6 +110,69 @@ func TestListWorktrees_MainOnly(t *testing.T) {
 	}
 }
 
+func TestListWorktrees_NoCommits(t *testing.T) {
+	// A freshly-enrolled repo without any commits must still surface the
+	// main worktree so the dashboard can render its main card.
+	dir := t.TempDir()
+	if _, err := gogit.PlainInit(dir, false); err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+
+	repo, err := OpenRepository(dir)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+
+	wts, err := repo.ListWorktrees()
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(wts) != 1 {
+		t.Fatalf("expected 1 worktree, got %d", len(wts))
+	}
+	if !wts[0].IsMain {
+		t.Error("expected main worktree")
+	}
+	if wts[0].Detached {
+		t.Error("expected non-detached HEAD on unborn branch")
+	}
+	if wts[0].Branch != "master" && wts[0].Branch != "main" {
+		t.Errorf("unexpected branch %q", wts[0].Branch)
+	}
+	if wts[0].Sync != SyncUnknown && wts[0].Sync != SyncNoUpstream {
+		t.Errorf("unexpected sync status %v", wts[0].Sync)
+	}
+}
+
+func TestListWorktreesQuick_NoCommits(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := gogit.PlainInit(dir, false); err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+
+	repo, err := OpenRepository(dir)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+
+	wts, err := repo.ListWorktreesQuick()
+	if err != nil {
+		t.Fatalf("ListWorktreesQuick: %v", err)
+	}
+	if len(wts) != 1 {
+		t.Fatalf("expected 1 worktree, got %d", len(wts))
+	}
+	if !wts[0].IsMain {
+		t.Error("expected main worktree")
+	}
+	if wts[0].Detached {
+		t.Error("expected non-detached HEAD on unborn branch")
+	}
+	if wts[0].Branch != "master" && wts[0].Branch != "main" {
+		t.Errorf("unexpected branch %q", wts[0].Branch)
+	}
+}
+
 func TestListWorktrees_WithLinked(t *testing.T) {
 	dir, repo := setupTestRepo(t)
 
@@ -627,6 +690,53 @@ func TestPull_MultipleRemotes(t *testing.T) {
 	originHead := runGit(t, originDir, "rev-parse", "HEAD")
 	if localHead != originHead {
 		t.Errorf("local HEAD %s != origin HEAD %s after pull", localHead, originHead)
+	}
+}
+
+func TestInferRepoNameFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		// Forge-style layouts yield owner/repo.
+		{"/Users/me/src/github.com/owner/repo", "owner/repo"},
+		{"/home/me/src/gitlab.com/group/project", "group/project"},
+		{"/tmp/src/bitbucket.org/team/service", "team/service"},
+		// Non-forge parents fall back to basename only.
+		{"/Users/me/projects/standalone", "standalone"},
+		{"/tmp/foo", "foo"},
+		// Root / degenerate paths fall back to basename.
+		{"/repo", "repo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := inferRepoNameFromPath(tt.path)
+			if got != tt.want {
+				t.Errorf("inferRepoNameFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoName_NoOrigin_ForgePath(t *testing.T) {
+	// Simulate an empty, freshly-init'd repo at ".../github.com/<owner>/<repo>"
+	// with no origin remote configured. RepoName() should still return
+	// "<owner>/<repo>" (not just the bare basename) so downstream sandbox
+	// naming stays consistent with repos that do have an origin.
+	base := t.TempDir()
+	repoRoot := filepath.Join(base, "github.com", "acme", "widget")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := gogit.PlainInit(repoRoot, false); err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	repo, err := OpenRepository(repoRoot)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+	if got, want := repo.RepoName(), "acme/widget"; got != want {
+		t.Errorf("RepoName() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -135,6 +135,15 @@ func (a *App) buildContent() fyne.CanvasObject {
 		}
 	}
 
+	// Reconcile any stored sandbox name that doesn't match what sbx reports
+	// but whose alternative candidates do (user created the sandbox manually
+	// under a different naming convention). Running this BEFORE building
+	// repo entries means the initial repo panel render already shows the
+	// correct status dot for those repos — no 5s wait for the first tick.
+	if a.reconcileConfigOnLoad(cfg) {
+		_ = config.Save(a.configPath, cfg)
+	}
+
 	for _, entry := range cfg.Repos {
 		if re := a.buildRepoEntry(entry); re != nil {
 			a.repos = append(a.repos, re)
@@ -174,13 +183,13 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 	}
 	state.SetWorktrees(worktrees)
 
-	var sbxName string
+	var sbxCandidates []string
 	if len(entry.Modes) > 0 {
 		mode := entry.Modes[0]
 		state.ActiveMode = &mode
 		if mode.Type == "sandbox" {
-			sbxName = mode.SandboxName
-			if s, ok := a.sbxStatuses[sbxName]; ok {
+			sbxCandidates = sandbox.Candidates(mode.SandboxName, repo.RepoName(), repo.Root(), mode.Agent)
+			if _, s, ok := sandbox.MatchStatus(a.sbxStatuses, sbxCandidates); ok {
 				state.SandboxStatus = s
 			}
 		}
@@ -192,7 +201,7 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 	}
 
 	rm := NewRefreshManager(repo, a.detector, a.ideDetector, a.procLister, prProv, a.refreshInterval)
-	rm.SetSandboxName(sbxName)
+	rm.SetSandboxCandidates(sbxCandidates)
 
 	re := &repoEntry{
 		group:      group,
@@ -205,6 +214,16 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 
 	rm.OnRefresh = func(result ops.RefreshResult) {
 		fyne.Do(func() {
+			// Reconcile the stored sandbox name FIRST so ApplyRefresh's
+			// dashboard rebuild renders the real name in the same tick.
+			// Triggered when refresh matched a sandbox under a name that
+			// differs from what was stored (e.g. user created it manually
+			// via `sbx run`).
+			if result.SbxMatchedName != "" && re.state.ActiveMode != nil &&
+				re.state.ActiveMode.Type == "sandbox" &&
+				result.SbxMatchedName != re.state.ActiveMode.SandboxName {
+				a.reconcileSandboxName(re, re.state.ActiveMode.SandboxName, result.SbxMatchedName)
+			}
 			re.dashboard.ApplyRefresh(result)
 			if result.AllSbxStatuses != nil {
 				for k, v := range result.AllSbxStatuses {
@@ -218,6 +237,88 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 	}
 
 	return re
+}
+
+// reconcileConfigOnLoad rewrites any sandbox mode in cfg whose stored name
+// doesn't match a sandbox in a.sbxStatuses but whose alternative candidates
+// do. Pure cfg mutation — does NOT save to disk and does not touch runtime
+// state (no repoEntry exists yet at this point). Returns true if anything
+// changed so the caller can persist.
+func (a *App) reconcileConfigOnLoad(cfg *config.Config) bool {
+	if len(a.sbxStatuses) == 0 {
+		return false
+	}
+	changed := false
+	for i := range cfg.Repos {
+		repoPath := cfg.Repos[i].Path
+		var repoName string
+		if repo, err := git.OpenRepository(repoPath); err == nil {
+			repoName = repo.RepoName()
+		}
+		for j := range cfg.Repos[i].Modes {
+			m := &cfg.Repos[i].Modes[j]
+			if m.Type != "sandbox" || m.SandboxName == "" || m.Agent == "" {
+				continue
+			}
+			candidates := sandbox.Candidates(m.SandboxName, repoName, repoPath, m.Agent)
+			matched, _, ok := sandbox.MatchStatus(a.sbxStatuses, candidates)
+			if ok && matched != m.SandboxName {
+				m.SandboxName = matched
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+// reconcileSandboxName updates an in-memory mode and its on-disk config entry
+// from oldName to newName, then refreshes the repo panel and the refresh
+// manager's candidate list. No-op when oldName == newName or newName is empty.
+func (a *App) reconcileSandboxName(re *repoEntry, oldName, newName string) {
+	if newName == "" || oldName == newName {
+		return
+	}
+
+	// Update in-memory group modes.
+	for i := range re.group.Modes {
+		m := &re.group.Modes[i]
+		if m.Type == "sandbox" && m.SandboxName == oldName {
+			m.SandboxName = newName
+		}
+	}
+	// state.ActiveMode points to a separate copy (see buildRepoEntry /
+	// switchMode) — update it too so callers that dereference it see the
+	// new name.
+	if re.state.ActiveMode != nil && re.state.ActiveMode.Type == "sandbox" && re.state.ActiveMode.SandboxName == oldName {
+		re.state.ActiveMode.SandboxName = newName
+	}
+
+	// Regenerate candidates with the new stored name first so subsequent
+	// refreshes prefer it.
+	agent := ""
+	if re.state.ActiveMode != nil {
+		agent = re.state.ActiveMode.Agent
+	}
+	re.refreshMgr.SetSandboxCandidates(
+		sandbox.Candidates(newName, re.repo.RepoName(), re.repo.Root(), agent),
+	)
+
+	// Rebuild the repo panel since mode labels and sandbox-name lookups
+	// depend on the stored name.
+	if a.repoPanel != nil {
+		a.repoPanel.groups = a.collectGroups()
+		a.repoPanel.rebuildList()
+	}
+
+	// Persist to disk. Failure is non-fatal: the in-memory state is correct
+	// for this session.
+	cfg, err := config.Load(a.configPath)
+	if err != nil {
+		return
+	}
+	if cfg.UpdateSandboxName(re.group.Path, oldName, newName) {
+		_ = config.Save(a.configPath, cfg)
+	}
 }
 
 // buildMainLayout assembles the two-panel window layout from the current
@@ -272,14 +373,14 @@ func (a *App) switchMode(groupIdx, modeIdx int) {
 		re.state.ActiveMode = &mode
 		re.group.ActiveMode = modeIdx
 
-		sbxName := ""
+		var sbxCandidates []string
 		if mode.Type == "sandbox" {
-			sbxName = mode.SandboxName
-			if s, ok := a.sbxStatuses[sbxName]; ok {
+			sbxCandidates = sandbox.Candidates(mode.SandboxName, re.repo.RepoName(), re.repo.Root(), mode.Agent)
+			if _, s, ok := sandbox.MatchStatus(a.sbxStatuses, sbxCandidates); ok {
 				re.state.SandboxStatus = s
 			}
 		}
-		re.refreshMgr.SetSandboxName(sbxName)
+		re.refreshMgr.SetSandboxCandidates(sbxCandidates)
 	}
 
 	a.dashboard = re.dashboard
@@ -372,4 +473,3 @@ func (a *App) emptyState() fyne.CanvasObject {
 	msg.Alignment = fyne.TextAlignCenter
 	return container.NewCenter(msg)
 }
-

--- a/internal/gui/refresh.go
+++ b/internal/gui/refresh.go
@@ -24,11 +24,11 @@ type RefreshManager struct {
 	prProv          provider.PRProvider
 	cliAvail        provider.CLIAvailability
 	networkInterval time.Duration
-	sbxName         string
 
-	mu     sync.Mutex
-	ctx    context.Context
-	cancel context.CancelFunc
+	mu            sync.Mutex
+	ctx           context.Context
+	cancel        context.CancelFunc
+	sbxCandidates []string
 
 	// OnRefresh is called with refresh results. The caller is responsible
 	// for marshaling UI updates to the main thread (via fyne.Do).
@@ -54,11 +54,12 @@ func NewRefreshManager(
 	}
 }
 
-// SetSandboxName configures the sandbox name for status checks.
-func (rm *RefreshManager) SetSandboxName(name string) {
+// SetSandboxCandidates configures the ordered list of sandbox names to
+// check during refresh. Pass nil/empty to disable the sandbox status check.
+func (rm *RefreshManager) SetSandboxCandidates(candidates []string) {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
-	rm.sbxName = name
+	rm.sbxCandidates = candidates
 }
 
 // SetCLIAvail updates the cached CLI availability.
@@ -163,10 +164,10 @@ func (rm *RefreshManager) doQuick() {
 
 func (rm *RefreshManager) doLocal() {
 	rm.mu.Lock()
-	sbxName := rm.sbxName
+	candidates := rm.sbxCandidates
 	rm.mu.Unlock()
 
-	result := ops.LocalRefresh(rm.repo, rm.detector, rm.ideDetector, rm.procLister, sbxName)
+	result := ops.LocalRefresh(rm.repo, rm.detector, rm.ideDetector, rm.procLister, candidates)
 	if rm.OnRefresh != nil {
 		rm.OnRefresh(result)
 	}
@@ -174,11 +175,11 @@ func (rm *RefreshManager) doLocal() {
 
 func (rm *RefreshManager) doNetwork() {
 	rm.mu.Lock()
-	sbxName := rm.sbxName
+	candidates := rm.sbxCandidates
 	cliAvail := rm.cliAvail
 	rm.mu.Unlock()
 
-	result := ops.NetworkRefresh(rm.repo, rm.detector, rm.ideDetector, rm.procLister, rm.prProv, cliAvail, sbxName)
+	result := ops.NetworkRefresh(rm.repo, rm.detector, rm.ideDetector, rm.procLister, rm.prProv, cliAvail, candidates)
 	if rm.OnRefresh != nil {
 		rm.OnRefresh(result)
 	}

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -826,7 +826,9 @@ func (a *App) handleCreateOrEnrollSandbox() {
 				re.group.Modes = append(re.group.Modes, newMode)
 				re.state.ActiveMode = &newMode
 				re.group.ActiveMode = len(re.group.Modes) - 1
-				re.refreshMgr.SetSandboxName(sbxName)
+				re.refreshMgr.SetSandboxCandidates(
+					sandbox.Candidates(sbxName, re.repo.RepoName(), re.repo.Root(), agentName),
+				)
 				if a.repoPanel != nil {
 					a.repoPanel.groups = a.collectGroups()
 					a.repoPanel.SetActive(a.active, re.group.ActiveMode)

--- a/internal/ops/refresh.go
+++ b/internal/ops/refresh.go
@@ -27,6 +27,10 @@ type RefreshResult struct {
 	AllSbxStatuses map[string]sandbox.Status
 	SbxClientVer   string
 	SbxServerVer   string
+	// SbxMatchedName is the candidate that matched a running/stopped sandbox
+	// in sbx ls (empty if none matched). Lets callers reconcile config when
+	// the stored sandbox name differs from what sbx actually reports.
+	SbxMatchedName string
 }
 
 // CLICheckResult carries the CLI availability check result.
@@ -49,12 +53,14 @@ func QuickRefresh(repo *git.Repository) RefreshResult {
 }
 
 // LocalRefresh reads dirty status and detects agents and IDEs — no network I/O.
+// sbxCandidates is the ordered list of sandbox names to check (first match
+// wins); pass nil or empty to skip the sandbox status check.
 func LocalRefresh(
 	repo *git.Repository,
 	detector *agent.Detector,
 	ideDetector *ide.Detector,
 	procLister process.Lister,
-	sbxName string,
+	sbxCandidates []string,
 ) RefreshResult {
 	wts, err := repo.ListWorktrees()
 	if err != nil {
@@ -76,19 +82,24 @@ func LocalRefresh(
 		ides = ideDetector.DetectFromProcesses(procs, paths)
 	}
 
-	// Check all sandbox statuses with one sbx ls call.
+	// Check all sandbox statuses with one sbx ls call, then match against
+	// every candidate name so the GUI detects sandboxes created under either
+	// biomelab's naming ("<owner>-<repo>-<agent>") or sbx's default
+	// ("<repo-dir>-<agent>").
 	var sbxStatus sandbox.Status
+	var sbxMatched string
 	var sbxVer sandbox.VersionInfo
 	var allStatuses map[string]sandbox.Status
-	if sbxName != "" {
+	if len(sbxCandidates) > 0 {
 		statusMap := sandbox.CheckAllStatuses()
 		if statusMap != nil {
 			allStatuses = make(map[string]sandbox.Status, len(statusMap))
 			for k, v := range statusMap {
 				allStatuses[k] = v
 			}
-			if s, ok := statusMap[sbxName]; ok {
+			if name, s, ok := sandbox.MatchStatus(statusMap, sbxCandidates); ok {
 				sbxStatus = s
+				sbxMatched = name
 			}
 		}
 		sbxVer = sandbox.Version()
@@ -99,14 +110,17 @@ func LocalRefresh(
 		Agents:         agents,
 		IDEs:           ides,
 		SandboxStatus:  sbxStatus,
-		HasSbxStatus:   sbxName != "",
+		HasSbxStatus:   len(sbxCandidates) > 0,
 		AllSbxStatuses: allStatuses,
 		SbxClientVer:   sbxVer.Client,
 		SbxServerVer:   sbxVer.Server,
+		SbxMatchedName: sbxMatched,
 	}
 }
 
 // NetworkRefresh fetches remote refs and looks up PR status.
+// sbxCandidates is the ordered list of sandbox names to check (first match
+// wins); pass nil or empty to skip the sandbox status check.
 func NetworkRefresh(
 	repo *git.Repository,
 	detector *agent.Detector,
@@ -114,7 +128,7 @@ func NetworkRefresh(
 	procLister process.Lister,
 	prProv provider.PRProvider,
 	cliAvail provider.CLIAvailability,
-	sbxName string,
+	sbxCandidates []string,
 ) RefreshResult {
 	fetchErr := repo.Fetch()
 
@@ -147,19 +161,27 @@ func NetworkRefresh(
 	}
 
 	var sbxStatus sandbox.Status
-	if sbxName != "" {
-		sbxStatus = sandbox.CheckStatus(sbxName)
+	var sbxMatched string
+	if len(sbxCandidates) > 0 {
+		statusMap := sandbox.CheckAllStatuses()
+		if statusMap != nil {
+			if name, s, ok := sandbox.MatchStatus(statusMap, sbxCandidates); ok {
+				sbxStatus = s
+				sbxMatched = name
+			}
+		}
 	}
 
 	return RefreshResult{
-		Worktrees:    wts,
-		Agents:       agents,
-		IDEs:         ides,
-		PRs:          prs,
-		HasSbxStatus: sbxName != "",
-		HasPRs:        true,
-		FetchErr:      fetchErr,
-		SandboxStatus: sbxStatus,
+		Worktrees:      wts,
+		Agents:         agents,
+		IDEs:           ides,
+		PRs:            prs,
+		HasSbxStatus:   len(sbxCandidates) > 0,
+		HasPRs:         true,
+		FetchErr:       fetchErr,
+		SandboxStatus:  sbxStatus,
+		SbxMatchedName: sbxMatched,
 	}
 }
 

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -67,6 +68,57 @@ func SanitizeName(parts ...string) string {
 	name = strings.ReplaceAll(name, " ", "-")
 	name = strings.ToLower(name)
 	return name
+}
+
+// Candidates returns the ordered, deduplicated set of sandbox names that may
+// correspond to a given repo+agent. The list covers both orderings observed
+// in the wild:
+//   - biomelab's "<repo>-<agent>" (e.g. "mdelapenya-pay2class-claude")
+//   - sbx's default "<agent>-<repo>" (e.g. "claude-pay2class")
+//
+// For each ordering we try both the full "<owner>/<repo>" name and the bare
+// directory basename, so we match regardless of whether origin was configured
+// when the sandbox was created. The stored (config) name comes first.
+func Candidates(storedName, repoName, repoPath, agent string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(n string) {
+		if n == "" {
+			return
+		}
+		if _, ok := seen[n]; ok {
+			return
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	add(storedName)
+	if agent != "" {
+		if repoName != "" {
+			add(SanitizeName(repoName, agent))
+			add(SanitizeName(agent, repoName))
+		}
+		if repoPath != "" {
+			base := filepath.Base(repoPath)
+			add(SanitizeName(base, agent))
+			add(SanitizeName(agent, base))
+		}
+	}
+	return out
+}
+
+// MatchStatus returns the first candidate that exists in statusMap along with
+// its status. ok=false means none matched.
+func MatchStatus(statusMap map[string]Status, candidates []string) (name string, status Status, ok bool) {
+	for _, c := range candidates {
+		if c == "" {
+			continue
+		}
+		if s, found := statusMap[c]; found {
+			return c, s, true
+		}
+	}
+	return "", StatusNotFound, false
 }
 
 // CommandString joins args into a single shell command string.

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -46,6 +46,111 @@ func TestSanitizeName(t *testing.T) {
 	}
 }
 
+func TestCandidates(t *testing.T) {
+	tests := []struct {
+		name     string
+		stored   string
+		repoName string
+		repoPath string
+		agent    string
+		want     []string
+	}{
+		{
+			// biomelab stored "<repo>-<agent>" but sbx actually created
+			// "<agent>-<repo>". Both orderings must appear in the list.
+			name:     "both orderings included when repo is owner/name",
+			stored:   "pay2class-claude",
+			repoName: "mdelapenya/pay2class",
+			repoPath: "/Users/me/src/github.com/mdelapenya/pay2class",
+			agent:    "claude",
+			want: []string{
+				"pay2class-claude",
+				"mdelapenya-pay2class-claude",
+				"claude-mdelapenya-pay2class",
+				"claude-pay2class",
+			},
+		},
+		{
+			name:     "all forms converge — deduplicated",
+			stored:   "acme-widget-claude",
+			repoName: "acme/widget",
+			repoPath: "/tmp/widget",
+			agent:    "claude",
+			want: []string{
+				"acme-widget-claude",
+				"claude-acme-widget",
+				"widget-claude",
+				"claude-widget",
+			},
+		},
+		{
+			name:     "stored empty — still derives from repo in both orderings",
+			stored:   "",
+			repoName: "owner/repo",
+			repoPath: "/tmp/repo",
+			agent:    "claude",
+			want: []string{
+				"owner-repo-claude",
+				"claude-owner-repo",
+				"repo-claude",
+				"claude-repo",
+			},
+		},
+		{
+			name:     "no agent — only stored name returned",
+			stored:   "abc",
+			repoName: "owner/repo",
+			repoPath: "/tmp/repo",
+			agent:    "",
+			want:     []string{"abc"},
+		},
+		{
+			name:   "everything empty",
+			stored: "",
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Candidates(tt.stored, tt.repoName, tt.repoPath, tt.agent)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Candidates() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchStatus(t *testing.T) {
+	m := map[string]Status{
+		"mdelapenya-pay2class-claude": StatusRunning,
+		"other-claude":                StatusStopped,
+	}
+	t.Run("first candidate matches", func(t *testing.T) {
+		name, status, ok := MatchStatus(m, []string{"mdelapenya-pay2class-claude", "pay2class-claude"})
+		if !ok || name != "mdelapenya-pay2class-claude" || status != StatusRunning {
+			t.Errorf("got (%q, %v, %v)", name, status, ok)
+		}
+	})
+	t.Run("second candidate matches when first missing", func(t *testing.T) {
+		name, status, ok := MatchStatus(m, []string{"pay2class-claude", "mdelapenya-pay2class-claude"})
+		if !ok || name != "mdelapenya-pay2class-claude" || status != StatusRunning {
+			t.Errorf("got (%q, %v, %v)", name, status, ok)
+		}
+	})
+	t.Run("no candidate matches", func(t *testing.T) {
+		_, _, ok := MatchStatus(m, []string{"nope", "also-nope"})
+		if ok {
+			t.Error("expected ok=false")
+		}
+	})
+	t.Run("empty candidates", func(t *testing.T) {
+		_, _, ok := MatchStatus(m, nil)
+		if ok {
+			t.Error("expected ok=false")
+		}
+	})
+}
+
 func TestCommandString(t *testing.T) {
 	args := []string{"sbx", "run", "--branch", "feature", "my-sandbox"}
 	got := CommandString(args)


### PR DESCRIPTION
## What's changed

A repo enrolled in biomelab with no commits and no `origin` remote (e.g. a brand-new `git init` directory) now renders its main card on first load. Previously go-git's `repo.Head()` returned `plumbing.ErrReferenceNotFound` for the unborn branch, which propagated through `ops.RefreshResult.Err` and caused `Dashboard.ApplyRefresh` to short-circuit before populating worktrees — so the card never appeared.

A sandbox attached to that repo is also detected regardless of how it was named. `sbx run <agent> .` defaults to `<agent>-<repo>`, while biomelab stored `<repo>-<agent>`, and `Repository.RepoName()` previously fell back to `filepath.Base` (dropping the owner prefix) when no origin was configured. The lookup now probes both orderings, with and without the owner prefix, and reconciles `repos.json` when an alternative candidate matches — so subsequent start/stop/remove operations target the real sandbox.

## Why is this important?

These are the two papercuts you hit when adding a brand-new repo to biomelab. The empty-repo case made the dashboard look broken on first launch; the sandbox-name mismatch made the running sandbox appear "not found" even though it was healthy, and biomelab's later actions (stop, remove) would have targeted a non-existent name. Both are common enough on real workflows (`git init` + `sbx run claude .`) that fixing them removes a class of confusing first-time experiences.

## Changes

**`internal/git`**
- `RepoName()` infers `<owner>/<repo>` from forge-style paths (`.../github.com/<owner>/<repo>`, gitlab.com, bitbucket.org…) when no origin remote is configured, via a new `inferRepoNameFromPath` helper.
- `ListWorktreesQuick` and `mainWorktree` detect `plumbing.ErrReferenceNotFound` and fall back to a new `parseHeadFile()` that reads `.git/HEAD` directly, so an unborn branch yields a normal main worktree (`Detached=false`, `IsDirty=false`, `Sync=Unknown`).

**`internal/sandbox`**
- New `Candidates(stored, repoName, repoPath, agent)` returns the deduplicated set of names to probe — both `<repo>-<agent>` and `<agent>-<repo>` orderings, with and without owner prefix; stored name first.
- New `MatchStatus(statusMap, candidates)` returns the first match.

**`internal/ops/refresh.go`**
- `LocalRefresh` and `NetworkRefresh` now take `sbxCandidates []string` (instead of a single name) and use `MatchStatus`.
- `RefreshResult.SbxMatchedName` carries the candidate that hit, so callers can reconcile.

**`internal/config`**
- New `Config.UpdateSandboxName(path, oldName, newName)` mutates the matching sandbox mode in-place; used by the runtime reconciliation.

**`internal/gui`**
- `RefreshManager.SetSandboxName` → `SetSandboxCandidates`; `app.go` and `shortcuts.go` compute candidates via `sandbox.Candidates(...)`.
- `App.reconcileSandboxName` runs in `OnRefresh` (before `ApplyRefresh`, so the dashboard renders the new name in the same tick) and rewrites in-memory state, the refresh candidates, the repo panel, and `repos.json`.
- `App.reconcileConfigOnLoad` runs in `buildContent` between the initial `sbx ls` and building the repo panel, so the green status dot appears at the same time as for already-aligned repos — no 5s wait for the first tick.

## Test plan

- [x] `go test -race ./...`
- New tests:
  - `git.TestListWorktrees_NoCommits`, `TestListWorktreesQuick_NoCommits`
  - `git.TestInferRepoNameFromPath`, `TestRepoName_NoOrigin_ForgePath`
  - `sandbox.TestCandidates`, `TestMatchStatus`
  - `config.TestUpdateSandboxName` (7 sub-tests)
- [ ] Manual: `git init my-empty-repo`, enroll in biomelab in sandbox mode → main card renders.
- [ ] Manual: create a sandbox externally with `sbx run claude .` in that repo → status flips to running on next launch and `repos.json` rewrites the `sandbox_name` to match `sbx ls`.
