### PR TITLE
fix(repo): reload config on sandbox mode removal

### DIFF
--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -1211,7 +1211,24 @@ func (a *App) handleRemoveMode() {
 		}
 		_ = config.Save(a.configPath, cfg)
 
-		dialog.ShowInformation("Mode Removed", modeLabel+" removed.\nRestart biomelab to update.", a.window)
+		idx := cfg.IndexOf(re.group.Path)
+		if idx < 0 {
+			return
+		}
+		re.group.Modes = cfg.Repos[idx].Modes
+		newMi := mi
+		if newMi >= len(re.group.Modes) {
+			newMi = len(re.group.Modes) - 1
+		}
+		if newMi < 0 {
+			newMi = 0
+		}
+		if a.repoPanel != nil {
+			a.repoPanel.groups = a.collectGroups()
+			a.repoPanel.rebuildList()
+		}
+		a.switchMode(a.active, newMi)
+		a.setStatus(modeLabel+" removed", false)
 	})
 }
 


### PR DESCRIPTION
## What's changed

Removing a mode from a repo (e.g. removing sandbox mode via `x`) no longer shows the "Mode Removed — Restart biomelab to update" dialog. Instead, `handleRemoveMode` now syncs the in-memory repo state from the freshly-saved config and refreshes the UI in place.

## Why is this important?

Previous commits already removed the restart prompt for other lifecycle actions (e.g. enrolling new repos, #50; modal-driven repo list refresh, #60), but the mode-removal path still asked the user to restart. That was inconsistent and unnecessary — the same in-memory refresh pattern used by `handleAddSandboxMode` works fine here.

## Changes

- `internal/gui/shortcuts.go` — replace the `dialog.ShowInformation("Mode Removed", …)` call in `handleRemoveMode` with logic that:
  - reloads modes from the persisted config into `re.group.Modes`
  - clamps `ActiveMode` to a valid index
  - rebuilds the repo panel groups and calls `switchMode` to re-render the dashboard
  - reports the result via `setStatus` instead of a modal
- DL-019 conversion (last sandbox removed → regular) is preserved.

## Test plan

- [ ] Repo with one sandbox mode + regular mode: remove the sandbox mode → no dialog, panel updates, dashboard switches to the remaining mode.
- [ ] Repo with only a sandbox mode: remove it → mode is converted to regular per DL-019, panel and dashboard reflect the regular mode without a restart prompt.
- [ ] Repo with multiple sandbox modes: remove one → remaining sandbox modes still listed, active mode falls back to a valid index.
- [ ] Confirm no "Restart biomelab" prompt appears anywhere in the app.
