### PR TITLE
feat(gui): pill-shaped count chips in repo panel and kanban headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
             task: package
             verify: |
               mkdir -p /tmp/verify
-              tar -xJf bin/Biomelab.tar.xz -C /tmp/verify
+              # fyne tools v1.7.1 wraps the tarball in a top-level
+              # directory (fyne-io/tools#105) — strip it.
+              tar -xJf bin/Biomelab.tar.xz -C /tmp/verify --strip-components=1
               /tmp/verify/usr/local/bin/biomelab --version
           - os: macos-latest
             task: package-darwin-universal

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,9 @@ jobs:
       - name: Verify Linux package
         run: |
           mkdir -p /tmp/verify
-          tar -xJf bin/Biomelab.tar.xz -C /tmp/verify
+          # fyne tools v1.7.1 wraps the tarball in a top-level
+          # directory (fyne-io/tools#105) — strip it.
+          tar -xJf bin/Biomelab.tar.xz -C /tmp/verify --strip-components=1
           /tmp/verify/usr/local/bin/biomelab --version
 
       - name: Prepare artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,9 @@ jobs:
       - name: Verify Linux package
         run: |
           mkdir -p /tmp/verify
-          tar -xJf bin/Biomelab.tar.xz -C /tmp/verify
+          # fyne tools v1.7.1 wraps the tarball in a top-level
+          # directory (fyne-io/tools#105) — strip it.
+          tar -xJf bin/Biomelab.tar.xz -C /tmp/verify --strip-components=1
           /tmp/verify/usr/local/bin/biomelab --version
 
       - name: Prepare artifact

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -88,10 +88,16 @@ tasks:
 
   setup-fyne:
     desc: Install the fyne CLI packaging tool
+    vars:
+      FYNE_VERSION: v1.7.1
     status:
       - command -v fyne
     cmds:
-      - '{{.GO}} install fyne.io/tools/cmd/fyne@latest'
+      # Pin the fyne CLI so packaging output (tarball layout, app
+      # bundle structure) is reproducible across CI and local builds.
+      # Bump deliberately and verify the verify steps in
+      # .github/workflows/{ci,nightly,release}.yml still match.
+      - '{{.GO}} install fyne.io/tools/cmd/fyne@{{.FYNE_VERSION}}'
 
   build:
     desc: Build the biomelab binary for the current platform

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -186,6 +186,7 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 		Provider: prov,
 	}
 	state.SetWorktrees(worktrees)
+	group.LinkedWorktreeCount = len(state.LinkedWorktrees())
 
 	var sbxCandidates []string
 	if len(entry.Modes) > 0 {
@@ -229,6 +230,20 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 				a.reconcileSandboxName(re, re.state.ActiveMode.SandboxName, result.SbxMatchedName)
 			}
 			re.dashboard.ApplyRefresh(result)
+
+			// Keep the left-panel worktree count in sync with refresh
+			// results so users see "tasks in flight" without opening
+			// the dashboard.
+			if result.Worktrees != nil {
+				newCount := max(len(result.Worktrees)-1, 0)
+				if newCount != re.group.LinkedWorktreeCount {
+					re.group.LinkedWorktreeCount = newCount
+					if a.repoPanel != nil {
+						a.repoPanel.rebuildList()
+					}
+				}
+			}
+
 			if result.AllSbxStatuses != nil {
 				for k, v := range result.AllSbxStatuses {
 					a.sbxStatuses[k] = v

--- a/internal/gui/card.go
+++ b/internal/gui/card.go
@@ -310,6 +310,20 @@ func makeBadge(text string) fyne.CanvasObject {
 	return container.NewStack(bg, container.NewPadded(label))
 }
 
+// countChip renders an integer as a pill-shaped badge with a tinted
+// background. Used in the repo panel and kanban headers to surface counts at
+// a glance.
+func countChip(n int, bgColor color.Color) fyne.CanvasObject {
+	bg := canvas.NewRectangle(bgColor)
+	bg.CornerRadius = 8
+
+	label := monoText(fmt.Sprintf("%d", n), colorForeground, true)
+	label.TextSize = scaledSize(10)
+	label.Alignment = fyne.TextAlignCenter
+
+	return container.NewStack(bg, container.NewPadded(label))
+}
+
 // monoText creates a monospace canvas.Text with the given color and bold state.
 func monoText(text string, c color.Color, bold bool) *canvas.Text {
 	t := canvas.NewText(text, c)

--- a/internal/gui/kanban.go
+++ b/internal/gui/kanban.go
@@ -333,13 +333,16 @@ func (d *Dashboard) buildKanbanView() fyne.CanvasObject {
 		accentColor := kanbanColumnColor(si)
 
 		// ── Header (pinned, stronger tint) ──────────────────────────────
-		headerText := fmt.Sprintf("%s  %d", kanbanColumnTitles[si], len(stageIndices))
-		headerLabel := monoText(headerText, accentColor, true)
-		headerLabel.TextSize = scaledSize(11)
+		// Title on the left, count chip on the right. Chip uses the
+		// column's accent color so it pops against the muted header bg.
+		titleLabel := monoText(kanbanColumnTitles[si], accentColor, true)
+		titleLabel.TextSize = scaledSize(11)
+
+		headerRow := container.NewBorder(nil, nil, nil, countChip(len(stageIndices), accentColor), titleLabel)
 
 		headerBg := canvas.NewRectangle(kanbanColumnHeaderBgColor(si))
 		headerBg.CornerRadius = 4
-		header := container.NewStack(headerBg, container.NewPadded(headerLabel))
+		header := container.NewStack(headerBg, container.NewPadded(headerRow))
 		headerSection := container.NewVBox(header, widget.NewSeparator())
 
 		// ── Cards (vertically scrollable, width-constrained) ─────────────

--- a/internal/gui/repo_panel.go
+++ b/internal/gui/repo_panel.go
@@ -13,10 +13,11 @@ import (
 
 // RepoGroup represents a registered repository with its modes.
 type RepoGroup struct {
-	Path       string
-	Name       string
-	Modes      []config.ModeEntry
-	ActiveMode int
+	Path                string
+	Name                string
+	Modes               []config.ModeEntry
+	ActiveMode          int
+	LinkedWorktreeCount int
 }
 
 // RepoPanel is the left panel showing the repository/mode list.
@@ -104,12 +105,24 @@ func (rp *RepoPanel) rebuildList() {
 		}
 
 		// Repo header (not clickable) — bold + foreground color for
-		// strong visual hierarchy over the mode sub-items.
-		header := monoText(group.Name, colorForeground, true)
-		header.TextSize = scaledSize(12)
+		// strong visual hierarchy over the mode sub-items. The optional
+		// linked-worktree count surfaces "tasks in flight" at a glance.
+		// truncMonoText (instead of monoText) shrinks long repo names to
+		// fit, so a narrow panel never triggers a horizontal scrollbar
+		// that would push the chip off-screen.
+		header := newTruncMonoText(group.Name, colorForeground, true, false)
+		header.txt.TextSize = scaledSize(12)
 		topGap := canvas.NewRectangle(colorPanelBg)
 		topGap.SetMinSize(fyne.NewSize(0, 4))
-		rp.list.Add(container.NewVBox(topGap, header))
+
+		var headerRow fyne.CanvasObject = header
+		if group.LinkedWorktreeCount > 0 {
+			// Chip on the right edge, header in the center so the chip
+			// claims its natural width first and the header truncates
+			// into whatever space is left.
+			headerRow = container.NewBorder(nil, nil, nil, worktreeCountChip(group.LinkedWorktreeCount), header)
+		}
+		rp.list.Add(container.NewVBox(topGap, headerRow))
 
 		// Mode entries (clickable).
 		for mi, mode := range group.Modes {
@@ -184,4 +197,13 @@ func (rp *RepoPanel) buildModeLine(mode config.ModeEntry, isActive bool) fyne.Ca
 		return container.NewStack(bg, container.NewPadded(row))
 	}
 	return row
+}
+
+// worktreeCountChip renders the linked-worktree count as a pill-shaped badge
+// aligned to the right edge of the repo header. The trailing spacer keeps the
+// chip away from the panel/scrollbar edge.
+func worktreeCountChip(n int) fyne.CanvasObject {
+	rightPad := canvas.NewRectangle(colorPanelBg)
+	rightPad.SetMinSize(fyne.NewSize(8, 0))
+	return container.NewHBox(countChip(n, colorSelection), rightPad)
 }


### PR DESCRIPTION
## What's changed

The left repo panel now shows the linked-worktree count for each repository as a pill-shaped chip on the right edge of the repo header. The count is populated on initial load and refreshed live by the existing `OnRefresh` callback, so users see "tasks in flight" without opening a dashboard.

The kanban dashboard's column headers now use the same chip style, surfacing the per-stage worktree count with the column's accent color instead of inline `Title  N` text.

The repo-name label was switched from `monoText` to `truncMonoText` so long repository names shrink to fit the panel width. Without this, a narrow panel triggered a horizontal scrollbar that pushed the chip off-screen.

## Why is this important?

Managing multiple repositories at once is the core biomelab workflow, but until now the left panel only listed repo names. Users had to switch into each dashboard to see how many worktrees were active. Surfacing the count on the always-visible left panel turns the repo list into a real overview of work in flight, and keeping the same chip style on the kanban columns gives the GUI a consistent visual language for counts.

## Changes

- `internal/gui/repo_panel.go` — add `LinkedWorktreeCount` to `RepoGroup`; render a pill chip in the header when count > 0; switch the repo name to `truncMonoText` so it shrinks instead of overflowing.
- `internal/gui/app.go` — populate the count from initial `state.LinkedWorktrees()` and update it inside the `OnRefresh` callback (panel only rebuilds when the count actually changes).
- `internal/gui/card.go` — extract a generic `countChip(n, bgColor)` helper next to `makeBadge`.
- `internal/gui/kanban.go` — split the column header into a title + `countChip` tinted with the column's accent color.

## Test plan

- [ ] Open biomelab with a repo that has linked worktrees; verify the chip on the repo header shows the correct count.
- [ ] Add or remove a worktree externally and wait for the next refresh tick; the chip count updates automatically.
- [ ] Narrow the window so the left panel is small; verify long repo names truncate with an ellipsis and the chip stays visible at the right edge (no horizontal scrollbar).
- [ ] Open the kanban view; verify each column header shows a pill-shaped count chip in the column's accent color.
