### PR TITLE
feat(terminal): detect terminals and activate-or-open on Enter

### DIFF
--- a/.claude/skills/product-owner/SKILL.md
+++ b/.claude/skills/product-owner/SKILL.md
@@ -53,10 +53,17 @@ scanning system processes: **Claude, Copilot, Codex, Kiro, OpenCode, Gemini**.
 An editor/IDE open in a worktree. Auto-detected: **VS Code, Cursor, Zed,
 Windsurf, GoLand, IntelliJ, PyCharm, Neovim, Vim**.
 
+### Terminal
+A terminal emulator with a shell whose working directory matches a worktree.
+Auto-detected by scanning system processes for shells (bash, zsh, fish, pwsh)
+whose ancestor is a known terminal emulator: **Terminal.app, iTerm2, Alacritty,
+kitty, WezTerm, gnome-terminal, Konsole, Tilix, xfce4-terminal, Hyper,
+Windows Terminal**.
+
 ### Card
 The visual representation of a worktree in the right panel. Each card shows:
 branch name, path, sandbox status, PR/MR info, agent status, IDE status,
-dirty/clean state, and sync status (ahead/behind/diverged).
+terminal status, dirty/clean state, and sync status (ahead/behind/diverged).
 
 ---
 
@@ -106,7 +113,8 @@ Every worktree is rendered as a card showing at-a-glance status:
 | **Sandbox** | `(running)` green / `(stopped)` yellow / `(not found)` red |
 | **PR/MR** | `PR #123 Title (open/draft/merged/closed)` with CI icon: success/failure/pending |
 | **Agent** | `claude (PID 1234)` green, or `no agent` dimmed; sub-agents shown indented |
-| **IDE** | `vscode` cyan, or `no IDE` dimmed; multiple IDEs listed separately |
+| **IDE** | `vscode (PID 567)` blue, or `no IDE` dimmed; multiple IDEs listed separately |
+| **Terminal** | `Terminal (PID 890)` purple, or `no terminal` dimmed; one entry per emulator window |
 | **Dirty** | `dirty` orange or `clean` green |
 | **Sync** | `up-to-date` / `ahead` / `behind` / `diverged` / `no upstream` |
 
@@ -163,16 +171,35 @@ worktree is created inside the sandbox.
 Press `p` to fetch all remotes and merge from origin. Multi-remote aware:
 fetches origin, upstream, and any configured forks before merging.
 
-### 8. Open in Terminal
+### 8. Open in Terminal (activate-or-open)
 
-Press Enter on any card to open the worktree in a new terminal window. Each
-press opens a fresh window — no tab reuse or split panels.
-In sandbox mode, the terminal runs `sbx run --branch <branch> <name>` to
-attach to the sandbox session. In regular mode, a shell opens in the worktree
-directory.
+Press Enter on any card to open the worktree in a terminal. If a terminal is
+already detected for that worktree (see Feature 10b), biomelab brings it to
+the foreground instead of opening a new one. If no terminal is detected, a new
+window opens.
+
+**Activation mechanism (macOS):** biomelab resolves the detected shell's PID to
+its TTY device (via `lsof`), then uses AppleScript to search Terminal.app or
+iTerm2 tabs for a matching `tty` property and brings that window to front. This
+is immune to shell prompts overwriting the window title. Falls back to bringing
+the terminal app to the foreground generically if TTY matching fails.
+
+**Activation mechanism (Linux):** uses `xdotool search --pid` to find the
+terminal emulator's window by its root PID, then `windowactivate` to raise it.
+Falls back to `wmctrl -x -a` by window class if xdotool is unavailable.
+
+**New terminal windows** include an ANSI title escape (`\033]0;biomelab: <branch>\007`)
+for visual identification in the terminal's title bar or tab.
+
+In sandbox mode, Enter always opens a new terminal (sandbox sessions are remote
+and not tracked by local process detection).
 
 macOS uses `.command` files via `open` (no permissions required). Linux uses
 `x-terminal-emulator` (system default). Override with `BIOME_TERMINAL` env var.
+
+> **macOS note:** First use triggers a macOS Automation permission prompt
+> (System Settings > Privacy & Security > Automation) to allow biomelab to
+> control Terminal.app or iTerm2 via AppleScript.
 
 ### 9. Open in Editor
 
@@ -187,6 +214,23 @@ worktree. Results appear on cards and refresh every 5 seconds.
 Agents show PID, process state, and start time. Sub-agent processes (child PIDs)
 are grouped under the parent. IDEs show kind and one entry per independent
 window (Electron helper processes are grouped by process tree).
+
+### 10b. Terminal Detection
+
+The same process scanning that detects agents and IDEs also detects terminal
+sessions. biomelab finds shell processes (bash, zsh, fish, pwsh), walks up their
+PPID chain to identify the terminal emulator ancestor (Terminal.app, iTerm2,
+Alacritty, etc.), and matches the shell's working directory to worktree paths.
+
+Terminal status appears on cards in purple (`▶ Terminal (PID 890)` or
+`▷ no terminal`). Kanban cards show a compact `▶ Terminal` line when detected.
+
+Detection shares the same process snapshot as agent/IDE detection (one
+`gopsutil` call per refresh cycle), so it adds no extra system overhead.
+Shells spawned by non-terminal parents (editors, scripts, cron) are filtered
+out by the PPID walk — only shells descending from a known terminal emulator
+are reported. Multiple terminals open for the same worktree under different
+emulators are listed separately.
 
 ### 11. PR / MR Status
 
@@ -214,7 +258,7 @@ both panels.
 
 | Cycle | Interval | What it checks |
 |---|---|---|
-| **Local** | 5 s | Worktree list, dirty status, agent/IDE detection, sandbox status |
+| **Local** | 5 s | Worktree list, dirty status, agent/IDE/terminal detection, sandbox status |
 | **Network** | 30 s (configurable) | Git fetch all remotes, PR/MR lookup, CI status, sync status |
 | **Manual** | On-demand (`r`) | Full network refresh for the selected card only |
 | **Quick** | After create/delete/pull/fetch-PR | Worktree list only (fast) |
@@ -327,7 +371,7 @@ This data is fetched from `gh pr view --json reviews` (GitHub) and `glab mr view
 | `S` | Stop running sandbox | Main card, sandbox running |
 | `d` | Delete worktree or sandbox | Linked card: delete worktree; main card in sandbox: remove sandbox |
 | `e` | Open in editor | Any card |
-| `Enter` | Open in terminal | Any card |
+| `Enter` | Activate existing terminal or open new | Any card |
 | `p` | Pull from remote | Any card |
 | `r` | Refresh selected card | Any card |
 | `g` | Toggle kanban ↔ grid view | Global |
@@ -473,15 +517,20 @@ in a single sandbox would create conflicting environments and make it unclear
 which agent "owns" the sandbox lifecycle. One-to-one mapping keeps the mental
 model simple.
 
-### DL-007: Fresh terminal window per Enter press
+### DL-007: Activate-or-open terminal on Enter (revised)
 
-**Decision:** Every Enter press opens a new terminal window. No tab tracking,
-no split panels, no terminal-specific integrations.
+**Decision:** Enter activates (brings to front) an existing terminal for the
+worktree if one is detected, or opens a new one if not. Supersedes the earlier
+"fresh terminal per Enter press" policy.
 
-**Why:** Maintaining compatibility across different terminal emulators (Warp,
-iTerm, Terminal.app, gnome-terminal, konsole, xfce4-terminal) with tab reuse
-and split panel logic was cumbersome and fragile. The simple approach — open a
-fresh window every time — works everywhere with no permissions or AppleScript.
+**Why:** When managing many worktrees with agents, developers accumulate many
+terminal windows. Opening a new one on every Enter press increases cognitive
+load — the user must hunt for the right window among dozens. Activate-or-open
+reduces this by reusing the existing terminal. Detection is based on process
+scanning (shell CWD matching worktree path), so it finds terminals regardless
+of whether biomelab opened them. Activation uses TTY matching (PID → lsof →
+AppleScript tab tty), which is immune to shell prompts overwriting window titles.
+Sandbox mode always opens new (sandbox sessions are remote, not locally tracked).
 
 ### DL-008: Main card is not deletable
 
@@ -642,3 +691,30 @@ yellow ● commented.
 "PR In Review" in the kanban board. It also provides a quick signal on cards in
 the grid view so users know whether action is needed without opening the PR URL.
 The icon is kept minimal (single character) to avoid crowding the card line.
+
+### DL-023: TTY-based terminal activation over window title matching
+
+**Decision:** Terminal activation uses the shell's TTY device (`lsof -p <pid>`)
+matched against Terminal.app/iTerm2 tab `tty` properties via AppleScript, rather
+than matching by window title.
+
+**Why:** The initial implementation set a `biomelab: <branch>` title via ANSI
+escape when opening terminals and searched for that title to activate. This
+failed because shell prompts (oh-my-zsh, powerlevel10k, starship) overwrite the
+window title on every command. TTY matching is immune to title changes — it uses
+the kernel's device assignment, which is stable for the lifetime of the terminal
+session. On Linux, `xdotool search --pid` serves the same purpose.
+
+### DL-024: PPID-walk filtering for terminal detection
+
+**Decision:** Terminal detection filters shell processes by walking their PPID
+chain upward to find a known terminal emulator ancestor. Shells whose ancestry
+does not include a terminal emulator are discarded.
+
+**Why:** Many shell processes exist on a system that are not user-interactive
+terminal sessions — editors spawn shells, build tools use shells, cron jobs run
+shells. Without the PPID walk, every shell whose CWD happened to match a
+worktree path would be falsely reported as a terminal. The upward walk ensures
+only shells that descend from Terminal.app, iTerm2, Alacritty, etc. are counted.
+The emulator pattern list is ordered so that specific names (e.g. "iterm2")
+match before broad ones (e.g. "terminal").

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 
 - **Multi-repo dashboard** -- Register multiple repositories and switch between them in a two-panel layout. The left panel shows registered repos as a tree with indented mode lines (regular `📂 [host]` or sandbox `🐳 [agent]`). The right panel shows the selected mode's worktree dashboard. Press `Tab` to switch focus between panels.
 - **Persistent config** -- Registered repos are saved to `~/.config/biomelab/repos.json` and restored on next launch. Starting biomelab inside a git repo auto-adds it.
-- **Worktree cards** -- Each card shows: branch name, path, dirty/clean status, sync status (ahead/behind/diverged/up-to-date), active agents, open IDEs, and PR info.
+- **Worktree cards** -- Each card shows: branch name, path, dirty/clean status, sync status (ahead/behind/diverged/up-to-date), active agents, open IDEs, terminal sessions, and PR info.
 - **Agent detection** -- Automatically detects coding agents (Claude, Kiro, Copilot, Codex, OpenCode, Gemini) running in each worktree by scanning system processes.
 - **IDE detection** -- Detects open IDEs (VS Code, Cursor, Zed, Windsurf, GoLand, IntelliJ, PyCharm, Neovim, Vim) in each worktree.
+- **Terminal detection** -- Detects terminal sessions (Terminal.app, iTerm2, Alacritty, kitty, WezTerm, gnome-terminal, Konsole, and more) by finding shells whose working directory matches a worktree path. Shown in purple on cards.
 - **PR/MR status** -- Fetches pull request (GitHub) or merge request (GitLab) information and CI check status for each branch.
 - **Sync status** -- Compares each branch against remote tracking branches and shows ahead/behind/diverged status.
 - **Docker Sandbox mode** (recommended) -- One sandbox per agent per repo. Real-time status monitoring (running/stopped/not found). Create, start, stop, and remove sandboxes from the dashboard.
@@ -18,7 +19,7 @@
 - **Fetch PR** -- Press `f` to fetch a PR into a new worktree. Accepts `123` or `owner/repo#123`.
 - **Send PR** -- Press `Shift+P` to push and create a PR (multi-phase: dirty check → remote selection → confirmation). Detects existing PRs for push-only mode.
 - **Pull** -- Press `p` to fetch all remotes and merge from origin.
-- **Open in terminal** -- Press `Enter` to open a worktree in a new terminal window.
+- **Open in terminal** -- Press `Enter` to open a worktree in a terminal. If a terminal is already detected for that worktree, it is brought to the foreground instead of opening a new one. On macOS, activation uses TTY matching via AppleScript (requires Automation permission on first use).
 - **Open in editor** -- Press `e` to open in `$BIOME_EDITOR` (defaults to VS Code).
 - **Zoom** -- `Ctrl+=` / `Ctrl+-` / `Ctrl+0` to scale the UI font.
 - **System tray** -- Closing the window hides to system tray. Tray menu toggles Show/Hide.
@@ -117,7 +118,7 @@ Launch `biomelab` from any directory, or open `Biomelab.app` from Spotlight/Find
 | `↓` / `j` | Navigate down (by row in grid) | Any card |
 | `←` / `h` | Navigate left | Linked cards |
 | `→` / `l` | Navigate right | Linked cards |
-| `Enter` | Open in terminal | Any card |
+| `Enter` | Activate existing terminal or open new | Any card |
 | `e` | Open in editor | Any card |
 | `c` | Create worktree | Main card |
 | `f` | Fetch PR/MR | Main card |

--- a/cmd/biomelab/main.go
+++ b/cmd/biomelab/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/gui"
 	"github.com/mdelapenya/biomelab/internal/ide"
 	"github.com/mdelapenya/biomelab/internal/process"
+	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
 //go:embed icon.png
@@ -66,6 +67,7 @@ func main() {
 
 	detector := agent.NewDetector()
 	ideDetector := ide.NewDetector()
+	termDetector := terminal.NewDetector()
 	procLister := &process.OSLister{}
 	configPath := config.DefaultPath()
 
@@ -86,6 +88,6 @@ func main() {
 
 	gui.AppIcon = &fyne.StaticResource{StaticName: "icon.png", StaticContent: iconBytes}
 
-	app := gui.NewApp(configPath, detector, ideDetector, procLister, refreshInterval)
+	app := gui.NewApp(configPath, detector, ideDetector, termDetector, procLister, refreshInterval)
 	app.Run()
 }

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/process"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
+	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
 // repoEntry holds per-repo runtime state.
@@ -52,6 +53,7 @@ type App struct {
 	configPath      string
 	detector        *agent.Detector
 	ideDetector     *ide.Detector
+	termDetector    *terminal.Detector
 	procLister      process.Lister
 	refreshInterval time.Duration
 
@@ -69,6 +71,7 @@ func NewApp(
 	configPath string,
 	detector *agent.Detector,
 	ideDetector *ide.Detector,
+	termDetector *terminal.Detector,
 	procLister process.Lister,
 	refreshInterval time.Duration,
 ) *App {
@@ -76,6 +79,7 @@ func NewApp(
 		configPath:      configPath,
 		detector:        detector,
 		ideDetector:     ideDetector,
+		termDetector:    termDetector,
 		procLister:      procLister,
 		refreshInterval: refreshInterval,
 		sbxStatuses:     make(map[string]sandbox.Status),
@@ -200,7 +204,7 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 		a.focus = focusRight // clicking a card means right panel has focus
 	}
 
-	rm := NewRefreshManager(repo, a.detector, a.ideDetector, a.procLister, prProv, a.refreshInterval)
+	rm := NewRefreshManager(repo, a.detector, a.ideDetector, a.termDetector, a.procLister, prProv, a.refreshInterval)
 	rm.SetSandboxCandidates(sbxCandidates)
 
 	re := &repoEntry{

--- a/internal/gui/card.go
+++ b/internal/gui/card.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/ide"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
+	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
 // maxLinkedPathChars is the max characters for a path in a linked card.
@@ -82,6 +83,7 @@ func buildCardContent(
 	wt git.Worktree,
 	agents []agent.Info,
 	ides []ide.Info,
+	terminals []terminal.Info,
 	pr *provider.PRInfo,
 	cliAvail provider.CLIAvailability,
 	prov provider.Provider,
@@ -181,6 +183,16 @@ func buildCardContent(
 		}
 	} else {
 		items = append(items, monoText("□ no IDE", colorDimGray, false))
+	}
+
+	// Terminal status.
+	if len(terminals) > 0 {
+		for _, t := range terminals {
+			line := fmt.Sprintf("▶ %s (PID %d)", string(t.Kind), t.ShellPID)
+			items = append(items, monoText(line, colorPurple, false))
+		}
+	} else {
+		items = append(items, monoText("▷ no terminal", colorDimGray, false))
 	}
 
 	// Dirty + sync status on one line.

--- a/internal/gui/dashboard.go
+++ b/internal/gui/dashboard.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/ops"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
+	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
 // flexGridLayout lays out cards on a grid where the column count is determined
@@ -149,6 +150,9 @@ func (d *Dashboard) ApplyRefresh(result ops.RefreshResult) {
 	if result.IDEs != nil {
 		d.state.IDEs = result.IDEs
 	}
+	if result.Terminals != nil {
+		d.state.Terminals = result.Terminals
+	}
 	if result.HasPRs {
 		d.state.PRs = result.PRs
 		d.state.LastNetworkRefresh = time.Now()
@@ -271,6 +275,7 @@ func (d *Dashboard) build() fyne.CanvasObject {
 		*mainWt,
 		d.agentsFor(mainWt.Path),
 		d.idesFor(mainWt.Path),
+		d.terminalsFor(mainWt.Path),
 		d.prFor(mainWt.Branch),
 		d.state.CLIAvail,
 		d.state.Provider,
@@ -337,6 +342,7 @@ func (d *Dashboard) build() fyne.CanvasObject {
 			wt,
 			d.agentsFor(wt.Path),
 			d.idesFor(wt.Path),
+			d.terminalsFor(wt.Path),
 			d.prFor(wt.Branch),
 			d.state.CLIAvail,
 			d.state.Provider,
@@ -392,6 +398,13 @@ func (d *Dashboard) idesFor(wtPath string) []ide.Info {
 		return nil
 	}
 	return d.state.IDEs[wtPath]
+}
+
+func (d *Dashboard) terminalsFor(wtPath string) []terminal.Info {
+	if d.state.Terminals == nil {
+		return nil
+	}
+	return d.state.Terminals[wtPath]
 }
 
 func (d *Dashboard) prFor(branch string) *provider.PRInfo {

--- a/internal/gui/kanban.go
+++ b/internal/gui/kanban.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/agent"
 	"github.com/mdelapenya/biomelab/internal/git"
 	"github.com/mdelapenya/biomelab/internal/provider"
+	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
 // prLink is a tappable monospace label that opens the PR/MR URL in the default
@@ -96,6 +97,7 @@ func (h *hintIcon) MouseMoved(_ *desktop.MouseEvent) {}
 func buildKanbanCardContent(
 	wt git.Worktree,
 	agents []agent.Info,
+	terminals []terminal.Info,
 	pr *provider.PRInfo,
 	selected bool,
 ) fyne.CanvasObject {
@@ -122,6 +124,13 @@ func buildKanbanCardContent(
 		agentLine := monoText("● "+string(agents[0].Kind), colorGreen, false)
 		agentLine.TextSize = scaledSize(10)
 		rows = append(rows, agentLine)
+	}
+
+	// ── Row 2b: ▶ terminal (omitted when no terminal) ───────────────────
+	if len(terminals) > 0 {
+		termLine := monoText("▶ "+string(terminals[0].Kind), colorPurple, false)
+		termLine.TextSize = scaledSize(10)
+		rows = append(rows, termLine)
 	}
 
 	// ── Row 3: #42 ↗  review  CI  (omitted when no PR) ─────────────────
@@ -346,6 +355,7 @@ func (d *Dashboard) buildKanbanView() fyne.CanvasObject {
 				content := buildKanbanCardContent(
 					wt,
 					d.agentsFor(wt.Path),
+					d.terminalsFor(wt.Path),
 					d.prFor(wt.Branch),
 					isSelected,
 				)

--- a/internal/gui/refresh.go
+++ b/internal/gui/refresh.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/ops"
 	"github.com/mdelapenya/biomelab/internal/process"
 	"github.com/mdelapenya/biomelab/internal/provider"
+	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
 const localRefreshInterval = 5 * time.Second
@@ -20,6 +21,7 @@ type RefreshManager struct {
 	repo            *git.Repository
 	detector        *agent.Detector
 	ideDetector     *ide.Detector
+	termDetector    *terminal.Detector
 	procLister      process.Lister
 	prProv          provider.PRProvider
 	cliAvail        provider.CLIAvailability
@@ -40,6 +42,7 @@ func NewRefreshManager(
 	repo *git.Repository,
 	detector *agent.Detector,
 	ideDetector *ide.Detector,
+	termDetector *terminal.Detector,
 	procLister process.Lister,
 	prProv provider.PRProvider,
 	networkInterval time.Duration,
@@ -48,6 +51,7 @@ func NewRefreshManager(
 		repo:            repo,
 		detector:        detector,
 		ideDetector:     ideDetector,
+		termDetector:    termDetector,
 		procLister:      procLister,
 		prProv:          prProv,
 		networkInterval: networkInterval,
@@ -167,7 +171,7 @@ func (rm *RefreshManager) doLocal() {
 	candidates := rm.sbxCandidates
 	rm.mu.Unlock()
 
-	result := ops.LocalRefresh(rm.repo, rm.detector, rm.ideDetector, rm.procLister, candidates)
+	result := ops.LocalRefresh(rm.repo, rm.detector, rm.ideDetector, rm.termDetector, rm.procLister, candidates)
 	if rm.OnRefresh != nil {
 		rm.OnRefresh(result)
 	}
@@ -179,7 +183,7 @@ func (rm *RefreshManager) doNetwork() {
 	cliAvail := rm.cliAvail
 	rm.mu.Unlock()
 
-	result := ops.NetworkRefresh(rm.repo, rm.detector, rm.ideDetector, rm.procLister, rm.prProv, cliAvail, candidates)
+	result := ops.NetworkRefresh(rm.repo, rm.detector, rm.ideDetector, rm.termDetector, rm.procLister, rm.prProv, cliAvail, candidates)
 	if rm.OnRefresh != nil {
 		rm.OnRefresh(result)
 	}

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -422,11 +422,29 @@ func (a *App) handleEnter() {
 
 	mode := re.state.ActiveMode
 	if mode != nil && mode.Type == "sandbox" && mode.SandboxName != "" {
+		// Sandbox mode: no terminal detection (sandbox terminals are remote).
 		args := sandbox.RunWithBranchArgs(mode.SandboxName, wt.Branch)
 		cmd := sandbox.CommandString(args)
-		go func() { _ = ops.OpenTerminal("", cmd) }()
+		go func() { _ = ops.OpenTerminal("", cmd, "") }()
+		return
+	}
+
+	identifier := wt.Branch
+
+	// If a terminal is already detected for this worktree, try to activate it.
+	if terms := re.state.Terminals[wt.Path]; len(terms) > 0 {
+		t := terms[0]
+		go func() {
+			// Try 1: activate by TTY — resolves shell PID to its tty device,
+			// then finds the terminal window/tab that owns it.
+			if ops.ActivateTerminalByPID(t.ShellPID, t.RootPID, t.Kind) {
+				return
+			}
+			// Try 2: bring the terminal app to front generically.
+			ops.ActivateTerminalApp(t.Kind)
+		}()
 	} else {
-		go func() { _ = ops.OpenTerminal(wt.Path, "") }()
+		go func() { _ = ops.OpenTerminal(wt.Path, "", identifier) }()
 	}
 }
 

--- a/internal/gui/state.go
+++ b/internal/gui/state.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/ide"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
+	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
 // ViewMode controls how the linked worktrees are displayed.
@@ -30,6 +31,7 @@ type RepoState struct {
 	Worktrees     []git.Worktree
 	Agents        agent.DetectionResult
 	IDEs          ide.DetectionResult
+	Terminals     terminal.DetectionResult
 	PRs           provider.PRResult
 	CLIAvail      provider.CLIAvailability
 	Provider      provider.Provider

--- a/internal/ops/refresh.go
+++ b/internal/ops/refresh.go
@@ -11,13 +11,15 @@ import (
 	"github.com/mdelapenya/biomelab/internal/process"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
+	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
-// RefreshResult carries updated worktree, agent, IDE, and PR data.
+// RefreshResult carries updated worktree, agent, IDE, terminal, and PR data.
 type RefreshResult struct {
 	Worktrees      []git.Worktree
 	Agents         agent.DetectionResult
 	IDEs           ide.DetectionResult
+	Terminals      terminal.DetectionResult
 	PRs            provider.PRResult
 	HasPRs         bool
 	Err            error
@@ -59,6 +61,7 @@ func LocalRefresh(
 	repo *git.Repository,
 	detector *agent.Detector,
 	ideDetector *ide.Detector,
+	termDetector *terminal.Detector,
 	procLister process.Lister,
 	sbxCandidates []string,
 ) RefreshResult {
@@ -72,14 +75,16 @@ func LocalRefresh(
 		paths[i] = wt.Path
 	}
 
-	// Fetch processes once and share across both detectors.
+	// Fetch processes once and share across all detectors.
 	ctx := context.Background()
 	procs, procErr := procLister.Processes(ctx)
 	var agents agent.DetectionResult
 	var ides ide.DetectionResult
+	var terms terminal.DetectionResult
 	if procErr == nil {
 		agents = detector.DetectFromProcesses(procs, paths)
 		ides = ideDetector.DetectFromProcesses(procs, paths)
+		terms = termDetector.DetectFromProcesses(procs, paths)
 	}
 
 	// Check all sandbox statuses with one sbx ls call, then match against
@@ -109,6 +114,7 @@ func LocalRefresh(
 		Worktrees:      wts,
 		Agents:         agents,
 		IDEs:           ides,
+		Terminals:      terms,
 		SandboxStatus:  sbxStatus,
 		HasSbxStatus:   len(sbxCandidates) > 0,
 		AllSbxStatuses: allStatuses,
@@ -125,6 +131,7 @@ func NetworkRefresh(
 	repo *git.Repository,
 	detector *agent.Detector,
 	ideDetector *ide.Detector,
+	termDetector *terminal.Detector,
 	procLister process.Lister,
 	prProv provider.PRProvider,
 	cliAvail provider.CLIAvailability,
@@ -148,9 +155,11 @@ func NetworkRefresh(
 	procs, procErr := procLister.Processes(ctx)
 	var agents agent.DetectionResult
 	var ides ide.DetectionResult
+	var terms terminal.DetectionResult
 	if procErr == nil {
 		agents = detector.DetectFromProcesses(procs, paths)
 		ides = ideDetector.DetectFromProcesses(procs, paths)
+		terms = termDetector.DetectFromProcesses(procs, paths)
 	}
 
 	var prs provider.PRResult
@@ -176,6 +185,7 @@ func NetworkRefresh(
 		Worktrees:      wts,
 		Agents:         agents,
 		IDEs:           ides,
+		Terminals:      terms,
 		PRs:            prs,
 		HasSbxStatus:   len(sbxCandidates) > 0,
 		HasPRs:         true,
@@ -191,6 +201,7 @@ func CardRefresh(
 	repo *git.Repository,
 	detector *agent.Detector,
 	ideDetector *ide.Detector,
+	termDetector *terminal.Detector,
 	procLister process.Lister,
 	prProv provider.PRProvider,
 	cliAvail provider.CLIAvailability,
@@ -207,9 +218,11 @@ func CardRefresh(
 	procs, procErr := procLister.Processes(ctx)
 	var agents agent.DetectionResult
 	var ides ide.DetectionResult
+	var terms terminal.DetectionResult
 	if procErr == nil {
 		agents = detector.DetectFromProcesses(procs, []string{wtPath})
 		ides = ideDetector.DetectFromProcesses(procs, []string{wtPath})
+		terms = termDetector.DetectFromProcesses(procs, []string{wtPath})
 	}
 
 	var prs provider.PRResult
@@ -223,6 +236,7 @@ func CardRefresh(
 		Worktrees: wts,
 		Agents:    agents,
 		IDEs:      ides,
+		Terminals: terms,
 		PRs:       prs,
 		HasPRs:    true,
 		FetchErr:  fetchErr,

--- a/internal/ops/worktree.go
+++ b/internal/ops/worktree.go
@@ -168,6 +168,22 @@ func OpenEditor(dir string) error {
 }
 
 // OpenTerminal opens a terminal window for the given directory or command.
-func OpenTerminal(dir, command string) error {
+// If identifier is non-empty, the terminal title is set to "biomelab: <identifier>".
+func OpenTerminal(dir, command, identifier string) error {
+	if identifier != "" {
+		return terminal.OpenWithTitle(dir, command, identifier)
+	}
 	return terminal.Open(dir, command)
+}
+
+// ActivateTerminalByPID looks up the shell's TTY and brings the owning
+// terminal window to the foreground. Returns true if successful.
+func ActivateTerminalByPID(shellPID, rootPID int32, kind terminal.Kind) bool {
+	return terminal.ActivateByPID(shellPID, rootPID, kind)
+}
+
+// ActivateTerminalApp brings a terminal emulator application to the foreground
+// without targeting a specific window. Use as a last-resort fallback.
+func ActivateTerminalApp(kind terminal.Kind) bool {
+	return terminal.ActivateApp(kind)
 }

--- a/internal/terminal/activate.go
+++ b/internal/terminal/activate.go
@@ -1,0 +1,177 @@
+package terminal
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// titlePrefix is the string prepended to all biomelab terminal window titles.
+const titlePrefix = "biomelab: "
+
+// Title returns the full window title for a given identifier (usually a branch name).
+func Title(identifier string) string {
+	return titlePrefix + identifier
+}
+
+// ActivateByPID looks up the TTY for the given shell PID and activates the
+// terminal window/tab that owns it. This is the most reliable activation
+// method — it doesn't depend on window titles (which shell prompts overwrite).
+//
+// On macOS: resolves PID → tty via lsof, then uses AppleScript to find and
+// activate the Terminal.app/iTerm2 tab with that tty.
+// On Linux: uses xdotool to find and activate the window owned by rootPID.
+func ActivateByPID(shellPID, rootPID int32, kind Kind) bool {
+	switch runtime.GOOS {
+	case "darwin":
+		tty := ttyForPID(shellPID)
+		if tty == "" {
+			return false
+		}
+		ok, _ := activateDarwinByTTY(tty, kind)
+		return ok
+	case "linux":
+		return activateLinuxByPID(rootPID)
+	default:
+		return false
+	}
+}
+
+// ActivateApp brings a terminal emulator application to the foreground without
+// searching for a specific window. Use this as a last-resort fallback.
+func ActivateApp(kind Kind) bool {
+	switch runtime.GOOS {
+	case "darwin":
+		return activateAppDarwin(kind)
+	case "linux":
+		return activateAppLinux(kind)
+	default:
+		return false
+	}
+}
+
+// ttyForPID resolves the controlling terminal device for a process.
+// Returns a path like "/dev/ttys003" or "" if unavailable.
+func ttyForPID(pid int32) string {
+	cmd := exec.Command("lsof", "-p", fmt.Sprintf("%d", pid), "-a", "-d", "0", "-F", "n")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "n/dev/") {
+			return line[1:] // strip the 'n' field prefix
+		}
+	}
+	return ""
+}
+
+// activateDarwinByTTY uses AppleScript to find and activate the Terminal.app
+// or iTerm2 tab whose tty matches, then brings its window to front.
+func activateDarwinByTTY(tty string, kind Kind) (bool, error) {
+	switch kind {
+	case ITerm2:
+		return activateITerm2ByTTY(tty)
+	default:
+		// Terminal.app and other emulators that follow Terminal.app's scripting model.
+		return activateTerminalAppByTTY(tty)
+	}
+}
+
+func activateTerminalAppByTTY(tty string) (bool, error) {
+	script := fmt.Sprintf(`
+tell application "Terminal"
+	repeat with w in windows
+		repeat with t in tabs of w
+			if tty of t is %q then
+				set selected tab of w to t
+				set index of w to 1
+				activate
+				return true
+			end if
+		end repeat
+	end repeat
+end tell
+return false`, tty)
+
+	cmd := exec.Command("osascript", "-e", script)
+	out, err := cmd.Output()
+	if err != nil {
+		return false, nil
+	}
+	return strings.TrimSpace(string(out)) == "true", nil
+}
+
+func activateITerm2ByTTY(tty string) (bool, error) {
+	script := fmt.Sprintf(`
+tell application "iTerm"
+	repeat with w in windows
+		repeat with t in tabs of w
+			repeat with s in sessions of t
+				if tty of s is %q then
+					select s
+					tell w to select t
+					activate
+					return true
+				end if
+			end repeat
+		end repeat
+	end repeat
+end tell
+return false`, tty)
+
+	cmd := exec.Command("osascript", "-e", script)
+	out, err := cmd.Output()
+	if err != nil {
+		return false, nil
+	}
+	return strings.TrimSpace(string(out)) == "true", nil
+}
+
+// activateLinuxByPID uses xdotool to find and activate the window owned by
+// the terminal emulator's root PID.
+func activateLinuxByPID(rootPID int32) bool {
+	if _, err := exec.LookPath("xdotool"); err != nil {
+		return false
+	}
+
+	cmd := exec.Command("xdotool", "search", "--pid", fmt.Sprintf("%d", rootPID))
+	out, err := cmd.Output()
+	if err != nil || len(strings.TrimSpace(string(out))) == 0 {
+		return false
+	}
+
+	windowID := strings.Split(strings.TrimSpace(string(out)), "\n")[0]
+	activateCmd := exec.Command("xdotool", "windowactivate", windowID)
+	return activateCmd.Run() == nil
+}
+
+// darwinAppNames maps terminal Kind to the macOS application name used by
+// `open -a`. Only populated for emulators likely found on macOS.
+var darwinAppNames = map[Kind]string{
+	TerminalApp: "Terminal",
+	ITerm2:      "iTerm",
+	Alacritty:   "Alacritty",
+	Kitty:       "kitty",
+	WezTerm:     "WezTerm",
+	Hyper:       "Hyper",
+}
+
+func activateAppDarwin(kind Kind) bool {
+	name, ok := darwinAppNames[kind]
+	if !ok {
+		return false
+	}
+	cmd := exec.Command("open", "-a", name)
+	return cmd.Run() == nil
+}
+
+func activateAppLinux(kind Kind) bool {
+	if _, err := exec.LookPath("wmctrl"); err != nil {
+		return false
+	}
+	class := strings.ToLower(string(kind))
+	cmd := exec.Command("wmctrl", "-x", "-a", class)
+	return cmd.Run() == nil
+}

--- a/internal/terminal/activate_test.go
+++ b/internal/terminal/activate_test.go
@@ -1,0 +1,139 @@
+package terminal
+
+import "testing"
+
+func TestTitle(t *testing.T) {
+	got := Title("feature-branch")
+	want := "biomelab: feature-branch"
+	if got != want {
+		t.Errorf("Title() = %q, want %q", got, want)
+	}
+}
+
+func TestTitleEscape(t *testing.T) {
+	got := titleEscape("feature-branch")
+	want := "printf '\\033]0;biomelab: feature-branch\\007'; "
+	if got != want {
+		t.Errorf("titleEscape() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildShellCmdWithTitle(t *testing.T) {
+	got, err := buildShellCmdWithTitle("/project", "", "my-branch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "printf '\\033]0;biomelab: my-branch\\007'; cd '/project'; exec $SHELL"
+	if got != want {
+		t.Errorf("buildShellCmdWithTitle() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildShellCmdWithTitle_EmptyIdentifier(t *testing.T) {
+	got, err := buildShellCmdWithTitle("/project", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No title prefix when identifier is empty.
+	want := "cd '/project'; exec $SHELL"
+	if got != want {
+		t.Errorf("buildShellCmdWithTitle() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildShellCmdWithTitle_WithCommand(t *testing.T) {
+	got, err := buildShellCmdWithTitle("", "sbx run mybox", "my-branch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "printf '\\033]0;biomelab: my-branch\\007'; sbx run mybox; exec $SHELL"
+	if got != want {
+		t.Errorf("buildShellCmdWithTitle() = %q, want %q", got, want)
+	}
+}
+
+func TestDarwinAppNames_Coverage(t *testing.T) {
+	// Verify that the common macOS terminal kinds have app name mappings.
+	for _, kind := range []Kind{TerminalApp, ITerm2, Alacritty, Kitty, WezTerm} {
+		if _, ok := darwinAppNames[kind]; !ok {
+			t.Errorf("darwinAppNames missing entry for %q", kind)
+		}
+	}
+}
+
+func TestDarwinAppNames_NoLinuxOnly(t *testing.T) {
+	// Linux-only emulators should NOT have macOS app name mappings.
+	for _, kind := range []Kind{GnomeTerminal, Konsole, Tilix, Xfce4Terminal} {
+		if name, ok := darwinAppNames[kind]; ok {
+			t.Errorf("darwinAppNames should not contain Linux-only %q (mapped to %q)", kind, name)
+		}
+	}
+}
+
+func TestTitle_EmptyIdentifier(t *testing.T) {
+	got := Title("")
+	want := "biomelab: "
+	if got != want {
+		t.Errorf("Title(\"\") = %q, want %q", got, want)
+	}
+}
+
+func TestTitle_SpecialCharacters(t *testing.T) {
+	got := Title("feature/my-branch")
+	want := "biomelab: feature/my-branch"
+	if got != want {
+		t.Errorf("Title() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildShellCmdWithTitle_NoArgs(t *testing.T) {
+	_, err := buildShellCmdWithTitle("", "", "my-branch")
+	if err == nil {
+		t.Error("expected error when both dir and command are empty")
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "'simple'"},
+		{"has space", "'has space'"},
+		{"it's", "'it'\\''s'"},
+		{"", "''"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := shellQuote(tt.input); got != tt.want {
+				t.Errorf("shellQuote(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildShellCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		dir     string
+		command string
+		want    string
+		wantErr bool
+	}{
+		{"dir only", "/project", "", "cd '/project'; exec $SHELL", false},
+		{"command only", "", "sbx run mybox", "sbx run mybox; exec $SHELL", false},
+		{"command takes precedence", "/project", "sbx run mybox", "sbx run mybox; exec $SHELL", false},
+		{"neither", "", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildShellCmd(tt.dir, tt.command)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildShellCmd() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("buildShellCmd() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/terminal/detect.go
+++ b/internal/terminal/detect.go
@@ -1,0 +1,153 @@
+package terminal
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/mdelapenya/biomelab/internal/process"
+)
+
+// maxPPIDHops limits how far we walk up the process tree to avoid infinite
+// loops from circular PPID references.
+const maxPPIDHops = 20
+
+// Detect finds terminal shell processes and matches their CWDs to the given
+// worktree paths. It fetches processes internally via the configured Lister.
+func (d *Detector) Detect(worktreePaths []string) DetectionResult {
+	ctx := context.Background()
+
+	procs, err := d.lister.Processes(ctx)
+	if err != nil {
+		return DetectionResult{}
+	}
+
+	return d.DetectFromProcesses(procs, worktreePaths)
+}
+
+// DetectFromProcesses matches pre-fetched processes against known shell
+// patterns, walks their PPID chains to identify terminal emulator ancestors,
+// and matches shell CWDs to worktree paths. Use this when sharing a single
+// process snapshot across multiple detectors.
+func (d *Detector) DetectFromProcesses(procs []process.Info, worktreePaths []string) DetectionResult {
+	ctx := context.Background()
+
+	// Build PID→Info lookup for O(1) PPID walks.
+	byPID := make(map[int32]process.Info, len(procs))
+	for _, p := range procs {
+		byPID[p.PID] = p
+	}
+
+	// Filter for shell processes.
+	type shellProc struct {
+		process.Info
+		emulatorKind Kind
+		emulatorPID  int32
+	}
+	var shells []shellProc
+	for _, p := range procs {
+		name := strings.ToLower(filepath.Base(p.Name))
+		if !isShell(name) {
+			continue
+		}
+		// Walk PPID chain to find a terminal emulator ancestor.
+		kind, rootPID, found := walkToEmulator(p.PPID, byPID)
+		if !found {
+			continue
+		}
+		shells = append(shells, shellProc{
+			Info:         p,
+			emulatorKind: kind,
+			emulatorPID:  rootPID,
+		})
+	}
+
+	if len(shells) == 0 {
+		return DetectionResult{}
+	}
+
+	// Enrich shells with CWD (only if not already provided).
+	for i := range shells {
+		if shells[i].Cwd == "" {
+			process.Enrich(ctx, &shells[i].Info)
+		}
+	}
+
+	// Clean worktree paths once for comparison.
+	cleanPaths := make([]string, len(worktreePaths))
+	for i, p := range worktreePaths {
+		cleanPaths[i] = filepath.Clean(p)
+	}
+
+	// Match shell CWD to worktree paths, deduplicating by (wtPath, rootPID).
+	type treeKey struct {
+		wtPath  string
+		rootPID int32
+	}
+	seen := make(map[treeKey]bool)
+	result := make(DetectionResult)
+
+	for _, sh := range shells {
+		if sh.Cwd == "" {
+			continue
+		}
+		cwd := filepath.Clean(sh.Cwd)
+		for j, wtPath := range worktreePaths {
+			if cwd != cleanPaths[j] {
+				continue
+			}
+			tk := treeKey{wtPath: wtPath, rootPID: sh.emulatorPID}
+			if seen[tk] {
+				continue
+			}
+			seen[tk] = true
+			result[wtPath] = append(result[wtPath], Info{
+				Kind:     sh.emulatorKind,
+				ShellPID: sh.PID,
+				RootPID:  sh.emulatorPID,
+			})
+		}
+	}
+
+	return result
+}
+
+// isShell checks if a lowercased process base name matches any shell pattern.
+func isShell(name string) bool {
+	for _, pat := range ShellPatterns {
+		if strings.Contains(name, pat) {
+			return true
+		}
+	}
+	return false
+}
+
+// walkToEmulator walks up the PPID chain from startPPID looking for a known
+// terminal emulator. Returns the emulator Kind, its PID, and whether one was found.
+func walkToEmulator(startPPID int32, byPID map[int32]process.Info) (Kind, int32, bool) {
+	visited := make(map[int32]bool)
+	pid := startPPID
+	for range maxPPIDHops {
+		if pid <= 1 || visited[pid] {
+			break
+		}
+		visited[pid] = true
+
+		p, ok := byPID[pid]
+		if !ok {
+			break
+		}
+
+		name := strings.ToLower(filepath.Base(p.Name))
+		for _, ep := range EmulatorPatterns {
+			for _, pat := range ep.Patterns {
+				if strings.Contains(name, pat) {
+					return ep.Kind, p.PID, true
+				}
+			}
+		}
+
+		pid = p.PPID
+	}
+	return "", 0, false
+}

--- a/internal/terminal/detect_test.go
+++ b/internal/terminal/detect_test.go
@@ -1,0 +1,412 @@
+package terminal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mdelapenya/biomelab/internal/process"
+)
+
+type mockLister struct {
+	procs []process.Info
+}
+
+func (m *mockLister) Processes(_ context.Context) ([]process.Info, error) {
+	return m.procs, nil
+}
+
+func TestDetect_ShellWithTerminalParent(t *testing.T) {
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 150, PPID: 100, Name: "login"},
+			{PID: 200, PPID: 150, Name: "zsh", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result["/project"]) != 1 {
+		t.Fatalf("expected 1 terminal, got %d", len(result["/project"]))
+	}
+
+	info := result["/project"][0]
+	if info.Kind != TerminalApp {
+		t.Errorf("expected kind %q, got %q", TerminalApp, info.Kind)
+	}
+	if info.ShellPID != 200 {
+		t.Errorf("expected ShellPID 200, got %d", info.ShellPID)
+	}
+	if info.RootPID != 100 {
+		t.Errorf("expected RootPID 100, got %d", info.RootPID)
+	}
+}
+
+func TestDetect_ShellWithoutTerminalParent(t *testing.T) {
+	// A shell spawned by an IDE (code / VS Code) should NOT be detected.
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "code"},
+			{PID: 200, PPID: 100, Name: "bash", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 terminals, got %d", len(result))
+	}
+}
+
+func TestDetect_MultipleShellsSameEmulator(t *testing.T) {
+	// Two shells under the same Terminal.app should deduplicate to one entry.
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "zsh", Cwd: "/project"},
+			{PID: 300, PPID: 100, Name: "bash", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result["/project"]) != 1 {
+		t.Fatalf("expected 1 terminal (deduplicated), got %d", len(result["/project"]))
+	}
+}
+
+func TestDetect_DifferentWorktrees(t *testing.T) {
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "zsh", Cwd: "/project-a"},
+			{PID: 50, PPID: 1, Name: "iTerm2"},
+			{PID: 300, PPID: 50, Name: "fish", Cwd: "/project-b"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project-a", "/project-b"})
+
+	if len(result["/project-a"]) != 1 {
+		t.Fatalf("expected 1 terminal for project-a, got %d", len(result["/project-a"]))
+	}
+	if result["/project-a"][0].Kind != TerminalApp {
+		t.Errorf("expected Terminal for project-a, got %s", result["/project-a"][0].Kind)
+	}
+
+	if len(result["/project-b"]) != 1 {
+		t.Fatalf("expected 1 terminal for project-b, got %d", len(result["/project-b"]))
+	}
+	if result["/project-b"][0].Kind != ITerm2 {
+		t.Errorf("expected iTerm2 for project-b, got %s", result["/project-b"][0].Kind)
+	}
+}
+
+func TestDetect_EmptyCWDSkipped(t *testing.T) {
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "zsh", Cwd: ""},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 terminals, got %d", len(result))
+	}
+}
+
+func TestDetect_NoShells(t *testing.T) {
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "node"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d entries", len(result))
+	}
+}
+
+func TestDetect_DeepPPIDChain(t *testing.T) {
+	// Shell → login → Terminal (2 hops up).
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "login"},
+			{PID: 300, PPID: 200, Name: "bash", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result["/project"]) != 1 {
+		t.Fatalf("expected 1 terminal via deep chain, got %d", len(result["/project"]))
+	}
+	if result["/project"][0].RootPID != 100 {
+		t.Errorf("expected RootPID 100, got %d", result["/project"][0].RootPID)
+	}
+}
+
+func TestDetect_PPIDCycleProtection(t *testing.T) {
+	// Process with PPID pointing to itself should not cause infinite loop.
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 100, PPID: 100, Name: "zsh", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	// Should not panic; no terminal emulator found.
+	if len(result) != 0 {
+		t.Errorf("expected 0 terminals for self-referencing PPID, got %d", len(result))
+	}
+}
+
+func TestDetectFromProcesses(t *testing.T) {
+	procs := []process.Info{
+		{PID: 1, Name: "launchd"},
+		{PID: 100, PPID: 1, Name: "Terminal"},
+		{PID: 200, PPID: 100, Name: "zsh", Cwd: "/project"},
+		{PID: 300, PPID: 100, Name: "bash", Cwd: "/other"},
+	}
+
+	d := NewDetector() // lister not used when calling DetectFromProcesses
+	result := d.DetectFromProcesses(procs, []string{"/project", "/other"})
+
+	if len(result["/project"]) != 1 {
+		t.Fatalf("expected 1 terminal for /project, got %d", len(result["/project"]))
+	}
+	if len(result["/other"]) != 1 {
+		t.Fatalf("expected 1 terminal for /other, got %d", len(result["/other"]))
+	}
+}
+
+func TestDetect_ITerm2BeforeTerminal(t *testing.T) {
+	// Ensure iTerm2 is matched before the broad "terminal" pattern.
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "iTerm2"},
+			{PID: 200, PPID: 100, Name: "zsh", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result["/project"]) != 1 {
+		t.Fatalf("expected 1 terminal, got %d", len(result["/project"]))
+	}
+	if result["/project"][0].Kind != ITerm2 {
+		t.Errorf("expected iTerm2, got %s", result["/project"][0].Kind)
+	}
+}
+
+func TestDetect_MultipleEmulatorsForSameWorktree(t *testing.T) {
+	// Two different terminal emulators both with shells in the same worktree.
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "zsh", Cwd: "/project"},
+			{PID: 50, PPID: 1, Name: "iTerm2"},
+			{PID: 300, PPID: 50, Name: "bash", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	// Two different root PIDs = two entries.
+	if len(result["/project"]) != 2 {
+		t.Fatalf("expected 2 terminals (different emulators), got %d", len(result["/project"]))
+	}
+}
+
+func TestIsShell(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"bash", true},
+		{"zsh", true},
+		{"fish", true},
+		{"pwsh", true},
+		{"powershell", true},
+		{"-bash", true},  // login shell (macOS style)
+		{"-zsh", true},   // login shell (macOS style)
+		{"node", false},
+		{"code", false},
+		{"claude", false},
+		{"vim", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isShell(tt.name); got != tt.want {
+				t.Errorf("isShell(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWalkToEmulator(t *testing.T) {
+	byPID := map[int32]process.Info{
+		1:   {PID: 1, PPID: 0, Name: "launchd"},
+		100: {PID: 100, PPID: 1, Name: "Terminal"},
+		200: {PID: 200, PPID: 100, Name: "login"},
+	}
+
+	// Walk from login → Terminal (1 hop).
+	kind, pid, found := walkToEmulator(200, byPID)
+	if !found {
+		t.Fatal("expected to find emulator")
+	}
+	if kind != TerminalApp {
+		t.Errorf("expected Terminal, got %s", kind)
+	}
+	if pid != 100 {
+		t.Errorf("expected PID 100, got %d", pid)
+	}
+
+	// Walk from a PID with no terminal ancestor.
+	_, _, found = walkToEmulator(1, byPID)
+	if found {
+		t.Error("expected no emulator from launchd ancestry")
+	}
+}
+
+func TestWalkToEmulator_UnknownPPID(t *testing.T) {
+	// Shell whose parent PID doesn't exist in the map.
+	byPID := map[int32]process.Info{
+		1: {PID: 1, PPID: 0, Name: "launchd"},
+	}
+
+	_, _, found := walkToEmulator(999, byPID)
+	if found {
+		t.Error("expected no emulator for unknown PPID")
+	}
+}
+
+func TestDetect_CWDMismatch(t *testing.T) {
+	// Shell under a terminal emulator but CWD doesn't match any worktree.
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "zsh", Cwd: "/other-project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 terminals (CWD mismatch), got %d", len(result))
+	}
+}
+
+func TestDetect_LinuxEmulators(t *testing.T) {
+	tests := []struct {
+		emulatorName string
+		wantKind     Kind
+	}{
+		{"gnome-terminal-server", GnomeTerminal},
+		{"konsole", Konsole},
+		{"alacritty", Alacritty},
+		{"kitty", Kitty},
+		{"wezterm-gui", WezTerm},
+		{"tilix", Tilix},
+		{"xfce4-terminal", Xfce4Terminal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.emulatorName, func(t *testing.T) {
+			lister := &mockLister{
+				procs: []process.Info{
+					{PID: 1, Name: "systemd"},
+					{PID: 100, PPID: 1, Name: tt.emulatorName},
+					{PID: 200, PPID: 100, Name: "bash", Cwd: "/project"},
+				},
+			}
+
+			d := NewDetectorWithLister(lister)
+			result := d.Detect([]string{"/project"})
+
+			if len(result["/project"]) != 1 {
+				t.Fatalf("expected 1 terminal for %s, got %d", tt.emulatorName, len(result["/project"]))
+			}
+			if result["/project"][0].Kind != tt.wantKind {
+				t.Errorf("expected kind %s, got %s", tt.wantKind, result["/project"][0].Kind)
+			}
+		})
+	}
+}
+
+func TestDetect_NoProcesses(t *testing.T) {
+	lister := &mockLister{
+		procs: []process.Info{},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result) != 0 {
+		t.Errorf("expected empty result for no processes, got %d", len(result))
+	}
+}
+
+func TestDetect_NoWorktreePaths(t *testing.T) {
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "zsh", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{})
+
+	if len(result) != 0 {
+		t.Errorf("expected empty result for no worktree paths, got %d", len(result))
+	}
+}
+
+func TestDetect_PathNormalization(t *testing.T) {
+	// Worktree path with trailing slash should still match.
+	lister := &mockLister{
+		procs: []process.Info{
+			{PID: 1, Name: "launchd"},
+			{PID: 100, PPID: 1, Name: "Terminal"},
+			{PID: 200, PPID: 100, Name: "zsh", Cwd: "/project"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project/"})
+
+	if len(result["/project/"]) != 1 {
+		t.Fatalf("expected 1 terminal with path normalization, got %d", len(result["/project/"]))
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -9,6 +9,33 @@ import (
 	"strings"
 )
 
+// OpenWithTitle opens a new terminal window with a biomelab-specific window
+// title. The identifier (typically a branch name) is used to set the title
+// to "biomelab: <identifier>", making the window discoverable for later
+// activation via Activate().
+//
+// If identifier is empty, this behaves identically to Open.
+func OpenWithTitle(dir, command, identifier string) error {
+	if identifier == "" {
+		return Open(dir, command)
+	}
+	shellCmd, err := buildShellCmdWithTitle(dir, command, identifier)
+	if err != nil {
+		return err
+	}
+	if t := os.Getenv("BIOME_TERMINAL"); t != "" {
+		return openCustomRaw(t, shellCmd)
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return darwinOpenRaw(shellCmd)
+	case "linux":
+		return linuxOpenRaw(shellCmd)
+	default:
+		return fmt.Errorf("terminal: unsupported platform %s — set BIOME_TERMINAL", runtime.GOOS)
+	}
+}
+
 // Open opens a new terminal window.
 // If command is non-empty, the terminal runs that command.
 // If dir is non-empty, the terminal starts a shell in that directory.
@@ -100,6 +127,73 @@ func buildShellCmd(dir, command string) (string, error) {
 		return "cd " + shellQuote(dir) + "; exec $SHELL", nil
 	}
 	return "", fmt.Errorf("terminal: nothing to run (no dir or command)")
+}
+
+// buildShellCmdWithTitle wraps buildShellCmd and prepends an ANSI title escape.
+// If identifier is empty, no title is prepended.
+func buildShellCmdWithTitle(dir, command, identifier string) (string, error) {
+	base, err := buildShellCmd(dir, command)
+	if err != nil {
+		return "", err
+	}
+	if identifier == "" {
+		return base, nil
+	}
+	return titleEscape(identifier) + base, nil
+}
+
+// titleEscape returns a printf command that sets the terminal window title
+// via the standard OSC (Operating System Command) escape sequence.
+func titleEscape(identifier string) string {
+	return fmt.Sprintf("printf '\\033]0;biomelab: %s\\007'; ", identifier)
+}
+
+// openCustomRaw launches a user-specified terminal with a pre-built shell command.
+func openCustomRaw(terminal, shellCmd string) error {
+	cmd := exec.Command(terminal, "-e", "sh", "-c", shellCmd)
+	cmd.Stderr = os.Stderr
+	return cmd.Start()
+}
+
+// darwinOpenRaw writes a pre-built shell command to a .command file and opens it.
+func darwinOpenRaw(shellCmd string) error {
+	f, err := os.CreateTemp("", "biomelab-*.command")
+	if err != nil {
+		return fmt.Errorf("terminal: create temp file: %w", err)
+	}
+	path := f.Name()
+
+	script := "#!/bin/bash\nrm -f " + shellQuote(path) + "\n" + shellCmd + "\n"
+	if _, err := f.WriteString(script); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("terminal: write temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("terminal: close temp file: %w", err)
+	}
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("terminal: chmod temp file: %w", err)
+	}
+
+	cmd := exec.Command("open", filepath.Clean(path))
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// linuxOpenRaw launches x-terminal-emulator with a pre-built shell command.
+func linuxOpenRaw(shellCmd string) error {
+	const term = "x-terminal-emulator"
+	if _, err := exec.LookPath(term); err != nil {
+		return fmt.Errorf("terminal: %s not found — set BIOME_TERMINAL", term)
+	}
+
+	cmd := exec.Command(term, "-e", "sh", "-c", shellCmd)
+	cmd.Stderr = os.Stderr
+	return cmd.Start()
 }
 
 // shellQuote wraps a string in single quotes for safe shell use.

--- a/internal/terminal/terminals.go
+++ b/internal/terminal/terminals.go
@@ -1,0 +1,74 @@
+package terminal
+
+import "github.com/mdelapenya/biomelab/internal/process"
+
+// Kind identifies a terminal emulator.
+type Kind string
+
+const (
+	TerminalApp     Kind = "Terminal"
+	ITerm2          Kind = "iTerm2"
+	Alacritty       Kind = "Alacritty"
+	Kitty           Kind = "kitty"
+	WezTerm         Kind = "WezTerm"
+	GnomeTerminal   Kind = "gnome-terminal"
+	Konsole         Kind = "Konsole"
+	Tilix           Kind = "Tilix"
+	Xfce4Terminal   Kind = "xfce4-terminal"
+	Hyper           Kind = "Hyper"
+	WindowsTerminal Kind = "Windows Terminal"
+)
+
+// ShellPatterns lists substrings that identify interactive shell processes.
+// We don't care which shell it is — only that it is a shell.
+var ShellPatterns = []string{"bash", "zsh", "fish", "pwsh", "powershell"}
+
+// processPattern pairs a Kind with the process-name substrings that identify it.
+type processPattern struct {
+	Kind     Kind
+	Patterns []string
+}
+
+// EmulatorPatterns lists terminal emulators and their process-name substrings.
+// Order matters: more specific patterns must appear before broader ones
+// (e.g. "iterm2" before "terminal") to prevent mis-classification.
+var EmulatorPatterns = []processPattern{
+	{ITerm2, []string{"iterm2"}},
+	{Alacritty, []string{"alacritty"}},
+	{Kitty, []string{"kitty"}},
+	{WezTerm, []string{"wezterm"}},
+	{GnomeTerminal, []string{"gnome-terminal"}},
+	{Konsole, []string{"konsole"}},
+	{Tilix, []string{"tilix"}},
+	{Xfce4Terminal, []string{"xfce4-terminal"}},
+	{Hyper, []string{"hyper"}},
+	{WindowsTerminal, []string{"windowsterminal", "windows terminal"}},
+	// TerminalApp must come last: "terminal" is a broad pattern that could
+	// match emulators whose name contains the word (e.g. gnome-terminal).
+	{TerminalApp, []string{"terminal"}},
+}
+
+// Info holds information about a detected terminal session.
+type Info struct {
+	Kind     Kind  // which terminal emulator
+	ShellPID int32 // PID of the shell process (bash/zsh/fish)
+	RootPID  int32 // PID of the terminal emulator process
+}
+
+// DetectionResult maps absolute worktree paths to detected terminal sessions.
+type DetectionResult map[string][]Info
+
+// Detector finds terminal shell processes and matches them to worktree paths.
+type Detector struct {
+	lister process.Lister
+}
+
+// NewDetector creates a Detector using real system processes.
+func NewDetector() *Detector {
+	return &Detector{lister: &process.OSLister{}}
+}
+
+// NewDetectorWithLister creates a Detector with a custom process lister (for testing).
+func NewDetectorWithLister(lister process.Lister) *Detector {
+	return &Detector{lister: lister}
+}


### PR DESCRIPTION
## What's changed

Add terminal detection and smart activation to biomelab. Pressing Enter on a worktree card now brings an existing terminal to the foreground instead of always opening a new one. If no terminal is detected, a new one opens as before.

Terminal sessions are detected using the same process-scanning infrastructure as agents and IDEs — shell processes (bash, zsh, fish, pwsh) are matched by walking their PPID chain upward to find a known terminal emulator ancestor (Terminal.app, iTerm2, Alacritty, kitty, WezTerm, gnome-terminal, Konsole, and more), then matching the shell's working directory to worktree paths.

## Why is this important?

When managing many worktrees with AI agents, developers accumulate dozens of terminal windows. Opening a new one on every Enter press forces users to hunt through windows to find the right one — significant cognitive overhead. The activate-or-open behavior reduces this by reusing existing terminals, making the Enter key a reliable "take me there" action.

## Changes

### Terminal detection (`internal/terminal/`)
- **`terminals.go`**: Kind enum for 11 terminal emulators, shell name patterns, `Info`/`DetectionResult` types, `Detector` struct
- **`detect.go`**: `DetectFromProcesses` — filters shells by name, walks PPID chain to emulator ancestors, matches CWD to worktree paths, deduplicates by `(path, rootPID)`
- **`activate.go`**: `ActivateByPID` resolves shell PID → TTY via `lsof`, then uses AppleScript to find the Terminal.app/iTerm2 tab with that `tty` property. Linux uses `xdotool search --pid`. `ActivateApp` fallback brings the terminal app to front generically
- **`terminal.go`**: `OpenWithTitle` injects an ANSI title escape (`\033]0;biomelab: <branch>\007`) for visual identification in new terminals

### Refresh cycle integration (`internal/ops/`, `internal/gui/`)
- Terminal detector added to `RefreshManager`, `LocalRefresh`, `NetworkRefresh`, and `CardRefresh` — shares the single process snapshot with agent/IDE detectors (no extra overhead)
- `Terminals` field added to `RefreshResult` and `RepoState`
- `handleEnter` now checks detection state first: activate by TTY → fallback to app activation → open new

### Card rendering
- Grid cards: purple `▶ Terminal (PID xxx)` / `▷ no terminal` line after IDE status
- Kanban cards: compact `▶ Terminal` row when detected

### Documentation
- **README.md**: Terminal detection feature, updated Enter key behavior, macOS Automation permission note
- **Product Owner skill**: Terminal concept, Feature 8 rewrite (activate-or-open), Feature 10b (terminal detection), DL-007 revision, DL-023 (TTY-based activation), DL-024 (PPID-walk filtering)

### Tests (32 test cases)
- `detect_test.go`: Shell+parent matching, IDE-shell filtering, deduplication, deep PPID chains, cycle protection, iTerm2 priority, 7 Linux emulators, path normalization, `isShell`/`walkToEmulator` helpers
- `activate_test.go`: Title format, ANSI escape, `buildShellCmd`, `shellQuote`, `darwinAppNames` coverage

## Test plan

- [ ] `task test-race` — all tests pass (32 new terminal tests + existing suite)
- [ ] `task lint` — zero issues
- [ ] Manual: open app, select worktree, press Enter → terminal opens with `biomelab: <branch>` in title
- [ ] Wait for refresh (~5s) → card shows `▶ Terminal (PID xxx)` in purple
- [ ] Press Enter again → existing terminal comes to front (no new window)
- [ ] Close terminal, wait for refresh → card shows `▷ no terminal`
- [ ] Press Enter → new terminal opens
- [ ] Grant macOS Automation permission on first AppleScript prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
