### PR TITLE
feat(sbx): show how to install sbx

### DIFF
--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -1,12 +1,14 @@
 package gui
 
 import (
+	"net/url"
 	"time"
 
 	"fyne.io/fyne/v2"
 	fyneapp "fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/widget"
 
@@ -56,6 +58,11 @@ type App struct {
 	termDetector    *terminal.Detector
 	procLister      process.Lister
 	refreshInterval time.Duration
+
+	// warnSbxMissing is set during buildContent when at least one configured
+	// repo uses sandbox mode but the sbx CLI is not on PATH. Run() shows a
+	// one-shot informational dialog after the window appears.
+	warnSbxMissing bool
 
 	focus        focusPanel
 	dialogOpen   bool
@@ -121,7 +128,27 @@ func (a *App) Run() {
 	// SetCloseIntercept is set inside setupSystemTray.
 	a.setupSystemTray()
 
+	if a.warnSbxMissing {
+		// fyne.Do queues onto the UI thread; the queued work fires once
+		// ShowAndRun starts the event loop, so the dialog appears over the
+		// freshly painted window.
+		go fyne.Do(a.showSbxMissingDialog)
+	}
+
 	a.window.ShowAndRun()
+}
+
+func (a *App) showSbxMissingDialog() {
+	installURL, _ := url.Parse(sbxInstallURL)
+	content := container.NewVBox(
+		widget.NewLabel("One or more configured repositories use sandbox mode,"),
+		widget.NewLabel("but the sbx CLI was not found in PATH."),
+		widget.NewLabel("Sandbox actions will fail until you install it."),
+		widget.NewHyperlink("Install sbx", installURL),
+	)
+	d := dialog.NewCustom("Sandbox CLI Missing", "OK", content, a.window)
+	d.Resize(dialogMinSize)
+	d.Show()
 }
 
 func (a *App) buildContent() fyne.CanvasObject {
@@ -136,6 +163,18 @@ func (a *App) buildContent() fyne.CanvasObject {
 		statusMap := sandbox.CheckAllStatuses()
 		for k, v := range statusMap {
 			a.sbxStatuses[k] = v
+		}
+	} else {
+		for _, entry := range cfg.Repos {
+			for _, m := range entry.Modes {
+				if m.Type == "sandbox" {
+					a.warnSbxMissing = true
+					break
+				}
+			}
+			if a.warnSbxMissing {
+				break
+			}
 		}
 	}
 

--- a/internal/gui/input_dialogs.go
+++ b/internal/gui/input_dialogs.go
@@ -1,11 +1,17 @@
 package gui
 
 import (
+	"net/url"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
+
+	"github.com/mdelapenya/biomelab/internal/sandbox"
 )
+
+const sbxInstallURL = "https://docs.docker.com/ai/sandboxes/"
 
 func showBranchInput(parent fyne.Window, onDone func(), onSubmit func(name string)) dialog.Dialog {
 	entry := widget.NewEntry()
@@ -70,17 +76,30 @@ func showAddRepoInput(parent fyne.Window, onDone func(), onSubmit func(path stri
 func showModeSelection(parent fyne.Window, onDone func(), onRegular func(), onSandbox func()) dialog.Dialog {
 	var d dialog.Dialog
 
+	sbxAvailable := sandbox.Available()
+	sbxBtn := widget.NewButton("Sandbox (recommended)", func() {
+		d.Hide()
+		onSandbox()
+	})
+
 	content := container.NewVBox(
 		widget.NewLabel("Select mode:"),
-		widget.NewButton("Sandbox (recommended)", func() {
-			d.Hide()
-			onSandbox()
-		}),
-		widget.NewButton("Regular (host)", func() {
-			d.Hide()
-			onRegular()
-		}),
+		sbxBtn,
 	)
+
+	if !sbxAvailable {
+		sbxBtn.Disable()
+		installURL, _ := url.Parse(sbxInstallURL)
+		content.Add(container.NewHBox(
+			widget.NewLabel("sbx CLI not found in PATH —"),
+			widget.NewHyperlink("install sbx", installURL),
+		))
+	}
+
+	content.Add(widget.NewButton("Regular (host)", func() {
+		d.Hide()
+		onRegular()
+	}))
 
 	d = dialog.NewCustom("Select Mode", "Cancel", content, parent)
 	d.SetOnClosed(func() {

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -826,6 +826,9 @@ func (a *App) handleCreateOrEnrollSandbox() {
 	}
 
 	// Non-sandbox → enroll by asking for agent name.
+	if !a.requireSbxInstalled() {
+		return
+	}
 	done := a.openDialog()
 	showAgentInput(a.window, done, func(agentName string) {
 		sbxName := sandbox.SanitizeName(re.group.Name, agentName)
@@ -834,7 +837,7 @@ func (a *App) handleCreateOrEnrollSandbox() {
 			err := sandbox.Preflight()
 			fyne.Do(func() {
 				if err != nil {
-					a.setStatus("Sandbox not ready — run: sbx ls", true)
+					a.setStatus(err.Error(), true)
 					return
 				}
 				cfg, _ := config.Load(a.configPath)
@@ -859,9 +862,24 @@ func (a *App) handleCreateOrEnrollSandbox() {
 	})
 }
 
+// requireSbxInstalled returns true if the sbx CLI is on PATH; otherwise it
+// reports the canonical install message via setStatus and returns false.
+// Use it to short-circuit flows that would otherwise open an agent picker
+// only to fail at Preflight.
+func (a *App) requireSbxInstalled() bool {
+	if sandbox.Available() {
+		return true
+	}
+	a.setStatus("sbx CLI not found in PATH — install it from "+sbxInstallURL, true)
+	return false
+}
+
 func (a *App) handleAddSandboxMode() {
 	re := a.activeRepo()
 	if re == nil {
+		return
+	}
+	if !a.requireSbxInstalled() {
 		return
 	}
 	done := a.openDialog()
@@ -872,7 +890,7 @@ func (a *App) handleAddSandboxMode() {
 			err := sandbox.Preflight()
 			fyne.Do(func() {
 				if err != nil {
-					a.setStatus("Sandbox not ready — run: sbx ls", true)
+					a.setStatus(err.Error(), true)
 					return
 				}
 				cfg, _ := config.Load(a.configPath)
@@ -894,7 +912,7 @@ func (a *App) doCreateSandboxWithPreflight(re *repoEntry, sbxName, sbxAgent, rep
 	go func() {
 		err := sandbox.Preflight()
 		if err != nil {
-			fyne.Do(func() { a.setStatus("Sandbox not ready — run: sbx ls", true) })
+			fyne.Do(func() { a.setStatus(err.Error(), true) })
 			return
 		}
 		args := sandbox.CreateArgs(sbxName, sbxAgent, repoPath)
@@ -938,7 +956,7 @@ func (a *App) handleAddRepo() {
 					err := sandbox.Preflight()
 					fyne.Do(func() {
 						if err != nil {
-							a.setStatus("Sandbox not ready — run: sbx ls", true)
+							a.setStatus(err.Error(), true)
 							return
 						}
 						a.addRepoToConfig(repoRoot, repo.RepoName(), mode)

--- a/internal/gui/systray.go
+++ b/internal/gui/systray.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"errors"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -51,11 +52,18 @@ func (a *App) setupSystemTray() {
 		}
 	})
 
+	sbxDocsItem := fyne.NewMenuItem("Docker Sandboxes docs", func() {
+		if u, err := url.Parse(sbxInstallURL); err == nil {
+			_ = a.fyneApp.OpenURL(u)
+		}
+	})
+
 	a.trayMenu = fyne.NewMenu("biomelab",
 		toggleItem,
 		fyne.NewMenuItemSeparator(),
 		themeItem,
 		configItem,
+		sbxDocsItem,
 		fyne.NewMenuItemSeparator(),
 		fyne.NewMenuItem("Quit", func() {
 			a.stopAllRefresh()


### PR DESCRIPTION
## What's changed

biomelab uses the `sbx` CLI under the hood for sandbox-mode worktrees, but
previously did nothing to surface its absence on the host. The user only
discovered the problem after going through dialogs that ultimately failed at
preflight with a generic message.

This PR adds four touchpoints that detect a missing or non-bootstrapped
`sbx` and tell the user exactly what to do, plus a tray-menu shortcut to the
official docs.

## Why is this important?

Sandbox mode is the recommended way to run agents, but it depends on a
separate CLI that biomelab cannot install for the user. Failing late and
with vague messaging made it look like biomelab itself was broken. Failing
early — and pointing at the install page — turns the problem into a
one-click fix.

## Changes

- **Startup warning** (`internal/gui/app.go`): if any configured repo uses
  sandbox mode but `sbx` is not on PATH, show a one-shot info dialog with a
  hyperlink to the install page after the window paints.
- **Surface real Preflight error** (`internal/gui/shortcuts.go`): all four
  preflight call sites now show the actual `sandbox.Preflight()` message
  ("not found in PATH" vs. "daemon not ready") instead of the canned
  "Sandbox not ready — run: sbx ls".
- **Gate Sandbox button on enroll** (`internal/gui/input_dialogs.go`): in
  `showModeSelection`, when `sbx` is missing the Sandbox button is disabled
  and an inline hyperlink to the install page is rendered below it.
- **Gate promote-to-sandbox at entry** (`internal/gui/shortcuts.go`): the
  enroll branch of `handleCreateOrEnrollSandbox` and `handleAddSandboxMode`
  short-circuit via a new `requireSbxInstalled()` helper, so the agent
  picker no longer opens when `sbx` is missing.
- **Tray entry for docs** (`internal/gui/systray.go`): new "Docker
  Sandboxes docs" item between the Theme submenu and Quit. Opens
  https://docs.docker.com/ai/sandboxes/ in the default browser.

The install URL is centralized as `sbxInstallURL` in
`internal/gui/input_dialogs.go` and reused from the startup dialog, the
mode-selection hyperlink, the preflight short-circuit message, and the
tray entry.

## Test plan

- [x] `task build` and `task install` succeed.
- [x] `task test` and `task lint` are green.
- [ ] On a host **without** `sbx` installed:
  - [ ] Launching biomelab against a config that has at least one sandbox
        mode shows the "Sandbox CLI Missing" dialog with a working
        "Install sbx" hyperlink.
  - [ ] Adding a new repo and choosing the mode shows the Sandbox button
        disabled with the install hyperlink visible.
  - [ ] Triggering enroll on a regular-mode repo immediately shows the
        install message in the status bar — no agent picker opens.
  - [ ] Triggering "add sandbox mode" behaves the same.
  - [ ] The system tray menu shows a "Docker Sandboxes docs" entry that
        opens the docs page in the default browser.
- [ ] On a host **with** `sbx` installed but the daemon stopped:
  - [ ] Triggering a sandbox action surfaces the real "sbx not ready —
        run 'sbx ls' …" error in the status bar.
- [ ] On a host **with** `sbx` installed and ready: existing flows are
      unchanged.
