### PR TITLE
fix(gui): clear dialog state after Escape dismissal

### DIFF
--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -31,11 +31,20 @@ func (a *App) handleKeyName(key fyne.KeyName) {
 	// Escape dismisses open dialogs via their Hide() method.
 	// This triggers Fyne's proper cleanup (unlike manual overlay removal
 	// which corrupts the canvas state and breaks SetOnKeyDown).
+	//
+	// IMPORTANT: Fyne's dialog.ConfirmDialog.Hide() does NOT invoke the
+	// user-provided func(ok bool) callback when called programmatically
+	// (only button clicks fire it). That means the openDialog() cleanup
+	// closure — which sets dialogOpen=false and unfocuses the canvas — is
+	// never reached on an Escape dismissal. We mirror the cleanup here so
+	// the next keypress isn't swallowed by a stale dialogOpen guard.
 	if a.dialogOpen && key == fyne.KeyEscape {
 		if a.activeDialog != nil {
 			a.activeDialog.Hide()
 			a.activeDialog = nil
 		}
+		a.dialogOpen = false
+		a.window.Canvas().Unfocus()
 		return
 	}
 	if a.dialogOpen {

--- a/internal/gui/shortcuts_test.go
+++ b/internal/gui/shortcuts_test.go
@@ -1,0 +1,129 @@
+package gui
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+)
+
+// mockDialog is a stand-in for fyne dialog.Dialog used to inspect Hide() calls.
+type mockDialog struct{ hidden int }
+
+func (m *mockDialog) Hide() { m.hidden++ }
+
+// TestHandleKeyName_EscapeClearsDialogStateEvenWhenHideSkipsCallback is a
+// regression test for the bug where dialog.ConfirmDialog.Hide() in Fyne v2.7
+// does NOT invoke the func(ok bool) callback when called programmatically
+// (only button clicks do). The openDialog() cleanup runs from that callback,
+// so an Escape dismissal left a.dialogOpen=true forever, swallowing every
+// subsequent keypress — `e`, `c`, `f`, `p` etc.
+//
+// handleKeyName's global-Escape branch now mirrors the cleanup explicitly.
+// This test guarantees that contract holds for any future refactor.
+func TestHandleKeyName_EscapeClearsDialogStateEvenWhenHideSkipsCallback(t *testing.T) {
+	testApp := test.NewApp()
+	defer testApp.Quit()
+	win := testApp.NewWindow("test")
+	defer win.Close()
+
+	dlg := &mockDialog{}
+	a := &App{
+		window:       win,
+		dialogOpen:   true,
+		activeDialog: dlg,
+	}
+
+	a.handleKeyName(fyne.KeyEscape)
+
+	if a.dialogOpen {
+		t.Error("dialogOpen should be false after Escape dismissal (regression: was getting stuck true)")
+	}
+	if a.activeDialog != nil {
+		t.Errorf("activeDialog should be nil after Escape, got %v", a.activeDialog)
+	}
+	if dlg.hidden != 1 {
+		t.Errorf("Hide() should be called exactly once, got %d", dlg.hidden)
+	}
+}
+
+// TestHandleKeyName_EscapeWithNilActiveDialog ensures the Escape branch is
+// robust against a logical inconsistency (dialogOpen=true but activeDialog=nil).
+// State must still be cleared so future keys reach their handlers.
+func TestHandleKeyName_EscapeWithNilActiveDialog(t *testing.T) {
+	testApp := test.NewApp()
+	defer testApp.Quit()
+	win := testApp.NewWindow("test")
+	defer win.Close()
+
+	a := &App{
+		window:       win,
+		dialogOpen:   true,
+		activeDialog: nil,
+	}
+
+	a.handleKeyName(fyne.KeyEscape)
+
+	if a.dialogOpen {
+		t.Error("dialogOpen should be cleared even when activeDialog is nil")
+	}
+}
+
+// TestHandleKeyName_NonEscapeIsSwallowedWhileDialogOpen documents the
+// short-circuit on the second guard: any non-Escape key is dropped while a
+// dialog is open. Combined with the Escape regression test above, this
+// confirms the fix isolation — only Escape clears state, other keys still
+// honour the dialog-open guard.
+func TestHandleKeyName_NonEscapeIsSwallowedWhileDialogOpen(t *testing.T) {
+	testApp := test.NewApp()
+	defer testApp.Quit()
+	win := testApp.NewWindow("test")
+	defer win.Close()
+
+	dlg := &mockDialog{}
+	a := &App{
+		window:       win,
+		dialogOpen:   true,
+		activeDialog: dlg,
+	}
+
+	a.handleKeyName(fyne.KeyE)
+
+	if !a.dialogOpen {
+		t.Error("dialogOpen should remain true after a non-Escape key")
+	}
+	if a.activeDialog != dlg {
+		t.Error("activeDialog should remain set after a non-Escape key")
+	}
+	if dlg.hidden != 0 {
+		t.Errorf("Hide() should NOT be called for non-Escape keys, got %d calls", dlg.hidden)
+	}
+}
+
+// TestOpenDialog_CleanupResetsState verifies the cleanup closure returned by
+// openDialog() resets every piece of dialog state. The Escape regression
+// fix duplicates this cleanup inline; this test pins the canonical version
+// so the two paths stay in sync.
+func TestOpenDialog_CleanupResetsState(t *testing.T) {
+	testApp := test.NewApp()
+	defer testApp.Quit()
+	win := testApp.NewWindow("test")
+	defer win.Close()
+
+	a := &App{window: win}
+
+	cleanup := a.openDialog()
+	if !a.dialogOpen {
+		t.Fatal("openDialog should set dialogOpen=true")
+	}
+	a.activeDialog = &mockDialog{}
+
+	cleanup()
+
+	if a.dialogOpen {
+		t.Error("cleanup should reset dialogOpen to false")
+	}
+	if a.activeDialog != nil {
+		t.Error("cleanup should reset activeDialog to nil")
+	}
+}


### PR DESCRIPTION
## What's changed

Mirrors the `openDialog()` cleanup inline in the global Escape branch of
`handleKeyName`, so dismissing a dialog with Escape clears `dialogOpen` and
unfocuses the canvas the same way clicking a button would.

Adds `internal/gui/shortcuts_test.go` to pin the new contract: Escape
clears dialog state even when the dialog's callback never fires,
non-Escape keys remain swallowed while a dialog is open, and
`openDialog()`'s cleanup closure resets the same fields.

## Why is this important?

In Fyne v2.7, `dialog.ConfirmDialog.Hide()` does not invoke the
`func(ok bool)` callback when called programmatically — only button
clicks fire it. Every confirmation dialog in biomelab relies on that
callback to run the cleanup closure returned by `openDialog()`, which
resets `a.dialogOpen` and unfocuses the canvas. After Escape dismissed
the dialog the cleanup never ran, so `dialogOpen` stayed `true` and the
second guard in `handleKeyName` swallowed every subsequent keypress —
`e`, `c`, `f`, `p`, navigation keys — until the app was restarted.

The fix duplicates the cleanup (two lines) rather than threading the
callback through `Hide()` because Fyne's dialog API gives no clean way
to force the callback. The new tests document the contract so a future
refactor that extracts a helper can't silently regress it.

## Changes

- `internal/gui/shortcuts.go`: in the Escape-while-dialog-open branch,
  set `a.dialogOpen = false` and call `a.window.Canvas().Unfocus()`
  after `Hide()`. Added a comment explaining the Fyne quirk.
- `internal/gui/shortcuts_test.go` (new): four cases covering the
  Escape regression, nil-active-dialog robustness, non-Escape
  short-circuit, and the canonical `openDialog()` cleanup.

## Test plan

- [ ] `task test` — runs the new `shortcuts_test.go` cases.
- [ ] Manual: open any confirmation dialog (e.g. `c` to create a
      worktree, `d` to delete), press Escape, then press `e` or `c` and
      verify the action fires. Before the fix, those keys were silently
      dropped.
- [ ] Manual: dismiss the same dialog by clicking Cancel and confirm
      the same keys still work — the button path was already correct
      and must remain so.
