### PR TITLE
feat(gui): improve repo menu visual hierarchy and active-row indicator

### DIFF
--- a/internal/gui/repo_panel.go
+++ b/internal/gui/repo_panel.go
@@ -93,10 +93,23 @@ func (rp *RepoPanel) rebuildList() {
 	rp.list.Objects = nil
 
 	for gi, group := range rp.groups {
-		// Repo header (not clickable).
-		header := monoText(group.Name, colorGray, false)
-		header.TextSize = scaledSize(10)
-		rp.list.Add(container.NewPadded(header))
+		// Compact visual separator between repo groups.
+		if gi > 0 {
+			gap := canvas.NewRectangle(colorPanelBg)
+			gap.SetMinSize(fyne.NewSize(0, 4))
+			sep := canvas.NewRectangle(colorBorder)
+			sep.SetMinSize(fyne.NewSize(0, 1))
+			rp.list.Add(gap)
+			rp.list.Add(sep)
+		}
+
+		// Repo header (not clickable) — bold + foreground color for
+		// strong visual hierarchy over the mode sub-items.
+		header := monoText(group.Name, colorForeground, true)
+		header.TextSize = scaledSize(12)
+		topGap := canvas.NewRectangle(colorPanelBg)
+		topGap.SetMinSize(fyne.NewSize(0, 4))
+		rp.list.Add(container.NewVBox(topGap, header))
 
 		// Mode entries (clickable).
 		for mi, mode := range group.Modes {
@@ -157,8 +170,18 @@ func (rp *RepoPanel) buildModeLine(mode config.ModeEntry, isActive bool) fyne.Ca
 		}
 	}
 
+	var row fyne.CanvasObject
 	if dot != nil {
-		return container.NewHBox(label, dot)
+		row = container.NewHBox(label, dot)
+	} else {
+		row = label
 	}
-	return label
+
+	// Active row gets a highlighted background so it stands out.
+	if isActive {
+		bg := canvas.NewRectangle(colorSelection)
+		bg.CornerRadius = 4
+		return container.NewStack(bg, container.NewPadded(row))
+	}
+	return row
 }


### PR DESCRIPTION
## What's changed

Improve the visual hierarchy in the repo navigation panel so repository names stand out over their host/sandbox sub-items. Previously, repo headers used the same gray color, non-bold text, and a smaller font than mode entries, causing the eye to be drawn to sub-items instead.

Repo headers are now bold, use the foreground color, and render at size 12 (vs 11 for modes). A thin separator line between repo groups provides clear visual boundaries. The active mode row gets a semi-transparent selection background with rounded corners for immediate identification.

## Why is this important?

With multiple enrolled repos the flat, low-contrast list made it hard to scan and locate a specific repository. The stronger headers and group separators reduce cognitive load, and the highlighted active row removes guesswork about which mode is currently selected.

## Changes

**Repo panel (`internal/gui/repo_panel.go`)**
- Render repo headers with `colorForeground`, bold, `scaledSize(12)` instead of `colorGray`, non-bold, `scaledSize(10)`
- Add a 1px `colorBorder` separator line with 4px gap between repo groups
- Wrap the active mode row in a `colorSelection` background rectangle with 4px corner radius

## Test plan

- Launch the app with multiple repos enrolled
- Verify repo names are visually dominant (bright, bold) over gray mode sub-items
- Verify a thin line separates each repo group
- Click different modes and confirm the active row has a visible highlight
- Toggle light/dark theme (Ctrl+T) and verify both palettes render correctly
