### PR TITLE
feat(repos): drag-and-drop reorder of repo list

### DIFF
--- a/.claude/skills/product-owner/SKILL.md
+++ b/.claude/skills/product-owner/SKILL.md
@@ -298,7 +298,19 @@ If biomelab is launched from inside a git repository, that repo is automatically
 registered in regular mode. If launched from a non-git directory, biomelab shows
 an empty state with instructions to add a repo.
 
-### 18. Kanban Board View
+### 18. Reorder Repositories (drag handle)
+
+Each repo header in the left panel shows a small burger icon (`☰`) to the left
+of its name. Drag that icon vertically to move the repo up or down in the list.
+While dragging, a coloured bar marks the drop target between groups. Releasing
+the mouse commits the new order, persists it to `repos.json`, and keeps the
+previously-selected mode active under the same repo.
+
+Only the burger icon is draggable. Clicks on the repo name and its mode lines
+remain ordinary taps for selection. The hover cursor over the handle changes
+to a vertical-resize indicator to signal grab affordance.
+
+### 19. Kanban Board View
 
 The default view groups linked worktrees into four columns by PR/MR lifecycle stage:
 
@@ -718,3 +730,16 @@ worktree path would be falsely reported as a terminal. The upward walk ensures
 only shells that descend from Terminal.app, iTerm2, Alacritty, etc. are counted.
 The emulator pattern list is ordered so that specific names (e.g. "iterm2")
 match before broad ones (e.g. "terminal").
+
+### DL-025: Dedicated drag handle for repo reordering
+
+**Decision:** Repo reordering is triggered only by dragging the small burger
+icon (`☰`) on the left of each repo header. The rest of the header row — repo
+name, worktree-count chip, and the mode lines beneath — stays non-draggable.
+
+**Why:** Making the entire header row draggable risks accidental reorders when
+users click between modes or tap near the chip. A dedicated handle creates a
+clear, intentional gesture; the icon plus a vertical-resize cursor on hover
+signals "grab here to move this row" without overloading other row
+interactions. Keeping the handle small also avoids confusing it with the
+worktree-count chip on the right edge.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,7 @@ internal/
     dashboard.go       Right panel: main card + scrollable linked cards grid, refresh timestamps
     card.go            Worktree card rendering: branch, path, PR, agents, IDEs, status
     repo_panel.go      Left panel: tappable VBox of repo/mode items (NOT widget.Tree)
+    repo_panel_drag.go Drag-handle widget + reorder math for repo panel
     shortcuts.go       All keyboard handling: handleKeyName + handleRune, navigation, operations
     keycapture.go      desktop.Canvas.SetOnKeyDown setup, zoom shortcuts
     dialogs.go         Confirmation dialogs (delete, sandbox create/remove, send PR flow)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -269,6 +269,24 @@ func (c *Config) SetSandboxKits(path, sandboxName string, kits []KitInstall) boo
 	return false
 }
 
+// Move repositions the repo at fromIdx to toIdx, shifting the others to fill
+// the gap. Returns true if the order changed. Out-of-range or equal indices
+// are no-ops.
+func (c *Config) Move(fromIdx, toIdx int) bool {
+	n := len(c.Repos)
+	if fromIdx < 0 || fromIdx >= n || toIdx < 0 || toIdx >= n || fromIdx == toIdx {
+		return false
+	}
+	r := c.Repos[fromIdx]
+	if fromIdx < toIdx {
+		copy(c.Repos[fromIdx:toIdx], c.Repos[fromIdx+1:toIdx+1])
+	} else {
+		copy(c.Repos[toIdx+1:fromIdx+1], c.Repos[toIdx:fromIdx])
+	}
+	c.Repos[toIdx] = r
+	return true
+}
+
 // Remove removes a repo entry by path (all modes).
 // Returns true if the entry was found and removed.
 func (c *Config) Remove(path string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -264,6 +264,97 @@ func TestRemove(t *testing.T) {
 	}
 }
 
+func TestMove(t *testing.T) {
+	newCfg := func() *Config {
+		return &Config{
+			Repos: []RepoEntry{
+				{Path: "/a", Name: "a"},
+				{Path: "/b", Name: "b"},
+				{Path: "/c", Name: "c"},
+				{Path: "/d", Name: "d"},
+			},
+		}
+	}
+
+	paths := func(cfg *Config) []string {
+		out := make([]string, len(cfg.Repos))
+		for i, r := range cfg.Repos {
+			out[i] = r.Path
+		}
+		return out
+	}
+
+	t.Run("move down", func(t *testing.T) {
+		cfg := newCfg()
+		if !cfg.Move(0, 2) {
+			t.Fatal("expected change")
+		}
+		want := []string{"/b", "/c", "/a", "/d"}
+		if got := paths(cfg); !equalStrings(got, want) {
+			t.Errorf("paths = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("move up", func(t *testing.T) {
+		cfg := newCfg()
+		if !cfg.Move(3, 1) {
+			t.Fatal("expected change")
+		}
+		want := []string{"/a", "/d", "/b", "/c"}
+		if got := paths(cfg); !equalStrings(got, want) {
+			t.Errorf("paths = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("move to head", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.Move(2, 0)
+		want := []string{"/c", "/a", "/b", "/d"}
+		if got := paths(cfg); !equalStrings(got, want) {
+			t.Errorf("paths = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("move to tail", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.Move(1, 3)
+		want := []string{"/a", "/c", "/d", "/b"}
+		if got := paths(cfg); !equalStrings(got, want) {
+			t.Errorf("paths = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("no-op when from == to", func(t *testing.T) {
+		cfg := newCfg()
+		if cfg.Move(1, 1) {
+			t.Fatal("expected no change")
+		}
+	})
+
+	t.Run("out of range is no-op", func(t *testing.T) {
+		cfg := newCfg()
+		if cfg.Move(-1, 0) || cfg.Move(0, -1) || cfg.Move(0, 4) || cfg.Move(4, 0) {
+			t.Fatal("expected no change for out-of-range indices")
+		}
+		want := []string{"/a", "/b", "/c", "/d"}
+		if got := paths(cfg); !equalStrings(got, want) {
+			t.Errorf("paths = %v, want %v", got, want)
+		}
+	})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestIndexOf(t *testing.T) {
 	cfg := &Config{
 		Repos: []RepoEntry{

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -389,6 +389,7 @@ func (a *App) buildMainLayout() fyne.CanvasObject {
 		a.focus = focusLeft // clicking the tree means left panel has focus
 		a.switchMode(gi, mi)
 	}
+	a.repoPanel.OnReorder = a.reorderRepos
 
 	// Active dashboard (right side).
 	a.active = 0

--- a/internal/gui/repo_panel.go
+++ b/internal/gui/repo_panel.go
@@ -33,7 +33,22 @@ type RepoPanel struct {
 	content *fyne.Container
 	list    *fyne.Container // the scrollable mode list
 
+	// headerRows holds the outer header container for each group so the
+	// drag-reorder code can snapshot Y positions without re-walking the
+	// list. Index matches group index.
+	headerRows []fyne.CanvasObject
+
+	// Drag-reorder state. dragSrc == -1 when no drag is in progress.
+	// Header Y positions are snapshotted at drag start (the list isn't
+	// rebuilt during the drag, so they stay valid).
+	dragSrc          int
+	dragDst          int
+	dragCumulativeDY float32
+	headerYSnap      []float32
+	headerHSnap      []float32
+
 	OnModeSelected func(groupIdx, modeIdx int)
+	OnReorder      func(fromIdx, toIdx int)
 }
 
 // NewRepoPanel creates a repo panel from config entries.
@@ -41,6 +56,8 @@ func NewRepoPanel(groups []*RepoGroup, sbxStatuses map[string]sandbox.Status) *R
 	rp := &RepoPanel{
 		groups:      groups,
 		sbxStatuses: sbxStatuses,
+		dragSrc:     -1,
+		dragDst:     -1,
 	}
 	rp.build()
 	return rp
@@ -92,6 +109,7 @@ func (rp *RepoPanel) RebuildFull() {
 
 func (rp *RepoPanel) rebuildList() {
 	rp.list.Objects = nil
+	rp.headerRows = rp.headerRows[:0]
 
 	for gi, group := range rp.groups {
 		// Compact visual separator between repo groups.
@@ -104,25 +122,39 @@ func (rp *RepoPanel) rebuildList() {
 			rp.list.Add(sep)
 		}
 
-		// Repo header (not clickable) — bold + foreground color for
-		// strong visual hierarchy over the mode sub-items. The optional
-		// linked-worktree count surfaces "tasks in flight" at a glance.
-		// truncMonoText (instead of monoText) shrinks long repo names to
-		// fit, so a narrow panel never triggers a horizontal scrollbar
-		// that would push the chip off-screen.
+		// Drop indicator: a colored bar showing where the dragged repo
+		// would land. Drawn above the group at the drop target. When the
+		// target is past the last group, indicator is drawn below it
+		// (handled after the loop).
+		if rp.dragSrc >= 0 && rp.dragDst == gi && rp.dragSrc != gi {
+			rp.list.Add(rp.dropIndicator())
+		}
+
+		// Repo header — bold + foreground color for strong visual
+		// hierarchy over the mode sub-items. The optional linked-worktree
+		// count surfaces "tasks in flight" at a glance. truncMonoText
+		// (instead of monoText) shrinks long repo names to fit, so a
+		// narrow panel never triggers a horizontal scrollbar that would
+		// push the chip off-screen.
 		header := newTruncMonoText(group.Name, colorForeground, true, false)
 		header.txt.TextSize = scaledSize(12)
 		topGap := canvas.NewRectangle(colorPanelBg)
 		topGap.SetMinSize(fyne.NewSize(0, 4))
 
-		var headerRow fyne.CanvasObject = header
+		// Drag handle on the left of the header. Only the handle is
+		// draggable so users don't accidentally reorder by clicking the
+		// name area.
+		handle := newDragHandle(gi, rp)
+
+		var rightContent fyne.CanvasObject
 		if group.LinkedWorktreeCount > 0 {
-			// Chip on the right edge, header in the center so the chip
-			// claims its natural width first and the header truncates
-			// into whatever space is left.
-			headerRow = container.NewBorder(nil, nil, nil, worktreeCountChip(group.LinkedWorktreeCount), header)
+			rightContent = worktreeCountChip(group.LinkedWorktreeCount)
 		}
-		rp.list.Add(container.NewVBox(topGap, headerRow))
+		headerRow := container.NewBorder(nil, nil, handle, rightContent, header)
+
+		groupHeader := container.NewVBox(topGap, headerRow)
+		rp.headerRows = append(rp.headerRows, groupHeader)
+		rp.list.Add(groupHeader)
 
 		// Mode entries (clickable).
 		for mi, mode := range group.Modes {
@@ -138,7 +170,19 @@ func (rp *RepoPanel) rebuildList() {
 			rp.list.Add(tap)
 		}
 	}
+
+	// Drop indicator below the last group when dragging past the end.
+	if rp.dragSrc >= 0 && rp.dragDst == len(rp.groups) && rp.dragSrc != len(rp.groups)-1 {
+		rp.list.Add(rp.dropIndicator())
+	}
+
 	rp.list.Refresh()
+}
+
+func (rp *RepoPanel) dropIndicator() fyne.CanvasObject {
+	bar := canvas.NewRectangle(colorSelected)
+	bar.SetMinSize(fyne.NewSize(0, 2))
+	return bar
 }
 
 func (rp *RepoPanel) buildModeLine(mode config.ModeEntry, isActive bool) fyne.CanvasObject {

--- a/internal/gui/repo_panel_drag.go
+++ b/internal/gui/repo_panel_drag.go
@@ -1,0 +1,135 @@
+package gui
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/widget"
+)
+
+// dragHandle is the small burger-icon widget that sits to the left of each
+// repo name. Only the handle is draggable — the rest of the header stays
+// passive — so users don't accidentally drag the row by clicking anywhere on
+// it. Drag events are delegated back to the owning panel so reorder logic
+// lives in one place.
+type dragHandle struct {
+	widget.BaseWidget
+	groupIdx int
+	panel    *RepoPanel
+	icon     *canvas.Text
+}
+
+func newDragHandle(groupIdx int, panel *RepoPanel) *dragHandle {
+	h := &dragHandle{
+		groupIdx: groupIdx,
+		panel:    panel,
+		icon:     monoText("☰", colorDimGray, true),
+	}
+	h.icon.TextSize = scaledSize(12)
+	h.ExtendBaseWidget(h)
+	return h
+}
+
+func (h *dragHandle) CreateRenderer() fyne.WidgetRenderer {
+	return widget.NewSimpleRenderer(h.icon)
+}
+
+func (h *dragHandle) Dragged(e *fyne.DragEvent) {
+	h.panel.onHeaderDragged(h, e)
+}
+
+func (h *dragHandle) DragEnd() {
+	h.panel.onHeaderDragEnd(h)
+}
+
+// Cursor signals vertical-drag intent on hover.
+func (h *dragHandle) Cursor() desktop.Cursor {
+	return desktop.VResizeCursor
+}
+
+// onHeaderDragged is the per-frame drag callback. The first call begins the
+// drag (snapshotting header positions); subsequent calls accumulate the
+// vertical delta and recompute the drop target. We only trigger a list
+// rebuild when the target slot actually changes — this keeps the indicator
+// visible without thrashing the canvas on every pixel of movement.
+func (rp *RepoPanel) onHeaderDragged(h *dragHandle, e *fyne.DragEvent) {
+	if rp.dragSrc < 0 {
+		rp.dragSrc = h.groupIdx
+		rp.dragDst = h.groupIdx
+		rp.dragCumulativeDY = 0
+		rp.snapshotHeaderPositions()
+	}
+	rp.dragCumulativeDY += e.Dragged.DY
+	newDst := rp.computeDropTarget()
+	if newDst != rp.dragDst {
+		rp.dragDst = newDst
+		rp.rebuildList()
+	}
+}
+
+func (rp *RepoPanel) onHeaderDragEnd(_ *dragHandle) {
+	if rp.dragSrc < 0 {
+		return
+	}
+	src := rp.dragSrc
+	dst := rp.dragDst
+
+	rp.dragSrc = -1
+	rp.dragDst = -1
+	rp.dragCumulativeDY = 0
+	rp.headerYSnap = nil
+	rp.headerHSnap = nil
+
+	if src != dst && dst >= 0 && rp.OnReorder != nil {
+		// computeDropTarget returns len(groups) when the user has dragged
+		// past the bottom-most group. Normalize to last-index for the
+		// reorder callback.
+		if dst >= len(rp.groups) {
+			dst = len(rp.groups) - 1
+		}
+		rp.OnReorder(src, dst)
+		return
+	}
+	// No reorder — repaint to clear the drop indicator.
+	rp.rebuildList()
+}
+
+func (rp *RepoPanel) snapshotHeaderPositions() {
+	n := len(rp.headerRows)
+	rp.headerYSnap = make([]float32, n)
+	rp.headerHSnap = make([]float32, n)
+	for i, row := range rp.headerRows {
+		rp.headerYSnap[i] = row.Position().Y
+		rp.headerHSnap[i] = row.Size().Height
+	}
+}
+
+// computeDropTarget returns the group index where the dragged row would land
+// if the user released right now. Range is [0, len(groups)]; len(groups) means
+// "after the last group".
+func (rp *RepoPanel) computeDropTarget() int {
+	src := rp.dragSrc
+	if src < 0 || src >= len(rp.headerYSnap) {
+		return src
+	}
+	// The midpoint of the source row at its current dragged position.
+	srcMidY := rp.headerYSnap[src] + rp.headerHSnap[src]/2 + rp.dragCumulativeDY
+
+	// Dragging up: target = first slot whose midpoint sits below the
+	// dragged midpoint.
+	for i := range src {
+		midY := rp.headerYSnap[i] + rp.headerHSnap[i]/2
+		if srcMidY < midY {
+			return i
+		}
+	}
+	// Dragging down: target = last slot whose midpoint sits above the
+	// dragged midpoint.
+	for i := len(rp.headerYSnap) - 1; i > src; i-- {
+		midY := rp.headerYSnap[i] + rp.headerHSnap[i]/2
+		if srcMidY > midY {
+			return i
+		}
+	}
+	return src
+}

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -1239,3 +1239,43 @@ func (a *App) collectGroups() []*RepoGroup {
 	}
 	return groups
 }
+
+// reorderRepos moves the repo at fromIdx to toIdx in both the in-memory slice
+// and the persisted config, keeping a.active pointing at the same repo entry.
+// Triggered by the repo panel's drag-and-drop callback.
+func (a *App) reorderRepos(fromIdx, toIdx int) {
+	if fromIdx < 0 || fromIdx >= len(a.repos) || toIdx < 0 || toIdx >= len(a.repos) || fromIdx == toIdx {
+		return
+	}
+
+	re := a.repos[fromIdx]
+	if fromIdx < toIdx {
+		copy(a.repos[fromIdx:toIdx], a.repos[fromIdx+1:toIdx+1])
+	} else {
+		copy(a.repos[toIdx+1:fromIdx+1], a.repos[toIdx:fromIdx])
+	}
+	a.repos[toIdx] = re
+
+	// Keep a.active pointing at the same repo entry after the shuffle.
+	switch {
+	case a.active == fromIdx:
+		a.active = toIdx
+	case fromIdx < a.active && toIdx >= a.active:
+		a.active--
+	case fromIdx > a.active && toIdx <= a.active:
+		a.active++
+	}
+
+	if a.repoPanel != nil {
+		a.repoPanel.groups = a.collectGroups()
+		a.repoPanel.SetActive(a.active, a.repos[a.active].group.ActiveMode)
+	}
+
+	cfg, err := config.Load(a.configPath)
+	if err != nil {
+		return
+	}
+	if cfg.Move(fromIdx, toIdx) {
+		_ = config.Save(a.configPath, cfg)
+	}
+}


### PR DESCRIPTION
## What's changed

Adds drag-and-drop reordering for repositories in the left panel. Each repo
header now shows a small burger handle (`☰`) to the left of its name; dragging
that handle vertically moves the repo up or down in the list, with a coloured
bar marking the drop target between groups. Releasing commits the new order,
persists it to `~/.config/biomelab/repos.json`, and keeps the previously
selected mode active under the same repo.

Only the handle is draggable. The repo name, the worktree-count chip, and the
mode lines beneath continue to behave as before — clicks select, drags do
nothing — so users don't reorder by accident when navigating between modes.

## Why is this important?

The repo order in the panel matters when you're juggling several projects
across many AI agents: muscle memory builds around position, and "current
focus" tends to live at the top of the list. Before this change the order was
locked to insertion order, so the only way to surface a repo was to remove and
re-add it. A dedicated drag handle gives a one-gesture reorder without losing
the safety of accidental drags from anywhere on the row.

## Changes

**config**
- New `Config.Move(fromIdx, toIdx int) bool` in `internal/config/config.go`
  that shifts a repo entry in-place; round-trip covered by `TestMove`
  (move up/down, head/tail, no-op, out-of-range).

**gui/repo panel**
- New `internal/gui/repo_panel_drag.go` housing the `dragHandle` widget
  (implements `Draggable` + `Cursor`) and the panel-side drag math:
  `snapshotHeaderPositions`, `computeDropTarget`, and the
  `onHeaderDragged`/`onHeaderDragEnd` callbacks.
- `RepoPanel` gains `headerRows`, drag state fields, and an `OnReorder`
  callback. `rebuildList` lays the handle on the left of the header via
  `container.NewBorder(nil, nil, handle, chip, name)` and inserts a thin
  coloured bar at the drop target while a drag is in progress.
- Drop-target math snapshots header Y positions at drag start so subsequent
  rebuilds (when the indicator moves) don't perturb the calculation.

**gui/app**
- `App.reorderRepos` (in `shortcuts.go`) mirrors `Config.Move` on the
  in-memory `a.repos` slice, adjusts `a.active` so it still points at the
  same repo entry, refreshes the panel via `SetActive`, and persists the
  new order through `config.Save`. Wired in `buildMainLayout` as
  `a.repoPanel.OnReorder`.

**docs**
- `.claude/skills/product-owner/SKILL.md` — adds feature 18 "Reorder
  Repositories (drag handle)" and DL-025 explaining why only the handle is
  draggable.
- `ARCHITECTURE.md` — adds `repo_panel_drag.go` to the package layout.

## Test plan

- `go test -race ./...` — all packages pass, including the new `TestMove`
  cases in `internal/config`.
- `task lint` — clean.
- Manual (macOS, packaged via `task install-macos`):
  - Drag a repo down past another repo; release; verify the new order
    survives a restart by inspecting `~/.config/biomelab/repos.json`.
  - Drag a repo up to the top.
  - Drag a repo to the very bottom (drop indicator below last group).
  - Drag-then-cancel by releasing on the original slot; verify no reorder
    and indicator clears.
  - Click the repo name and mode lines while not dragging; verify
    selection still works and no spurious reorders fire.
  - Hover the handle; verify the cursor changes to a vertical-resize
    indicator.
