### PR TITLE
fix(build): support Windows for `task install` via gvm GOROOT resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,10 @@ For internal architecture, design decisions, and state machines, see [ARCHITECTU
 Fyne requires CGo and system graphics libraries.
 
 ```
-# Linux prerequisites
-sudo apt install gcc libgl1-mesa-dev xorg-dev
+# Prerequisites — install a C toolchain
+#   macOS:    xcode-select --install
+#   Linux:    sudo apt install gcc libgl1-mesa-dev xorg-dev
+#   Windows:  scoop install gcc    (or MSYS2: pacman -S mingw-w64-ucrt-x86_64-gcc)
 
 # Build and test
 task build        # Build to bin/biomelab (CGO_ENABLED=1)

--- a/README.md
+++ b/README.md
@@ -73,15 +73,19 @@ Or download from the [releases page](https://github.com/mdelapenya/biomelab/rele
 
 ### From source
 
+Requires [Git](https://git-scm.com/), [Task](https://taskfile.dev/), and a C toolchain (Fyne uses CGO). Everything else — `gvm`, the Go toolchain, and the `fyne` CLI — is bootstrapped by `task setup` / `task setup-fyne`.
+
 ```bash
-# Linux prerequisites
-sudo apt install gcc libgl1-mesa-dev xorg-dev
+# Install a C toolchain for your OS
+#   macOS:    xcode-select --install
+#   Linux:    sudo apt install gcc libgl1-mesa-dev xorg-dev
+#   Windows:  scoop install gcc           (PowerShell; or MSYS2 / WinLibs)
 
 git clone https://github.com/mdelapenya/biomelab.git
 cd biomelab
 task build          # builds bin/biomelab
 task install        # installs to $GOPATH/bin
-task install-macos  # builds universal .app + installs to /Applications
+task install-macos  # builds universal .app + installs to /Applications (macOS only)
 ```
 
 ## Usage

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,10 +3,33 @@ version: '3'
 vars:
   GO_VERSION:
     sh: grep '^go ' go.mod | awk '{print $2}'
-  GO:
+  # GOROOT_GVM resolves the GOROOT for the requested Go version via gvm.
+  # On Windows, gvm --format=bash emits backslash paths that break in bash
+  # and Task shells, so we normalise to forward slashes.
+  GOROOT_GVM:
     sh: |
       if command -v gvm >/dev/null 2>&1; then
-        eval "$(gvm {{.GO_VERSION}})" >/dev/null 2>&1 && which go && exit 0
+        gvm_out=$(gvm --format=bash {{.GO_VERSION}} 2>/dev/null) || true
+        if [ -n "$gvm_out" ]; then
+          goroot=${gvm_out%%$'\n'*}
+          goroot=${goroot#export GOROOT=\"}
+          goroot=${goroot%\"}
+          goroot=${goroot//\\//}
+          echo "$goroot" && exit 0
+        fi
+      fi
+  GO:
+    sh: |
+      if [ -n "{{.GOROOT_GVM}}" ]; then
+        gobin="{{.GOROOT_GVM}}/bin/go"
+        if [ -f "$gobin.exe" ]; then gobin="$gobin.exe"; fi
+        # Prefix with GOROOT= so the correct toolchain is used even when a
+        # different GOROOT is already exported in the environment (Task's
+        # env: section does not override pre-existing variables).
+        if [ -x "$gobin" ] || [ -f "$gobin" ]; then
+          echo "GOROOT={{.GOROOT_GVM}} $gobin"
+          exit 0
+        fi
       fi
       echo go
   GOEXE:
@@ -28,6 +51,17 @@ tasks:
     desc: Install gvm if not present
     cmds:
       - task: install-gvm
+
+  require-cc:
+    desc: Ensure a C compiler is on PATH (required for CGO / Fyne)
+    internal: true
+    preconditions:
+      - sh: command -v gcc >/dev/null 2>&1 || command -v cc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1
+        msg: |
+          No C compiler found on PATH — required for CGO (Fyne).
+            macOS:   xcode-select --install
+            Linux:   sudo apt install gcc libgl1-mesa-dev xorg-dev
+            Windows: scoop install gcc   (or MSYS2: pacman -S mingw-w64-ucrt-x86_64-gcc)
 
   install-gvm:
     desc: Install gvm from prebuilt release binary (no Go required)
@@ -61,7 +95,7 @@ tasks:
 
   build:
     desc: Build the biomelab binary for the current platform
-    deps: [setup]
+    deps: [setup, require-cc]
     env:
       CGO_ENABLED: "1"
     cmds:
@@ -73,7 +107,7 @@ tasks:
 
   build-darwin-arm64:
     desc: Build for macOS arm64
-    deps: [setup]
+    deps: [setup, require-cc]
     env:
       CGO_ENABLED: "1"
       GOOS: darwin
@@ -83,7 +117,7 @@ tasks:
 
   build-darwin-amd64:
     desc: Build for macOS amd64
-    deps: [setup]
+    deps: [setup, require-cc]
     env:
       CGO_ENABLED: "1"
       GOOS: darwin
@@ -101,7 +135,7 @@ tasks:
 
   package:
     desc: Package biomelab for the current OS using fyne
-    deps: [setup, setup-fyne]
+    deps: [setup, setup-fyne, require-cc]
     env:
       CGO_ENABLED: "1"
       # Fyne's internal go build (used on Windows to inject PE resources) picks
@@ -158,7 +192,7 @@ tasks:
 
   test:
     desc: Run all tests
-    deps: [setup]
+    deps: [setup, require-cc]
     env:
       CGO_ENABLED: "1"
     cmds:
@@ -166,7 +200,7 @@ tasks:
 
   test-race:
     desc: Run all tests with race detector
-    deps: [setup]
+    deps: [setup, require-cc]
     env:
       CGO_ENABLED: "1"
     cmds:
@@ -174,7 +208,7 @@ tasks:
 
   install:
     desc: Install biomelab to $GOPATH/bin
-    deps: [setup]
+    deps: [setup, require-cc]
     env:
       CGO_ENABLED: "1"
     cmds:
@@ -182,7 +216,7 @@ tasks:
 
   lint:
     desc: Run golangci-lint v2
-    deps: [setup]
+    deps: [setup, require-cc]
     env:
       CGO_ENABLED: "1"
     cmds:


### PR DESCRIPTION
## Summary

- `task install` failed on Windows: gvm's bash output uses backslash paths and a subshell-eval pattern that didn't propagate `GOROOT` to Task. Resolve gvm's GOROOT explicitly, normalise path separators, and prefix the `go.exe` invocation so a stale environment `GOROOT` can't override it.
- Add a `require-cc` precondition (wired into every CGO task: `build`, `build-darwin-{arm64,amd64}`, `install`, `test`, `test-race`, `package`, `lint`) so a missing C toolchain fails fast with a per-OS install hint instead of a cryptic `cgo: C compiler "gcc" not found` error.
- Document the C-toolchain prerequisite for all three OSes in `README.md` (From source) and `CLAUDE.md`.

## Test plan

- [x] `task install` on Windows (Git Bash + Task 3.49.1 + gvm + `scoop install gcc`) → builds and installs `~/go/bin/biomelab.exe`, version `v0.3.0-nightly-10-gdf91d7b`
- [x] Precondition fires when gcc is removed from PATH: build aborts with the multi-line per-OS install hint
- [x] `task install` still works on macOS (clang via Xcode CLT)
- [x] `task install` still works on Linux (gcc via apt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)