### PR TITLE
feat(kits): support installing kits when creating a sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Launch `biomelab` from any directory, or open `Biomelab.app` from Spotlight/Find
 
 | Key | Action |
 |-----|--------|
-| `↑` / `k` | Previous mode |
-| `↓` / `j` | Next mode |
+| `↑` | Previous mode |
+| `↓` | Next mode |
 | `a` | Add repository |
 | `n` | New sandbox mode for selected repo |
 | `x` | Remove selected mode |
@@ -118,10 +118,10 @@ Launch `biomelab` from any directory, or open `Biomelab.app` from Spotlight/Find
 
 | Key | Action | Context |
 |-----|--------|---------|
-| `↑` / `k` | Navigate up (by row in grid) | Any card |
-| `↓` / `j` | Navigate down (by row in grid) | Any card |
-| `←` / `h` | Navigate left | Linked cards |
-| `→` / `l` | Navigate right | Linked cards |
+| `↑` | Navigate up (by row in grid) | Any card |
+| `↓` | Navigate down (by row in grid) | Any card |
+| `←` | Navigate left | Linked cards |
+| `→` | Navigate right | Linked cards |
 | `Enter` | Activate existing terminal or open new | Any card |
 | `e` | Open in editor | Any card |
 | `c` | Create worktree | Main card |
@@ -133,6 +133,7 @@ Launch `biomelab` from any directory, or open `Biomelab.app` from Spotlight/Find
 | `n` | Create/enroll sandbox | Main card |
 | `s` | Start stopped sandbox | Main card |
 | `Shift+S` | Stop running sandbox | Main card |
+| `k` | Pick kits → create (if missing) or recreate sandbox with `--kit` flags | Sandbox mode |
 | `Ctrl+=` | Zoom in | Global |
 | `Ctrl+-` | Zoom out | Global |
 | `Ctrl+0` | Reset zoom | Global |

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/go-git/go-billy/v6 v6.0.0-20260226131633-45bd0956d66f
 	github.com/go-git/go-git/v6 v6.0.0-20260320111621-ea91339c5263
 	github.com/shirou/gopsutil/v4 v4.26.2
+	golang.org/x/sync v0.19.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -57,8 +59,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/image v0.24.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,12 +7,22 @@ import (
 	"path/filepath"
 )
 
+// KitInstall records a kit applied to a sandbox at create time. Ref is the
+// short commit SHA of docker/sbx-kits-contrib captured the moment the kit
+// was installed — biomelab uses it as a "version" for display only; the
+// install URL itself is not pinned to that ref.
+type KitInstall struct {
+	Name string `json:"name"`          // kit directory in sbx-kits-contrib (e.g. "code-server")
+	Ref  string `json:"ref,omitempty"` // short SHA captured at install time
+}
+
 // ModeEntry describes how a repo is managed: regular (host worktrees) or
 // sandbox (Docker Sandbox via sbx CLI).
 type ModeEntry struct {
-	Type        string `json:"type"`                   // "regular" or "sandbox"
-	SandboxName string `json:"sandbox_name,omitempty"` // sbx sandbox name (sandbox only)
-	Agent       string `json:"agent,omitempty"`        // agent name (sandbox only, e.g. "claude")
+	Type        string       `json:"type"`                   // "regular" or "sandbox"
+	SandboxName string       `json:"sandbox_name,omitempty"` // sbx sandbox name (sandbox only)
+	Agent       string       `json:"agent,omitempty"`        // agent name (sandbox only, e.g. "claude")
+	Kits        []KitInstall `json:"kits,omitempty"`         // kits applied at create time (sandbox only)
 }
 
 // RepoEntry represents a registered repository with one or more modes.
@@ -238,6 +248,25 @@ func (c *Config) UpdateSandboxName(path, oldName, newName string) bool {
 		}
 	}
 	return changed
+}
+
+// SetSandboxKits replaces the recorded kits for a sandbox mode identified by
+// (repo path, sandbox name). Pass nil to clear. Returns true if a matching
+// mode was found and updated.
+func (c *Config) SetSandboxKits(path, sandboxName string, kits []KitInstall) bool {
+	for i := range c.Repos {
+		if c.Repos[i].Path != path {
+			continue
+		}
+		for j := range c.Repos[i].Modes {
+			m := &c.Repos[i].Modes[j]
+			if m.Type == "sandbox" && m.SandboxName == sandboxName {
+				m.Kits = kits
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Remove removes a repo entry by path (all modes).

--- a/internal/gui/card.go
+++ b/internal/gui/card.go
@@ -139,6 +139,15 @@ func buildCardContent(
 			}
 			items = append(items, monoText(ver, colorDimGray, false))
 		}
+		for _, k := range sbx.Kits {
+			label := "🧩 " + k.Name
+			if k.Ref != "" {
+				label += "@" + k.Ref
+			}
+			line := monoText(truncateStr(label, pathMax), colorPurple, false)
+			line.TextSize = scaledSize(11)
+			items = append(items, line)
+		}
 	}
 
 	// Separator before status section.

--- a/internal/gui/dashboard.go
+++ b/internal/gui/dashboard.go
@@ -137,7 +137,7 @@ func (d *Dashboard) Content() fyne.CanvasObject {
 // Must be called on the main thread (via fyne.Do).
 func (d *Dashboard) ApplyRefresh(result ops.RefreshResult) {
 	if result.Err != nil {
-		d.state.StatusMessage = result.Err.Error()
+		d.state.StatusMessage = ops.FirstNonEmptyLine(result.Err.Error())
 		d.state.StatusIsError = true
 		return
 	}
@@ -184,8 +184,11 @@ func (d *Dashboard) ApplyRefresh(result ops.RefreshResult) {
 	if result.SbxServerVer != "" {
 		d.state.SbxServerVersion = result.SbxServerVer
 	}
-	d.state.StatusMessage = ""
-	d.state.StatusIsError = false
+	// NOTE: StatusMessage is intentionally NOT cleared on a successful
+	// refresh. Refreshes happen every couple of seconds; clearing here
+	// wipes user-action messages ("Created X", "Pull complete", CLI
+	// errors) almost immediately. Status stays until another setStatus
+	// call or an Esc dismisses it.
 
 	d.Rebuild()
 }
@@ -297,11 +300,11 @@ func (d *Dashboard) build() fyne.CanvasObject {
 	if sbxInfo != nil {
 		switch sbxInfo.Status {
 		case sandbox.StatusRunning:
-			helpStr += "  [S] stop  [d] del sandbox"
+			helpStr += "  [S] stop  [k] recreate w/ kits  [d] del sandbox"
 		case sandbox.StatusStopped:
-			helpStr += "  [s] start  [d] del sandbox"
+			helpStr += "  [s] start  [k] recreate w/ kits  [d] del sandbox"
 		case sandbox.StatusNotFound:
-			helpStr += "  [n] create sandbox"
+			helpStr += "  [n] create sandbox  [k] create w/ kits"
 		}
 	}
 	helpColor := colorDimGray
@@ -425,5 +428,6 @@ func (d *Dashboard) sandboxInfo() *SandboxCardInfo {
 		Agent:         mode.Agent,
 		ClientVersion: d.state.SbxClientVersion,
 		ServerVersion: d.state.SbxServerVersion,
+		Kits:          mode.Kits,
 	}
 }

--- a/internal/gui/dialogs.go
+++ b/internal/gui/dialogs.go
@@ -9,11 +9,13 @@ import (
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/mdelapenya/biomelab/internal/git"
+	"github.com/mdelapenya/biomelab/internal/kits"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
 )
 
 var dialogMinSize = fyne.NewSize(450, 200)
+var kitsDialogSize = fyne.NewSize(600, 480)
 
 // All dialog functions return the dialog so the caller can store it for Escape dismissal.
 
@@ -39,9 +41,9 @@ func showConfirmDelete(parent fyne.Window, branch string, onDone func(), onConfi
 	return d
 }
 
-func showConfirmCreateSandbox(parent fyne.Window, sbxName, sbxAgent, repoPath string, onDone func(), onConfirm func()) dialog.Dialog {
+func showConfirmCreateSandbox(parent fyne.Window, sbxName, sbxAgent, repoPath string, kitURLs []string, onDone func(), onConfirm func()) dialog.Dialog {
 	var d *dialog.ConfirmDialog
-	args := sandbox.CreateArgs(sbxName, sbxAgent, repoPath)
+	args := sandbox.CreateArgs(sbxName, sbxAgent, repoPath, kitURLs)
 	cmd := sandbox.CommandString(args)
 
 	keyCap := newDialogKeyCapture(
@@ -62,6 +64,41 @@ func showConfirmCreateSandbox(parent fyne.Window, sbxName, sbxAgent, repoPath st
 		}
 	}, parent)
 	d.Resize(dialogMinSize)
+	d.Show()
+	focusInDialog(parent, keyCap)
+	return d
+}
+
+// showConfirmRecreateSandbox is the destructive confirmation shown when the
+// user wants to apply kits to an existing sandbox. Since `--kit` only works
+// at create time, biomelab must `sbx rm --force` and re-create. Host worktrees
+// are unaffected; container state is lost.
+func showConfirmRecreateSandbox(parent fyne.Window, sbxName, sbxAgent, repoPath string, kitURLs []string, onDone func(), onConfirm func()) dialog.Dialog {
+	var d *dialog.ConfirmDialog
+	rmCmd := sandbox.CommandString(sandbox.RemoveArgs(sbxName))
+	createCmd := sandbox.CommandString(sandbox.CreateArgs(sbxName, sbxAgent, repoPath, kitURLs))
+
+	keyCap := newDialogKeyCapture(
+		func() { d.Confirm() },
+		func() { d.Hide() },
+	)
+	body := container.NewVBox(
+		monoText("Recreate sandbox to apply kits?", colorYellow, true),
+		widget.NewLabel("Container state will be lost. Host worktrees are preserved."),
+		widget.NewSeparator(),
+		widget.NewLabel("Commands:"),
+		monoText(rmCmd, colorRed, false),
+		monoText(createCmd, colorSelected, false),
+	)
+	content := container.NewStack(body, keyCap)
+
+	d = dialog.NewCustomConfirm("Recreate Sandbox", "Recreate", "Cancel", content, func(ok bool) {
+		onDone()
+		if ok {
+			onConfirm()
+		}
+	}, parent)
+	d.Resize(kitsDialogSize)
 	d.Show()
 	focusInDialog(parent, keyCap)
 	return d
@@ -194,6 +231,106 @@ func showSendPRRemoteSelection(parent fyne.Window, remotes []git.RemoteInfo, onD
 		focusInDialog(parent, firstBtn)
 	}
 	return d
+}
+
+// showKitsDialog renders a multi-select picker for sandbox kits, split into
+// Agents and Mixins. Mixins are pre-filtered for the sandbox's agent by the
+// caller — this function only renders.
+//
+// onSubmit fires with the selected kits in the order they were rendered.
+func showKitsDialog(
+	parent fyne.Window,
+	sandboxName, agent string,
+	agents, mixins []kits.Kit,
+	onDone func(),
+	onSubmit func(selected []kits.Kit),
+) dialog.Dialog {
+	var d *dialog.ConfirmDialog
+	checks := make([]*widget.Check, 0, len(agents)+len(mixins))
+	all := make([]kits.Kit, 0, len(agents)+len(mixins))
+
+	body := container.NewVBox(
+		monoText(
+			fmt.Sprintf("Install kits into %s (agent: %s)", sandboxName, agent),
+			colorBranch, true,
+		),
+		widget.NewSeparator(),
+	)
+
+	addSection := func(title string, list []kits.Kit, emptyHint string) {
+		header := monoText(title, colorBlue, true)
+		body.Add(header)
+		if len(list) == 0 {
+			hint := monoText(emptyHint, colorDimGray, false)
+			hint.TextSize = scaledSize(11)
+			body.Add(hint)
+			body.Add(widget.NewSeparator())
+			return
+		}
+		for _, k := range list {
+			checks = append(checks, widget.NewCheck(displayLabel(k), nil))
+			all = append(all, k)
+			body.Add(checks[len(checks)-1])
+			if k.Description != "" {
+				desc := monoText("    "+k.Description, colorGray, false)
+				desc.TextSize = scaledSize(10)
+				body.Add(desc)
+			}
+		}
+		body.Add(widget.NewSeparator())
+	}
+
+	addSection("Agents", agents, "(none available)")
+	addSection(fmt.Sprintf("Mixins for %s", agent), mixins, "(no mixins compatible with this agent)")
+
+	// keyCap captures Escape (cancel) globally inside the dialog. Enter is
+	// NOT bound to confirm because Space toggles the focused checkbox and
+	// users may want to toggle several before submitting — Enter would
+	// race with that. They click "Install" or Tab to it and press Space.
+	keyCap := newDialogKeyCapture(
+		func() {}, // no-op on Enter — see comment above
+		func() { d.Hide() },
+	)
+	scroll := container.NewVScroll(body)
+	scroll.SetMinSize(kitsDialogSize)
+	content := container.NewStack(scroll, keyCap)
+
+	d = dialog.NewCustomConfirm("Install Kits", "Install", "Cancel", content, func(ok bool) {
+		onDone()
+		if !ok {
+			return
+		}
+		var selected []kits.Kit
+		for i, c := range checks {
+			if c.Checked {
+				selected = append(selected, all[i])
+			}
+		}
+		if len(selected) == 0 {
+			return
+		}
+		onSubmit(selected)
+	}, parent)
+	d.Resize(kitsDialogSize)
+	d.Show()
+	// Focus the first checkbox if any exist, so the user can Space-toggle
+	// immediately. Fall back to the key-capture overlay so Escape still
+	// dismisses even with no checkboxes.
+	if len(checks) > 0 {
+		focusInDialog(parent, checks[0])
+	} else {
+		focusInDialog(parent, keyCap)
+	}
+	return d
+}
+
+// displayLabel returns the user-visible label for a kit row.
+func displayLabel(k kits.Kit) string {
+	name := k.DisplayName
+	if name == "" {
+		name = k.Name
+	}
+	return fmt.Sprintf("%s  (%s)", name, k.Name)
 }
 
 func showSendPRConfirm(parent fyne.Window, branch string, remote git.RemoteInfo, existingPR *provider.PRInfo, onDone func(), onConfirm func()) dialog.Dialog {

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -1,6 +1,8 @@
 package gui
 
 import (
+	"context"
+	"fmt"
 	"math"
 
 	"fyne.io/fyne/v2"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/mdelapenya/biomelab/internal/config"
 	"github.com/mdelapenya/biomelab/internal/git"
+	"github.com/mdelapenya/biomelab/internal/kits"
 	"github.com/mdelapenya/biomelab/internal/ops"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
@@ -75,10 +78,6 @@ func (a *App) handleKeyName(key fyne.KeyName) {
 
 	if a.focus == focusLeft {
 		switch key {
-		case fyne.KeyJ:
-			a.navigateDown()
-		case fyne.KeyK:
-			a.navigateUp()
 		case fyne.KeyA:
 			a.handleAddRepo()
 		case fyne.KeyN:
@@ -90,14 +89,6 @@ func (a *App) handleKeyName(key fyne.KeyName) {
 	}
 
 	switch key {
-	case fyne.KeyJ:
-		a.navigateDown()
-	case fyne.KeyK:
-		a.navigateUp()
-	case fyne.KeyH:
-		a.navigateLeft()
-	case fyne.KeyL:
-		a.navigateRight()
 	case fyne.KeyR:
 		a.handleRefresh()
 	case fyne.KeyC:
@@ -114,6 +105,8 @@ func (a *App) handleKeyName(key fyne.KeyName) {
 		a.handleStartSandbox() // Shift+S (stop) handled in handleRune via 'S'
 	case fyne.KeyN:
 		a.handleCreateOrEnrollSandbox()
+	case fyne.KeyK:
+		a.handleInstallKits()
 	}
 }
 
@@ -449,6 +442,14 @@ func (a *App) handleEnter() {
 }
 
 func (a *App) handleEscape() {
+	// Clear any persistent status message first; only fall through to a
+	// focus-switch if there was no status to dismiss.
+	if a.dashboard != nil && a.dashboard.state.StatusMessage != "" {
+		a.dashboard.state.StatusMessage = ""
+		a.dashboard.state.StatusIsError = false
+		a.dashboard.Rebuild()
+		return
+	}
 	if a.focus == focusLeft {
 		a.focus = focusRight
 		if a.dashboard != nil {
@@ -542,7 +543,7 @@ func (a *App) handleCreate() {
 			}
 			fyne.Do(func() {
 				if result.Err != nil {
-					a.setStatus(result.Err.Error(), true)
+					a.setStatus(result.ErrorMessage(), true)
 				}
 				a.refreshMgr.TriggerQuick()
 			})
@@ -567,12 +568,16 @@ func (a *App) handleDeleteOrRemoveSandbox() {
 			return
 		}
 		done := a.openDialog()
-		a.activeDialog = showConfirmRemoveSandbox(a.window, mode.SandboxName, done, func() {
+		sbxName := mode.SandboxName
+		a.activeDialog = showConfirmRemoveSandbox(a.window, sbxName, done, func() {
+			a.setStatus("Removing sandbox "+sbxName+"…", false)
 			go func() {
-				result := ops.RemoveSandbox(mode.SandboxName)
+				result := ops.RemoveSandbox(sbxName)
 				fyne.Do(func() {
 					if result.Err != nil {
-						a.setStatus(result.Err.Error(), true)
+						a.setStatus(result.ErrorMessage(), true)
+					} else {
+						a.setStatus("Removed "+sbxName, false)
 					}
 					a.refreshMgr.TriggerLocal()
 				})
@@ -775,11 +780,14 @@ func (a *App) handleStartSandbox() {
 	if mode == nil || mode.Type != "sandbox" || mode.SandboxName == "" || re.state.SandboxStatus != sandbox.StatusStopped {
 		return
 	}
+	a.setStatus("Starting sandbox "+mode.SandboxName+"…", false)
 	go func() {
 		result := ops.StartSandbox(mode.SandboxName)
 		fyne.Do(func() {
 			if result.Err != nil {
-				a.setStatus(result.Err.Error(), true)
+				a.setStatus(result.ErrorMessage(), true)
+			} else {
+				a.setStatus("Started "+result.SandboxName, false)
 			}
 			a.refreshMgr.TriggerLocal()
 		})
@@ -795,15 +803,147 @@ func (a *App) handleStopSandbox() {
 	if mode == nil || mode.Type != "sandbox" || mode.SandboxName == "" || re.state.SandboxStatus != sandbox.StatusRunning {
 		return
 	}
+	a.setStatus("Stopping sandbox "+mode.SandboxName+"…", false)
 	go func() {
 		result := ops.StopSandbox(mode.SandboxName)
 		fyne.Do(func() {
 			if result.Err != nil {
-				a.setStatus(result.Err.Error(), true)
+				a.setStatus(result.ErrorMessage(), true)
+			} else {
+				a.setStatus("Stopped "+result.SandboxName, false)
 			}
 			a.refreshMgr.TriggerLocal()
 		})
 	}()
+}
+
+// handleInstallKits opens the kit picker for the active sandbox mode. Kits
+// can only be applied at sandbox creation time (sbx rejects --kit on
+// existing sandboxes), so the action behaves differently depending on state:
+//
+//   - StatusNotFound   → kits picker → confirm-create dialog → sbx create with --kit
+//   - Running/Stopped  → kits picker → confirm-recreate dialog → sbx rm + sbx create with --kit
+func (a *App) handleInstallKits() {
+	re := a.activeRepo()
+	if re == nil {
+		return
+	}
+	mode := re.state.ActiveMode
+	if mode == nil || mode.Type != "sandbox" || mode.SandboxName == "" {
+		return
+	}
+	if !a.requireSbxInstalled() {
+		return
+	}
+
+	sbxName := mode.SandboxName
+	agent := mode.Agent
+	repoPath := re.group.Path
+	status := re.state.SandboxStatus
+	a.setStatus("Fetching available kits…", false)
+
+	go func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		agents, mixins, err := kits.FetchAvailable(ctx)
+		// Capture the contrib HEAD SHA as the recorded "version" of the
+		// kits being installed. Best-effort — UI degrades to no version
+		// suffix if the call fails.
+		ref, _ := kits.HeadRef(ctx)
+		fyne.Do(func() {
+			if err != nil {
+				a.setStatus("Fetch kits: "+ops.FirstNonEmptyLine(err.Error()), true)
+				return
+			}
+			a.setStatus("", false)
+			compatibleMixins := kits.FilterMixinsForAgent(mixins, agent)
+			pickerDone := a.openDialog()
+			a.activeDialog = showKitsDialog(a.window, sbxName, agent, agents, compatibleMixins, pickerDone,
+				func(selected []kits.Kit) {
+					a.confirmKitsApply(re, sbxName, agent, repoPath, status, selected, ref)
+				})
+		})
+	}()
+}
+
+// confirmKitsApply chains the kit-picker selection into the appropriate
+// confirmation dialog: create-with-kits for a missing sandbox, or
+// destructive recreate-with-kits for an existing one. ref is the
+// contrib-repo SHA captured at fetch time, persisted alongside each kit.
+func (a *App) confirmKitsApply(re *repoEntry, sbxName, agent, repoPath string, status sandbox.Status, selected []kits.Kit, ref string) {
+	installs := buildKitInstalls(selected, ref)
+	urls := kitURLs(selected)
+	confirmDone := a.openDialog()
+	if status == sandbox.StatusNotFound {
+		a.activeDialog = showConfirmCreateSandbox(a.window, sbxName, agent, repoPath, urls, confirmDone, func() {
+			a.doCreateSandboxWithPreflight(re, sbxName, agent, repoPath, urls, installs)
+		})
+		return
+	}
+	a.activeDialog = showConfirmRecreateSandbox(a.window, sbxName, agent, repoPath, urls, confirmDone, func() {
+		a.doRecreateSandboxWithKits(re, sbxName, agent, repoPath, urls, installs)
+	})
+}
+
+// doRecreateSandboxWithKits removes the existing sandbox and creates it
+// again with the given kit URLs applied. Runs sbx Preflight first.
+func (a *App) doRecreateSandboxWithKits(re *repoEntry, sbxName, agent, repoPath string, kitURLs []string, installs []config.KitInstall) {
+	a.setStatus("Recreating "+sbxName+" with "+fmt.Sprintf("%d", len(kitURLs))+" kit(s)…", false)
+	go func() {
+		if err := sandbox.Preflight(); err != nil {
+			fyne.Do(func() { a.setStatus(ops.FirstNonEmptyLine(err.Error()), true) })
+			return
+		}
+		result := ops.RecreateSandboxWithKits(sbxName, agent, repoPath, kitURLs)
+		fyne.Do(func() {
+			if result.Err != nil {
+				a.setStatus(result.ErrorMessage(), true)
+			} else {
+				a.persistKits(re, repoPath, sbxName, installs)
+				a.setStatus(fmt.Sprintf("Recreated %s with %d kit(s)", sbxName, len(kitURLs)), false)
+			}
+			a.refreshMgr.TriggerLocal()
+		})
+	}()
+}
+
+// persistKits writes the recorded kit list to disk and updates the in-memory
+// mode entry so the dashboard renders without waiting for a config reload.
+// Must be called on the UI thread.
+func (a *App) persistKits(re *repoEntry, repoPath, sbxName string, installs []config.KitInstall) {
+	cfg, err := config.Load(a.configPath)
+	if err == nil && cfg.SetSandboxKits(repoPath, sbxName, installs) {
+		_ = config.Save(a.configPath, cfg)
+	}
+	if re != nil && re.state != nil {
+		if mode := re.state.ActiveMode; mode != nil && mode.SandboxName == sbxName {
+			mode.Kits = installs
+		}
+		for i := range re.group.Modes {
+			m := &re.group.Modes[i]
+			if m.Type == "sandbox" && m.SandboxName == sbxName {
+				m.Kits = installs
+			}
+		}
+	}
+}
+
+// kitURLs maps a selected kit slice to the --kit argument values.
+func kitURLs(selected []kits.Kit) []string {
+	urls := make([]string, len(selected))
+	for i, k := range selected {
+		urls[i] = k.GitURL()
+	}
+	return urls
+}
+
+// buildKitInstalls converts the picker selection into the persistence shape.
+func buildKitInstalls(selected []kits.Kit, ref string) []config.KitInstall {
+	out := make([]config.KitInstall, len(selected))
+	for i, k := range selected {
+		out[i] = config.KitInstall{Name: k.Name, Ref: ref}
+	}
+	return out
 }
 
 func (a *App) handleCreateOrEnrollSandbox() {
@@ -819,8 +959,8 @@ func (a *App) handleCreateOrEnrollSandbox() {
 			return
 		}
 		done := a.openDialog()
-		a.activeDialog = showConfirmCreateSandbox(a.window, mode.SandboxName, mode.Agent, re.group.Path, done, func() {
-			a.doCreateSandboxWithPreflight(re, mode.SandboxName, mode.Agent, re.group.Path)
+		a.activeDialog = showConfirmCreateSandbox(a.window, mode.SandboxName, mode.Agent, re.group.Path, nil, done, func() {
+			a.doCreateSandboxWithPreflight(re, mode.SandboxName, mode.Agent, re.group.Path, nil, nil)
 		})
 		return
 	}
@@ -837,7 +977,7 @@ func (a *App) handleCreateOrEnrollSandbox() {
 			err := sandbox.Preflight()
 			fyne.Do(func() {
 				if err != nil {
-					a.setStatus(err.Error(), true)
+					a.setStatus(ops.FirstNonEmptyLine(err.Error()), true)
 					return
 				}
 				cfg, _ := config.Load(a.configPath)
@@ -890,7 +1030,7 @@ func (a *App) handleAddSandboxMode() {
 			err := sandbox.Preflight()
 			fyne.Do(func() {
 				if err != nil {
-					a.setStatus(err.Error(), true)
+					a.setStatus(ops.FirstNonEmptyLine(err.Error()), true)
 					return
 				}
 				cfg, _ := config.Load(a.configPath)
@@ -908,18 +1048,28 @@ func (a *App) handleAddSandboxMode() {
 	})
 }
 
-func (a *App) doCreateSandboxWithPreflight(re *repoEntry, sbxName, sbxAgent, repoPath string) {
+func (a *App) doCreateSandboxWithPreflight(re *repoEntry, sbxName, sbxAgent, repoPath string, kitURLs []string, installs []config.KitInstall) {
+	if len(kitURLs) > 0 {
+		a.setStatus(fmt.Sprintf("Creating %s with %d kit(s)…", sbxName, len(kitURLs)), false)
+	} else {
+		a.setStatus("Creating "+sbxName+"…", false)
+	}
 	go func() {
 		err := sandbox.Preflight()
 		if err != nil {
 			fyne.Do(func() { a.setStatus(err.Error(), true) })
 			return
 		}
-		args := sandbox.CreateArgs(sbxName, sbxAgent, repoPath)
+		args := sandbox.CreateArgs(sbxName, sbxAgent, repoPath, kitURLs)
 		result := ops.CreateSandbox(args)
 		fyne.Do(func() {
 			if result.Err != nil {
-				a.setStatus(result.Err.Error(), true)
+				a.setStatus(result.ErrorMessage(), true)
+			} else if len(installs) > 0 {
+				a.persistKits(re, repoPath, sbxName, installs)
+				a.setStatus(fmt.Sprintf("Created %s with %d kit(s)", sbxName, len(installs)), false)
+			} else {
+				a.setStatus("Created "+sbxName, false)
 			}
 			a.refreshMgr.TriggerLocal()
 		})
@@ -956,7 +1106,7 @@ func (a *App) handleAddRepo() {
 					err := sandbox.Preflight()
 					fyne.Do(func() {
 						if err != nil {
-							a.setStatus(err.Error(), true)
+							a.setStatus(ops.FirstNonEmptyLine(err.Error()), true)
 							return
 						}
 						a.addRepoToConfig(repoRoot, repo.RepoName(), mode)
@@ -1052,99 +1202,8 @@ func (a *App) handleRemoveMode() {
 		}
 		_ = config.Save(a.configPath, cfg)
 
-		a.reloadRepoFromConfig(re.group.Path)
+		dialog.ShowInformation("Mode Removed", modeLabel+" removed.\nRestart biomelab to update.", a.window)
 	})
-}
-
-// reloadRepoFromConfig re-syncs the repo at repoPath with the on-disk config.
-// Used after a mode is removed so users see the change immediately instead of
-// being told to restart the app. Three outcomes:
-//   - Repo gone from cfg: drop it from a.repos and swap to another repo
-//     (or the empty state when none remain).
-//   - Repo still present: refresh its mode list, fall back to mode 0 if the
-//     previously-active mode disappeared, and re-run switchMode to rebuild
-//     state/refresh-manager wiring (e.g. sandbox candidates clearing on a
-//     sandbox→regular transition).
-//   - Repo not currently in the UI: no-op.
-func (a *App) reloadRepoFromConfig(repoPath string) {
-	cfg, err := config.Load(a.configPath)
-	if err != nil {
-		return
-	}
-
-	repoIdx := -1
-	for i, re := range a.repos {
-		if re.group.Path == repoPath {
-			repoIdx = i
-			break
-		}
-	}
-	if repoIdx < 0 {
-		return
-	}
-
-	cfgIdx := cfg.IndexOf(repoPath)
-	if cfgIdx < 0 {
-		a.removeRepoFromUI(repoIdx)
-		return
-	}
-
-	re := a.repos[repoIdx]
-	re.group.Modes = cfg.Repos[cfgIdx].Modes
-
-	newMode := re.group.ActiveMode
-	if newMode >= len(re.group.Modes) {
-		newMode = 0
-	}
-
-	// Force switchMode to re-apply all state by clearing active first. The
-	// guard in switchMode (active >= 0 && active < len(a.repos)) skips the
-	// pause step when active is -1, so we Pause manually for the repo whose
-	// modes just changed and let switchMode resume it.
-	if a.active == repoIdx {
-		re.refreshMgr.Pause()
-	}
-	a.active = -1
-
-	if a.repoPanel != nil {
-		a.repoPanel.groups = a.collectGroups()
-	}
-	a.switchMode(repoIdx, newMode)
-}
-
-// removeRepoFromUI drops repos[idx] from the in-memory state, pauses its
-// refresh manager, and re-points the active repo. When the last repo is gone
-// it swaps the window content back to the empty state.
-func (a *App) removeRepoFromUI(repoIdx int) {
-	a.repos[repoIdx].refreshMgr.Pause()
-	a.repos = append(a.repos[:repoIdx], a.repos[repoIdx+1:]...)
-
-	if len(a.repos) == 0 {
-		a.repoPanel = nil
-		a.dashboard = nil
-		a.refreshMgr = nil
-		a.dashSlot = nil
-		a.active = -1
-		a.window.SetContent(a.emptyState())
-		return
-	}
-
-	newActive := a.active
-	if newActive > repoIdx {
-		newActive--
-	}
-	if newActive >= len(a.repos) {
-		newActive = len(a.repos) - 1
-	}
-	if newActive < 0 {
-		newActive = 0
-	}
-
-	a.active = -1
-	if a.repoPanel != nil {
-		a.repoPanel.groups = a.collectGroups()
-	}
-	a.switchMode(newActive, 0)
 }
 
 func (a *App) collectGroups() []*RepoGroup {

--- a/internal/gui/state.go
+++ b/internal/gui/state.go
@@ -58,6 +58,7 @@ type SandboxCardInfo struct {
 	Agent         string
 	ClientVersion string
 	ServerVersion string
+	Kits          []config.KitInstall
 }
 
 // SetWorktrees stores worktrees and sorts linked ones alphabetically by branch.

--- a/internal/kits/kits.go
+++ b/internal/kits/kits.go
@@ -1,0 +1,234 @@
+// Package kits discovers Docker Sandbox kits published in
+// docker/sbx-kits-contrib so they can be applied to a sandbox via
+// `sbx run --kit "git+https://github.com/docker/sbx-kits-contrib.git#dir=<name>"`.
+package kits
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v3"
+)
+
+// ContribRepoURL is the git+ URL passed to `sbx --kit` to point at the
+// kits-contrib repository.
+const ContribRepoURL = "git+https://github.com/docker/sbx-kits-contrib.git"
+
+// Kind values from spec.yaml.
+const (
+	KindAgent = "agent"
+	KindMixin = "mixin"
+)
+
+// nonKitDirs are top-level directories that are not kit definitions.
+var nonKitDirs = map[string]struct{}{
+	".github": {},
+	"spec":    {},
+	"tck":     {},
+}
+
+// Kit is a sandbox kit discovered in docker/sbx-kits-contrib.
+// Fields mirror the relevant top-level keys in each kit's spec.yaml.
+type Kit struct {
+	Name        string `yaml:"name"`
+	Kind        string `yaml:"kind"`
+	DisplayName string `yaml:"displayName"`
+	Description string `yaml:"description"`
+	Extends     string `yaml:"extends"`
+}
+
+// GitURL returns the value to pass to sbx's --kit flag for this kit.
+func (k Kit) GitURL() string {
+	return URL(k.Name)
+}
+
+// URL returns the --kit reference for a kit by name.
+func URL(name string) string {
+	return ContribRepoURL + "#dir=" + name
+}
+
+// FetchAvailable lists every kit in docker/sbx-kits-contrib and splits them
+// into (agents, mixins) by spec.yaml `kind`. Discovery uses `gh api`, which
+// reuses the user's existing GitHub authentication (matching how
+// internal/provider/github.go talks to GitHub).
+//
+// Directories without a spec.yaml or with an unknown kind are skipped.
+func FetchAvailable(ctx context.Context) (agents, mixins []Kit, err error) {
+	dirs, err := listKitDirs(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	results := make([]Kit, len(dirs))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(8)
+	for i, dir := range dirs {
+		idx, name := i, dir
+		g.Go(func() error {
+			k, ok, ferr := fetchKitSpec(gctx, name)
+			if ferr != nil {
+				return ferr
+			}
+			if ok {
+				results[idx] = k
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
+	}
+
+	for _, k := range results {
+		switch k.Kind {
+		case KindAgent:
+			agents = append(agents, k)
+		case KindMixin:
+			mixins = append(mixins, k)
+		}
+	}
+	sortByDisplay(agents)
+	sortByDisplay(mixins)
+	return agents, mixins, nil
+}
+
+// HeadRef returns the short (7-char) commit SHA of the kits-contrib repo's
+// default branch. biomelab captures this when a user installs kits so the
+// main card can show "name@<short-sha>" as a version. The install URL
+// itself is not pinned — kits are always fetched from `main`.
+func HeadRef(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "api",
+		"repos/docker/sbx-kits-contrib/commits/main", "--jq", ".sha")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("kits HEAD ref: %w (%s)", err, ghStderr(err))
+	}
+	sha := strings.TrimSpace(string(out))
+	if len(sha) > 7 {
+		sha = sha[:7]
+	}
+	return sha, nil
+}
+
+// FilterMixinsForAgent returns the subset of mixins compatible with the given
+// sandbox agent. A mixin is compatible if its `extends` field is empty or
+// equal to the agent name.
+func FilterMixinsForAgent(mixins []Kit, agent string) []Kit {
+	out := make([]Kit, 0, len(mixins))
+	for _, m := range mixins {
+		if m.Extends == "" || m.Extends == agent {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// listKitDirs returns the candidate top-level directory names in the
+// kits-contrib repo (everything that's a dir and not in nonKitDirs).
+func listKitDirs(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "api", "repos/docker/sbx-kits-contrib/contents")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list kits: %w (%s)", err, ghStderr(err))
+	}
+	var entries []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(out, &entries); err != nil {
+		return nil, fmt.Errorf("parse kit listing: %w", err)
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.Type != "dir" {
+			continue
+		}
+		if _, skip := nonKitDirs[e.Name]; skip {
+			continue
+		}
+		dirs = append(dirs, e.Name)
+	}
+	return dirs, nil
+}
+
+// fetchKitSpec downloads and parses spec.yaml for a single kit directory.
+// Returns ok=false (without error) if the directory has no spec.yaml.
+func fetchKitSpec(ctx context.Context, dir string) (Kit, bool, error) {
+	cmd := exec.CommandContext(ctx, "gh", "api",
+		"repos/docker/sbx-kits-contrib/contents/"+dir+"/spec.yaml")
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ghStderr(err)
+		if strings.Contains(stderr, "Not Found") || strings.Contains(stderr, "HTTP 404") {
+			return Kit{}, false, nil
+		}
+		return Kit{}, false, fmt.Errorf("fetch %s/spec.yaml: %w (%s)", dir, err, stderr)
+	}
+	var resp struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return Kit{}, false, fmt.Errorf("parse %s/spec.yaml response: %w", dir, err)
+	}
+	raw, err := decodeContent(resp.Content, resp.Encoding)
+	if err != nil {
+		return Kit{}, false, fmt.Errorf("decode %s/spec.yaml: %w", dir, err)
+	}
+	k, err := ParseSpec(raw)
+	if err != nil {
+		return Kit{}, false, fmt.Errorf("parse %s/spec.yaml: %w", dir, err)
+	}
+	if k.Name == "" {
+		k.Name = dir
+	}
+	return k, true, nil
+}
+
+// ParseSpec unmarshals a spec.yaml into a Kit.
+func ParseSpec(raw []byte) (Kit, error) {
+	var k Kit
+	if err := yaml.Unmarshal(raw, &k); err != nil {
+		return Kit{}, err
+	}
+	return k, nil
+}
+
+func decodeContent(content, encoding string) ([]byte, error) {
+	if encoding != "base64" {
+		return []byte(content), nil
+	}
+	// gh api returns base64 with newlines.
+	cleaned := strings.ReplaceAll(content, "\n", "")
+	return base64.StdEncoding.DecodeString(cleaned)
+}
+
+// ghStderr extracts the stderr of an *exec.ExitError, if any.
+func ghStderr(err error) string {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return strings.TrimSpace(string(ee.Stderr))
+	}
+	return ""
+}
+
+func sortByDisplay(ks []Kit) {
+	sort.Slice(ks, func(i, j int) bool {
+		ai := ks[i].DisplayName
+		if ai == "" {
+			ai = ks[i].Name
+		}
+		aj := ks[j].DisplayName
+		if aj == "" {
+			aj = ks[j].Name
+		}
+		return strings.ToLower(ai) < strings.ToLower(aj)
+	})
+}

--- a/internal/kits/kits_test.go
+++ b/internal/kits/kits_test.go
@@ -1,0 +1,105 @@
+package kits
+
+import (
+	"testing"
+)
+
+func TestParseSpec_Agent(t *testing.T) {
+	raw := []byte(`schemaVersion: "1"
+kind: agent
+name: trivy
+displayName: Trivy
+description: "Vulnerability scanner"
+`)
+	k, err := ParseSpec(raw)
+	if err != nil {
+		t.Fatalf("ParseSpec: %v", err)
+	}
+	if k.Kind != KindAgent {
+		t.Errorf("Kind = %q, want %q", k.Kind, KindAgent)
+	}
+	if k.Name != "trivy" || k.DisplayName != "Trivy" {
+		t.Errorf("got %+v", k)
+	}
+	if k.Extends != "" {
+		t.Errorf("agent should not have Extends, got %q", k.Extends)
+	}
+}
+
+func TestParseSpec_Mixin(t *testing.T) {
+	raw := []byte(`schemaVersion: "1"
+kind: mixin
+name: code-server
+extends: claude
+displayName: code-server (web VS Code) with Claude Code
+description: Runs code-server on port 8080
+`)
+	k, err := ParseSpec(raw)
+	if err != nil {
+		t.Fatalf("ParseSpec: %v", err)
+	}
+	if k.Kind != KindMixin {
+		t.Errorf("Kind = %q, want %q", k.Kind, KindMixin)
+	}
+	if k.Extends != "claude" {
+		t.Errorf("Extends = %q, want claude", k.Extends)
+	}
+}
+
+func TestKit_GitURL(t *testing.T) {
+	k := Kit{Name: "code-server"}
+	got := k.GitURL()
+	want := "git+https://github.com/docker/sbx-kits-contrib.git#dir=code-server"
+	if got != want {
+		t.Errorf("GitURL = %q, want %q", got, want)
+	}
+}
+
+func TestFilterMixinsForAgent(t *testing.T) {
+	mixins := []Kit{
+		{Name: "claude-only", Kind: KindMixin, Extends: "claude"},
+		{Name: "gemini-only", Kind: KindMixin, Extends: "gemini"},
+		{Name: "universal", Kind: KindMixin, Extends: ""},
+	}
+
+	tests := []struct {
+		agent string
+		want  []string
+	}{
+		{"claude", []string{"claude-only", "universal"}},
+		{"gemini", []string{"gemini-only", "universal"}},
+		{"shell", []string{"universal"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.agent, func(t *testing.T) {
+			got := FilterMixinsForAgent(mixins, tc.agent)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tc.want), got)
+			}
+			for i, k := range got {
+				if k.Name != tc.want[i] {
+					t.Errorf("[%d] got %q, want %q", i, k.Name, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSortByDisplay(t *testing.T) {
+	ks := []Kit{
+		{Name: "z-name", DisplayName: "Apple"},
+		{Name: "a-name", DisplayName: "Zebra"},
+		{Name: "m-name"}, // no DisplayName → falls back to Name
+	}
+	sortByDisplay(ks)
+	want := []string{"Apple", "m-name", "Zebra"}
+	for i, w := range want {
+		got := ks[i].DisplayName
+		if got == "" {
+			got = ks[i].Name
+		}
+		if got != w {
+			t.Errorf("[%d] = %q, want %q", i, got, w)
+		}
+	}
+}

--- a/internal/ops/sandbox_ops.go
+++ b/internal/ops/sandbox_ops.go
@@ -1,12 +1,43 @@
 package ops
 
-import "github.com/mdelapenya/biomelab/internal/sandbox"
+import (
+	"strings"
+
+	"github.com/mdelapenya/biomelab/internal/sandbox"
+)
 
 // SandboxResult is the outcome of a sandbox operation.
 type SandboxResult struct {
 	SandboxName string
 	Output      string
 	Err         error
+}
+
+// ErrorMessage returns a user-facing error message. Prefers the underlying
+// CLI's stderr/stdout (Output) over the bare exec error ("exit status 1"),
+// which is what users actually need to see — sbx puts actionable messages
+// like "needs restart", "login required", "policy not set" in its output.
+// Returns "" if Err is nil.
+func (r SandboxResult) ErrorMessage() string {
+	if r.Err == nil {
+		return ""
+	}
+	if msg := FirstNonEmptyLine(r.Output); msg != "" {
+		return msg
+	}
+	return r.Err.Error()
+}
+
+// FirstNonEmptyLine returns the first non-empty, trimmed line of s, or "".
+// Used to compress multi-line CLI errors into a single-line status message.
+func FirstNonEmptyLine(s string) string {
+	for line := range strings.SplitSeq(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
 }
 
 // CreateSandbox creates a new sandbox.
@@ -35,4 +66,20 @@ func StopSandbox(name string) SandboxResult {
 func RemoveSandbox(name string) SandboxResult {
 	out, err := sandbox.Remove(name)
 	return SandboxResult{SandboxName: name, Output: out, Err: err}
+}
+
+// RecreateSandboxWithKits removes an existing sandbox and re-creates it with
+// the given kit URLs applied. Kits can only be set at create time, so this
+// is the only way to apply kits to a sandbox that already exists. State
+// inside the previous container is lost; host worktrees are not touched.
+//
+// Returns the result of the create step. If the rm step fails the create is
+// not attempted.
+func RecreateSandboxWithKits(sandboxName, agent, repoPath string, kitURLs []string) SandboxResult {
+	if _, err := sandbox.Remove(sandboxName); err != nil {
+		return SandboxResult{SandboxName: sandboxName, Err: err}
+	}
+	args := sandbox.CreateArgs(sandboxName, agent, repoPath, kitURLs)
+	out, err := sandbox.Create(args)
+	return SandboxResult{SandboxName: sandboxName, Output: out, Err: err}
 }

--- a/internal/ops/worktree.go
+++ b/internal/ops/worktree.go
@@ -20,6 +20,19 @@ type CreateWorktreeResult struct {
 	Err        error
 }
 
+// ErrorMessage returns a user-facing error message, preferring sbx's stderr
+// (SbxOutput) over the bare exec error. See SandboxResult.ErrorMessage for
+// the rationale. Returns "" if Err is nil.
+func (r CreateWorktreeResult) ErrorMessage() string {
+	if r.Err == nil {
+		return ""
+	}
+	if msg := FirstNonEmptyLine(r.SbxOutput); msg != "" {
+		return msg
+	}
+	return r.Err.Error()
+}
+
 // CreateWorktree creates a new linked worktree for the given branch.
 func CreateWorktree(repo *git.Repository, branchName string) CreateWorktreeResult {
 	err := repo.CreateWorktree(branchName)

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -15,9 +15,17 @@ func Available() bool {
 }
 
 // CreateArgs returns the arguments for creating a sandbox without attaching:
-// sbx create --name <name> <agent> <repoPath>
-func CreateArgs(name, agent, repoPath string) []string {
-	return []string{"sbx", "create", "--name", name, agent, repoPath}
+// sbx create --name <name> [--kit <url>...] <agent> <repoPath>
+//
+// kitURLs is optional; pass nil for a vanilla sandbox. Each kit URL is
+// emitted as its own --kit flag. Kits can only be applied at creation time —
+// `sbx run --kit` rejects the flag against an existing sandbox.
+func CreateArgs(name, agent, repoPath string, kitURLs []string) []string {
+	args := []string{"sbx", "create", "--name", name}
+	for _, k := range kitURLs {
+		args = append(args, "--kit", k)
+	}
+	return append(args, agent, repoPath)
 }
 
 // RunDetachedWithBranchArgs returns the arguments for creating a worktree

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -6,11 +6,28 @@ import (
 )
 
 func TestCreateArgs(t *testing.T) {
-	got := CreateArgs("my-sandbox", "claude", "/tmp/repo")
-	want := []string{"sbx", "create", "--name", "my-sandbox", "claude", "/tmp/repo"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("CreateArgs() = %v, want %v", got, want)
-	}
+	t.Run("no kits", func(t *testing.T) {
+		got := CreateArgs("my-sandbox", "claude", "/tmp/repo", nil)
+		want := []string{"sbx", "create", "--name", "my-sandbox", "claude", "/tmp/repo"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("CreateArgs() = %v, want %v", got, want)
+		}
+	})
+	t.Run("with kits", func(t *testing.T) {
+		got := CreateArgs("my-sandbox", "claude", "/tmp/repo", []string{
+			"git+https://example.com#dir=a",
+			"git+https://example.com#dir=b",
+		})
+		want := []string{
+			"sbx", "create", "--name", "my-sandbox",
+			"--kit", "git+https://example.com#dir=a",
+			"--kit", "git+https://example.com#dir=b",
+			"claude", "/tmp/repo",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("CreateArgs() = %v, want %v", got, want)
+		}
+	})
 }
 
 func TestRunDetachedWithBranchArgs(t *testing.T) {


### PR DESCRIPTION
## What's changed

Adds a kits picker to the sandbox card. Press `k` to fetch the catalog from
`docker/sbx-kits-contrib` (agents + agent-compatible mixins), pick what to
install, and either create the sandbox with the chosen `--kit` flags or
recreate it if it already exists. Selected kits are persisted in
`repos.json` and rendered on the card as 🧩 chips with the contrib-repo
short SHA as a "version".

Sandbox status messages now stay on screen until dismissed: in-progress
(`Creating …`), success (`Created X`), and CLI errors all flow through
`setStatus` and survive the next refresh tick. Escape clears the status
before falling through to focus changes. CLI errors render the first
non-empty line of stderr/stdout instead of `exit status 1`.

Drops the vim-style `j`/`k`/`h`/`l` shortcuts so `k` can be reused for the
kits picker.

## Why is this important?

Sandbox kits are the supported way to layer agents and tooling (code-server,
extra agents, mixins) into a sandbox, but `sbx --kit` only accepts URLs at
creation time and the catalog isn't browsable from the CLI. Discovering kits,
typing long `git+https://…#dir=…` URLs, and re-creating a sandbox to add one
were all manual today. Surfacing the catalog inline, owning the
rm-then-create dance, and recording what was installed makes kits a
first-class part of the sandbox workflow.

The status-message changes are a long-standing papercut: refreshes run every
couple of seconds and were wiping action feedback before users could read
it. CLI errors collapsed to `exit status 1` hid the actually useful sbx
messages (`needs restart`, `login required`, etc.).

## Changes

**`internal/kits/` (new package)**
- `FetchAvailable` lists kit dirs via `gh api`, fetches each `spec.yaml` in
  parallel (errgroup, limit 8), and splits results into agents/mixins by
  `kind`.
- `FilterMixinsForAgent` keeps mixins whose `extends` is empty or matches
  the sandbox's agent.
- `HeadRef` captures the contrib repo's short SHA so the card can show
  `name@<sha>` as a display-only version (the install URL is not pinned).

**Sandbox create with kits**
- `sandbox.CreateArgs` takes `kitURLs []string` and emits one `--kit <url>`
  per entry.
- `ops.RecreateSandboxWithKits` runs `sbx rm` then `sbx create` with the
  kit flags; aborts the create if rm fails.
- `config.KitInstall{Name, Ref}` recorded per sandbox; `SetSandboxKits`
  updates `repos.json`.

**GUI**
- `k` shortcut → `handleInstallKits` → kits picker → either
  `showConfirmCreateSandbox` (when `StatusNotFound`) or the new
  destructive `showConfirmRecreateSandbox` (when running/stopped).
- Kit picker uses `widget.Check` rows; Escape cancels, Enter is
  intentionally not bound to confirm (it would race with Space-toggle on
  the focused checkbox).
- Card renders kits as 🧩 chips below the agent/version line.
- Help bar shows the right hint per status: `[k] create w/ kits` vs
  `[k] recreate w/ kits`.

**Status / errors**
- `SandboxResult.ErrorMessage()` and `CreateWorktreeResult.ErrorMessage()`
  prefer the CLI's first non-empty output line over the exec error.
- `ops.FirstNonEmptyLine` shared helper.
- `ApplyRefresh` no longer clears `StatusMessage` on success; only an
  explicit `setStatus` or Escape clears it.

**Removed**
- vim-nav key handlers (`j`/`k`/`h`/`l`) in `internal/gui/shortcuts.go` and
  matching rows in the README shortcut tables.
- `reloadRepoFromConfig` / `removeRepoFromUI`: mode removal now shows a
  "Restart biomelab to update" info dialog instead of hot-swapping the UI.

**Deps**
- Promotes `golang.org/x/sync` and `gopkg.in/yaml.v3` from indirect to
  direct.

## Test plan

- [ ] `task test` — covers `kits.ParseSpec`, `FilterMixinsForAgent`,
      `sortByDisplay`, `Kit.GitURL`, and `sandbox.CreateArgs` (with and
      without kits).
- [ ] Manual: on a sandbox in `StatusNotFound`, press `k`, pick an agent
      and a mixin, confirm → sandbox is created with both `--kit` flags
      and chips render on the card.
- [ ] Manual: on a running sandbox, press `k`, pick a kit, confirm the
      destructive dialog → sandbox is removed and re-created with the
      kit; host worktrees are untouched.
- [ ] Manual: trigger an sbx error (e.g. stop docker) and verify the
      status line shows the sbx message, not `exit status 1`.
- [ ] Manual: kick off a long-running create, wait for the next refresh
      tick, confirm the status message survives until completion.
- [ ] Manual: remove a mode and verify the "Restart biomelab" dialog
      appears.
