### PR TITLE
feat(config): show config in systray menu

### DIFF
--- a/internal/gui/systray.go
+++ b/internal/gui/systray.go
@@ -1,8 +1,16 @@
 package gui
 
 import (
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/driver/desktop"
+
+	"github.com/mdelapenya/biomelab/internal/config"
 )
 
 // setupSystemTray creates a system tray icon with Show/Hide toggle, Theme
@@ -37,10 +45,17 @@ func (a *App) setupSystemTray() {
 	themeItem := fyne.NewMenuItem("Theme", nil)
 	themeItem.ChildMenu = fyne.NewMenu("", a.trayThemeLight, a.trayThemeDark)
 
+	configItem := fyne.NewMenuItem("Show Config", func() {
+		if err := a.openConfigFile(); err != nil {
+			dialog.ShowError(err, a.window)
+		}
+	})
+
 	a.trayMenu = fyne.NewMenu("biomelab",
 		toggleItem,
 		fyne.NewMenuItemSeparator(),
 		themeItem,
+		configItem,
 		fyne.NewMenuItemSeparator(),
 		fyne.NewMenuItem("Quit", func() {
 			a.stopAllRefresh()
@@ -56,6 +71,32 @@ func (a *App) setupSystemTray() {
 		toggleItem.Label = "Show"
 		desk.SetSystemTrayMenu(a.trayMenu)
 	})
+}
+
+// openConfigFile opens the config file with the system's default application.
+// If the file does not exist yet (fresh install), an empty config is written
+// first so the editor has something to open.
+func (a *App) openConfigFile() error {
+	if _, err := os.Stat(a.configPath); errors.Is(err, os.ErrNotExist) {
+		if err := config.Save(a.configPath, &config.Config{}); err != nil {
+			return err
+		}
+	}
+	return openInSystem(a.configPath)
+}
+
+// openInSystem opens path with the OS default handler.
+func openInSystem(path string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", path)
+	default:
+		cmd = exec.Command("xdg-open", path)
+	}
+	return cmd.Start()
 }
 
 func (a *App) stopAllRefresh() {


### PR DESCRIPTION
## What's changed

Adds a "Show Config" item to the system tray menu (between the Theme submenu and Quit) that opens `repos.json` in the OS default application — Finder/TextEdit on macOS, the registered handler on Windows, `xdg-open` elsewhere.

If the config file doesn't exist yet (fresh install with no repos added), an empty config is written first so the editor has something to open. Errors surface through `dialog.ShowError`.

## Why is this important?

The config file lives at `~/.config/biomelab/repos.json` and users currently have to locate and open it through the file manager or a terminal to inspect or hand-edit it. Surfacing it from the tray makes the file discoverable and one click away — useful for debugging, manual tweaks, and sharing setups.

## Changes

- `internal/gui/systray.go`: new `Show Config` menu item; `openConfigFile` ensures the file exists before opening; `openInSystem` dispatches to `open` (darwin), `rundll32 url.dll,FileProtocolHandler` (windows), or `xdg-open` (other).
