### PR TITLE
fix(website): update terminology from terminal UI to desktop app and fix light theme text rendering

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -85,7 +85,13 @@ body {
   color: var(--text-primary);
   line-height: 1.7;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden
+}
+
+[data-theme="light"] body {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto
 }
 
 body::before {
@@ -420,7 +426,7 @@ nav .container {
 .hero-content strong,
 .hero-points li {
   color: #fff;
-  text-shadow: 0 2px 20px rgba(0, 0, 0, .7), 0 1px 4px rgba(0, 0, 0, .5)
+  text-shadow: 0 1px 10px rgba(0, 0, 0, .6), 0 1px 3px rgba(0, 0, 0, .4)
 }
 
 .hero-content .install-box {
@@ -508,7 +514,7 @@ nav .container {
   color: transparent !important;
   -webkit-text-fill-color: transparent;
   text-shadow: none;
-  filter: drop-shadow(0 2px 12px rgba(0, 0, 0, .5))
+  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, .35))
 }
 
 .hero-copy .tagline {
@@ -1646,7 +1652,11 @@ footer {
   background-clip: text;
   color: transparent !important;
   -webkit-text-fill-color: transparent;
-  filter: drop-shadow(0 2px 12px rgba(0,0,0,.35))
+  filter: drop-shadow(0 1px 6px rgba(0,0,0,.2))
+}
+
+[data-theme="light"] .kb-accent {
+  filter: none
 }
 
 .kanban-intro {

--- a/website/index.html
+++ b/website/index.html
@@ -4,20 +4,20 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>biomelab - Terminal dashboard for git worktrees and AI coding agents</title>
+  <title>biomelab - Desktop dashboard for git worktrees and AI coding agents</title>
   <meta name="description"
-    content="Manage git worktrees, Docker Sandboxes, and AI coding agents from a single terminal UI. See every branch, every agent, every PR.">
+    content="Manage git worktrees, Docker Sandboxes, and AI coding agents from a single desktop app. See every branch, every agent, every PR.">
 
   <meta property="og:title" content="biomelab - Your Worktrees. Your Agents. One Dashboard.">
   <meta property="og:description"
-    content="A terminal dashboard for managing git worktrees and AI coding agents in parallel. Sandbox isolation, PR status, live agent detection.">
+    content="A desktop dashboard for managing git worktrees and AI coding agents in parallel. Sandbox isolation, PR status, live agent detection.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://biomelab.dev">
   <meta property="og:image" content="img/og-hero.png">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="biomelab - Your Worktrees. Your Agents. One Dashboard.">
-  <meta name="twitter:description" content="Terminal dashboard for git worktrees and AI coding agents.">
+  <meta name="twitter:description" content="Desktop dashboard for git worktrees and AI coding agents.">
   <meta name="twitter:image" content="img/og-hero.png">
 
   <link rel="icon" type="image/png" href="img/icon.png">
@@ -91,7 +91,7 @@
         <div class="hero-copy">
           <span class="eyebrow">Safe sandboxes for living code</span>
           <h1>Monitor your AI agents <span class="accent">across worktrees</span></h1>
-          <p class="tagline">biomelab is a terminal dashboard for managing git worktrees, coding agents, and Docker
+          <p class="tagline">biomelab is a desktop dashboard for managing git worktrees, coding agents, and Docker
             Sandboxes across all your repositories.</p>
           <ul class="hero-points">
             <li>Multi-repo visibility</li>
@@ -101,7 +101,7 @@
           <div class="hero-cta">
             <div class="install-box" id="install-copy" title="Click to copy">
               <span class="prompt">$</span>
-              <span>brew install mdelapenya/tap/biomelab</span>
+              <span>brew install --cask mdelapenya/tap/biomelab</span>
               <svg class="copy-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                 <path
                   d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z" />
@@ -187,7 +187,7 @@
         </div>
         <div class="sandbox-card"><span class="icon">⌨️</span>
           <h3>Lifecycle from the Dashboard</h3>
-          <p>Create, start, stop, remove, all from keyboard shortcuts. No terminal context-switching.</p>
+          <p>Create, start, stop, remove, all from the dashboard. No terminal context-switching.</p>
         </div>
       </div>
       <div class="sandbox-diagram-html">
@@ -521,8 +521,8 @@
         </div>
         <div class="tab-panel active" id="tab-homebrew">
           <div class="copyable-pre">
-            <pre>brew install mdelapenya/tap/biomelab</pre>
-            <button class="copy-btn" data-copy="brew install mdelapenya/tap/biomelab" title="Copy to clipboard">
+            <pre>brew install --cask mdelapenya/tap/biomelab</pre>
+            <button class="copy-btn" data-copy="brew install --cask mdelapenya/tap/biomelab" title="Copy to clipboard">
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/></svg>
             </button>
           </div>
@@ -562,15 +562,14 @@
   <section class="keyboard">
     <div class="container text-center">
       <span class="section-label">Keyboard-First</span>
-      <h2>Mouse optional, keyboard mandatory</h2>
-      <p class="mx-auto">Every action is a single keystroke. Toggle mouse mode with <kbd>m</kbd> when you want it.</p>
+      <h2>Point-and-click meets keyboard shortcuts</h2>
+      <p class="mx-auto">Every action is a single keystroke. Full mouse support built in.</p>
       <div class="keyboard-grid">
         <div class="key-item"><span class="key-cap key-green">c</span><span class="key-action">Create worktree</span></div>
         <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span></div>
         <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span></div>
         <div class="key-item"><span class="key-cap key-blue">f</span><span class="key-action">Fetch PR / MR</span></div>
         <div class="key-item"><span class="key-cap key-cyan">g</span><span class="key-action">Toggle kanban / grid</span></div>
-        <div class="key-item"><span class="key-cap">m</span><span class="key-action">Toggle mouse</span></div>
         <div class="key-item"><span class="key-cap">n</span><span class="key-action">New sandbox</span></div>
         <div class="key-item"><span class="key-cap key-orange">p</span><span class="key-action">Pull from remote</span></div>
         <div class="key-item"><span class="key-cap key-magenta">P</span><span class="key-action">Send PR</span></div>
@@ -649,7 +648,7 @@
     });
 
     document.getElementById('install-copy').addEventListener('click', function () {
-      var text = 'brew install mdelapenya/tap/biomelab';
+      var text = 'brew install --cask mdelapenya/tap/biomelab';
       navigator.clipboard.writeText(text).then(function () {
         var box = document.getElementById('install-copy');
         box.classList.add('copied');


### PR DESCRIPTION
## What's changed

Update the biomelab website to reflect that the project is now a desktop GUI (Fyne) rather than a terminal UI. Fix blurry text rendering in light theme.

## Why is this important?

The website still described biomelab as a "terminal dashboard" / "terminal UI" throughout — in the page title, meta tags, hero section, and feature copy. This is misleading since the project migrated from a TUI to a native desktop app built with Fyne. The Homebrew install command was also missing the `--cask` flag required for GUI apps, and the keyboard shortcuts section listed a TUI-only "toggle mouse" shortcut that no longer exists.

## Changes

### Wording (`website/index.html`)
- Replace "terminal dashboard" / "terminal UI" with "desktop dashboard" / "desktop app" across page title, meta description, OG tags, Twitter card, and hero tagline
- Update `brew install` to `brew install --cask` in hero CTA, install tab, and JS copy handler
- Remove the `m` / "Toggle mouse" keyboard shortcut (TUI-only, not present in GUI code)
- Update keyboard section heading and sandbox card copy to reflect native GUI interaction

### Blurry text (`website/css/style.css`)
- Reset `-webkit-font-smoothing` to `auto` in light theme for native subpixel rendering
- Reduce hero text-shadow blur radius (20px → 10px) and opacity
- Reduce drop-shadow on gradient-clipped accent text (`.accent`, `.kb-accent`)
- Disable drop-shadow entirely on `.kb-accent` in light theme

## Test plan
- Open `website/index.html` locally in a browser
- Verify all "terminal" references are gone (Cmd+F for "terminal")
- Switch to light theme and confirm text is sharp, not blurry
- Verify the brew install copy button copies `brew install --cask mdelapenya/tap/biomelab`
- Check that the `m` key no longer appears in the keyboard grid
