### PR TITLE
fix(ide): filter VS Code CLI-launcher zombies from detection

### DIFF
--- a/internal/ide/detect.go
+++ b/internal/ide/detect.go
@@ -52,6 +52,15 @@ func (d *Detector) DetectFromProcesses(procs []process.Info, worktreePaths []str
 
 	var ides []ideProc
 	for _, p := range procs {
+		// Electron-based IDEs (VS Code, Cursor) leave behind CLI-launcher
+		// processes after `code <path>`/`cursor <path>` runs. They invoke
+		// `<App>/Contents/Resources/app/out/cli.js` to handoff to the
+		// running window via IPC and then linger as zombies. They are NOT
+		// the IDE window — skip them so each worktree shows one entry per
+		// real window instead of N stale CLI handlers.
+		if strings.Contains(p.Cmdline, "/out/cli.js") {
+			continue
+		}
 		name := strings.ToLower(filepath.Base(p.Name))
 		matched := false
 		for _, pp := range ProcessPatterns {

--- a/internal/ide/detect_test.go
+++ b/internal/ide/detect_test.go
@@ -255,6 +255,35 @@ func TestDetect_TwoIndependentVSCodeWindows(t *testing.T) {
 	}
 }
 
+func TestDetect_FiltersCLILauncherZombies(t *testing.T) {
+	// macOS leaves behind `code <path>` CLI launchers as zombie pairs:
+	// a bash wrapper at /opt/homebrew/bin/code → a Code process running
+	// .../app/out/cli.js <path>. They IPC to the real window and never
+	// exit, polluting detection with N stale "vscode" entries per
+	// worktree. We must filter them out and keep only the real window.
+	lister := &mockLister{
+		procs: []process.Info{
+			// Real VS Code window.
+			{PID: 50, PPID: 1, Name: "Code", Cmdline: "/Applications/Visual Studio Code.app/Contents/MacOS/Code", Cwd: "/project"},
+			{PID: 51, PPID: 50, Name: "Code Helper (Renderer)", Cmdline: "Code Helper /project", Cwd: "/"},
+			// Three CLI launcher zombies from repeated `code /project` calls.
+			{PID: 100, PPID: 1, Name: "Code", Cmdline: "/Applications/Visual Studio Code.app/Contents/MacOS/Code /Applications/Visual Studio Code.app/Contents/Resources/app/out/cli.js /project", Cwd: "/"},
+			{PID: 200, PPID: 1, Name: "Code", Cmdline: "/Applications/Visual Studio Code.app/Contents/MacOS/Code /Applications/Visual Studio Code.app/Contents/Resources/app/out/cli.js /project", Cwd: "/"},
+			{PID: 300, PPID: 1, Name: "Code", Cmdline: "/Applications/Visual Studio Code.app/Contents/MacOS/Code /Applications/Visual Studio Code.app/Contents/Resources/app/out/cli.js /project", Cwd: "/"},
+		},
+	}
+
+	d := NewDetectorWithLister(lister)
+	result := d.Detect([]string{"/project"})
+
+	if len(result["/project"]) != 1 {
+		t.Fatalf("expected 1 IDE (real window only, cli.js zombies filtered), got %d", len(result["/project"]))
+	}
+	if result["/project"][0].PID != 50 {
+		t.Errorf("expected real-window root PID 50, got %d", result["/project"][0].PID)
+	}
+}
+
 func TestDetect_NestedHelpers(t *testing.T) {
 	// Some helpers spawn sub-helpers (e.g. Renderer spawns a child Renderer).
 	// They should all roll up to the same root.


### PR DESCRIPTION
## What's changed

Filters out Electron CLI-launcher processes (`.../app/out/cli.js`) from
IDE detection so VS Code and Cursor windows show as one entry per real
window instead of one per stale `code <path>` invocation.

## Why is this important?

On macOS, running `code /project` (or `cursor /project`) spawns a short
chain that ends in the IDE binary executing
`<App>/Contents/Resources/app/out/cli.js <path>`. That process IPCs to
the already-running window and then sits as a zombie — it never exits.
Each subsequent `code <path>` call adds another zombie. biomelab's
process-based IDE detector counts every match as an editor instance,
so a worktree the user opened three times in VS Code showed up as
three IDE entries on the card. Skipping `/out/cli.js` cmdlines removes
the duplicates without losing the real window process.

## Changes

- `internal/ide/detect.go`: in `DetectFromProcesses`, skip any process
  whose `Cmdline` contains `/out/cli.js` before pattern matching.
- `internal/ide/detect_test.go`: `TestDetect_FiltersCLILauncherZombies`
  feeds a real VS Code window plus three CLI-launcher zombies and
  asserts only the real window (PID 50) is returned.

## Test plan

- [ ] `task test` — covers the new filter case.
- [ ] Manual (macOS): open a worktree in VS Code two or three times
      with `code <path>`, then verify the card shows a single VS Code
      entry instead of N. Repeat with Cursor.
