### PR TITLE
feat(notes): add per-worktree markdown notes with PR integration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,6 +116,66 @@ type RepoEntry struct {
 
 The old flat format (with `Sandbox bool`) is auto-migrated on load.
 
+## Task notes
+
+Each worktree has two optional artifact files that biomelab reads during the
+Send PR flow. The package is `internal/notes/`.
+
+| Path                                | Purpose                            |
+|-------------------------------------|------------------------------------|
+| `<worktree>/.biomelab/note.md`      | PR description — free-form Markdown |
+| `<worktree>/.biomelab/pr-title.md`  | PR title — single line              |
+
+**Contract**
+
+- Files live **inside** the worktree, so they're mounted into the sandbox
+  microVM alongside the source. Agents running in the sandbox read them as
+  ordinary files at the worktree root.
+- On first save, biomelab appends `/.biomelab/` to the **common gitdir's**
+  `info/exclude` (resolved via `<wt-gitdir>/commondir` for linked worktrees).
+  The per-worktree `info/exclude` file created by `git worktree add` is
+  **not** consulted by `git status` / `git check-ignore` — verified
+  empirically. One exclude entry covers both files in every worktree of the
+  repo; idempotent on repeat writes.
+- `note.md` (`notes.Write`): trailing whitespace is stripped and the file
+  ends in a single newline. All-whitespace input is treated as a delete.
+- `pr-title.md` (`notes.WriteTitle`): whitespace runs (including embedded
+  newlines and tabs) are collapsed to single spaces via
+  `strings.Fields` + `Join`, so the file is always one clean line + newline.
+  Empty-after-collapse input is treated as a delete. `notes.ReadTitle`
+  returns the first non-empty line.
+
+**Lifecycle**
+
+- Created on save from the editor (`m` key or right-click → editor → Save,
+  or Cmd/Ctrl+S).
+- Deleted when the user clears the corresponding field and saves, clicks
+  "Delete note" in the editor (removes both files after confirmation), or
+  removes the worktree (`ops.RemoveWorktree` wipes the entire directory).
+- Survives sandbox restarts because the artifact dir is part of the mounted
+  worktree, not container-only state.
+
+**Extension point**
+
+Any external tool can populate these paths and biomelab picks them up at PR
+send time. The flow: when the user presses `Shift+P` and the confirm dialog
+shows the **Use task notes for the PR title and description** checkbox
+(rendered when either file exists), ticking it makes biomelab pass
+
+```
+gh pr create --title <pr-title.md content> --body-file <note.md path> --head <branch>
+```
+
+(or the `glab mr create --title ... --description-file ...` equivalent on
+GitLab). Either side falls back to the commit-derived default when the
+corresponding file is absent. When the checkbox is unticked, biomelab falls
+back to `--fill` for both — the note files are ignored, not removed.
+
+This contract is what the [`/pr-scribe`](https://github.com/mdelapenya/coding-skills)
+skill (and similar tools) target: write the generated title and description
+to those two paths, and biomelab turns them into the actual PR on the next
+`Shift+P`.
+
 ## Pitfalls
 
 - go-git v6 is a pseudo-version. Do NOT use a `replace` directive.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **Pull** -- Press `p` to fetch all remotes and merge from origin.
 - **Open in terminal** -- Press `Enter` to open a worktree in a terminal. If a terminal is already detected for that worktree, it is brought to the foreground instead of opening a new one. On macOS, activation uses TTY matching via AppleScript (requires Automation permission on first use).
 - **Open in editor** -- Press `e` to open in `$BIOME_EDITOR` (defaults to VS Code).
+- **Task notes** -- Press `m` (or right-click a card) to open a Markdown editor with a live preview, scoped to that worktree. Notes are stored at `<worktree>/.biomelab/note.md` (description) and `<worktree>/.biomelab/pr-title.md` (single-line title), auto-excluded from git, and mounted into the sandbox alongside the source so agents can read them. When you `Shift+P` to send a PR, biomelab offers to use the prepared title and description in place of the commit-derived defaults. External tools that write to those two paths become contributors to the next PR.
 - **Zoom** -- `Ctrl+=` / `Ctrl+-` / `Ctrl+0` to scale the UI font.
 - **System tray** -- Closing the window hides to system tray. Tray menu toggles Show/Hide.
 - **Auto-refresh** -- Local state refreshes every 5s, network state every 30s (configurable).
@@ -124,6 +125,7 @@ Launch `biomelab` from any directory, or open `Biomelab.app` from Spotlight/Find
 | `→` | Navigate right | Linked cards |
 | `Enter` | Activate existing terminal or open new | Any card |
 | `e` | Open in editor | Any card |
+| `m` | Open note editor (right-click also works) | Any card |
 | `c` | Create worktree | Main card |
 | `f` | Fetch PR/MR | Main card |
 | `d` | Delete worktree / remove sandbox | Linked: delete; Main+sandbox: remove |

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -422,10 +422,29 @@ func (r *Repository) mainWorktree() (*Worktree, error) {
 	if err != nil {
 		return nil, err
 	}
-	wt.IsDirty = !status.IsClean()
+	wt.IsDirty = isDirtyIgnoringBiomelab(status)
 	wt.Sync = r.syncStatus(wt.Branch)
 
 	return wt, nil
+}
+
+// isDirtyIgnoringBiomelab returns true when status reports any change other
+// than entries under the .biomelab/ directory. go-git's Status() does not
+// honor .git/info/exclude (only in-tree .gitignore files), so biomelab's
+// own scratchpad files would otherwise mark every worktree dirty even when
+// `git status` agrees it's clean. Scoped to .biomelab/ on purpose — fixing
+// the broader info/exclude gap in go-git is a separate concern.
+func isDirtyIgnoringBiomelab(status gogit.Status) bool {
+	for path, s := range status {
+		if s.Staging == gogit.Unmodified && s.Worktree == gogit.Unmodified {
+			continue
+		}
+		if path == ".biomelab" || strings.HasPrefix(path, ".biomelab/") {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // referenceRemotes are the remote names checked for sync status.
@@ -537,7 +556,7 @@ func (r *Repository) linkedWorktree(name string) (*Worktree, error) {
 	if err != nil {
 		return nil, err
 	}
-	wt.IsDirty = !status.IsClean()
+	wt.IsDirty = isDirtyIgnoringBiomelab(status)
 	wt.Sync = r.syncStatus(wt.Branch)
 
 	return wt, nil

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -67,7 +67,11 @@ type App struct {
 	focus        focusPanel
 	dialogOpen   bool
 	activeDialog interface{ Hide() } // current dialog, for Escape dismissal
-	trayMenu     *fyne.Menu
+	// noteWindows tracks the currently-open note editor windows keyed by
+	// the worktree path so a repeated 'm' or Review click raises the
+	// existing window instead of spawning duplicates.
+	noteWindows map[string]fyne.Window
+	trayMenu    *fyne.Menu
 	// System tray theme submenu items, held so we can update Checked state.
 	trayThemeLight *fyne.MenuItem
 	trayThemeDark  *fyne.MenuItem

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -243,6 +243,10 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 	dash.OnCardSelected = func(_ int) {
 		a.focus = focusRight // clicking a card means right panel has focus
 	}
+	dash.OnNoteRequested = func(wt git.Worktree) {
+		a.focus = focusRight
+		a.openNoteDialog(wt)
+	}
 
 	rm := NewRefreshManager(repo, a.detector, a.ideDetector, a.termDetector, a.procLister, prProv, a.refreshInterval)
 	rm.SetSandboxCandidates(sbxCandidates)

--- a/internal/gui/card.go
+++ b/internal/gui/card.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/agent"
 	"github.com/mdelapenya/biomelab/internal/git"
 	"github.com/mdelapenya/biomelab/internal/ide"
+	"github.com/mdelapenya/biomelab/internal/notes"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
 	"github.com/mdelapenya/biomelab/internal/terminal"
@@ -27,8 +28,9 @@ const maxMainPathChars = 90
 // tappableCard is a custom widget that wraps card content and responds to taps.
 type tappableCard struct {
 	widget.BaseWidget
-	content fyne.CanvasObject
-	onTap   func()
+	content        fyne.CanvasObject
+	onTap          func()
+	onSecondaryTap func()
 }
 
 func newTappableCard(content fyne.CanvasObject, onTap func()) *tappableCard {
@@ -37,13 +39,19 @@ func newTappableCard(content fyne.CanvasObject, onTap func()) *tappableCard {
 	return tc
 }
 
+func (tc *tappableCard) SetOnSecondaryTap(fn func()) { tc.onSecondaryTap = fn }
+
 func (tc *tappableCard) Tapped(_ *fyne.PointEvent) {
 	if tc.onTap != nil {
 		tc.onTap()
 	}
 }
 
-func (tc *tappableCard) TappedSecondary(_ *fyne.PointEvent) {}
+func (tc *tappableCard) TappedSecondary(_ *fyne.PointEvent) {
+	if tc.onSecondaryTap != nil {
+		tc.onSecondaryTap()
+	}
+}
 
 func (tc *tappableCard) CreateRenderer() fyne.WidgetRenderer {
 	return widget.NewSimpleRenderer(tc.content)
@@ -102,15 +110,18 @@ func buildCardContent(
 	}
 	branchText := monoText(branchPrefix+wt.Branch, branchColor, true)
 	branchText.TextSize = scaledSize(13)
-	if wt.IsMain {
-		badge := makeBadge("main")
-		items = append(items, container.NewHBox(branchText, badge))
-	} else if wt.Detached {
-		detached := monoText(" (detached)", colorDimGray, false)
-		items = append(items, container.NewHBox(branchText, detached))
-	} else {
-		items = append(items, branchText)
+	row := []fyne.CanvasObject{branchText}
+	if notes.Exists(wt.Path) {
+		noteIcon := monoText(" 📝", colorYellow, false)
+		noteIcon.TextSize = scaledSize(11)
+		row = append(row, noteIcon)
 	}
+	if wt.IsMain {
+		row = append(row, makeBadge("main"))
+	} else if wt.Detached {
+		row = append(row, monoText(" (detached)", colorDimGray, false))
+	}
+	items = append(items, container.NewHBox(row...))
 
 	// Path: prefix-truncated dynamically so it never overflows the card,
 	// regardless of how narrow the card becomes when the window is resized.

--- a/internal/gui/dashboard.go
+++ b/internal/gui/dashboard.go
@@ -12,6 +12,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 
 	"github.com/mdelapenya/biomelab/internal/agent"
+	"github.com/mdelapenya/biomelab/internal/git"
 	"github.com/mdelapenya/biomelab/internal/ide"
 	"github.com/mdelapenya/biomelab/internal/ops"
 	"github.com/mdelapenya/biomelab/internal/provider"
@@ -117,6 +118,10 @@ type Dashboard struct {
 	// OnCardSelected is called when a card is clicked. The index is the
 	// worktree index (0=main, 1+=linked).
 	OnCardSelected func(idx int)
+
+	// OnNoteRequested fires when the user right-clicks a card and wants to
+	// open the per-worktree note editor.
+	OnNoteRequested func(wt git.Worktree)
 }
 
 // NewDashboard creates a dashboard from the given repo state.
@@ -265,6 +270,12 @@ func (d *Dashboard) build() fyne.CanvasObject {
 		}
 		d.Rebuild()
 	})
+	mainWtCopy := *mainWt
+	mainCard.SetOnSecondaryTap(func() {
+		if d.OnNoteRequested != nil {
+			d.OnNoteRequested(mainWtCopy)
+		}
+	})
 
 	// Contextual help below main card (dynamic, matches TUI).
 	helpStr := "[c] create  [f] fetch PR  [p] pull"
@@ -326,13 +337,20 @@ func (d *Dashboard) build() fyne.CanvasObject {
 			isSelected,
 		)
 		cardIdx := wtIdx // capture for closure
-		cards = append(cards, makeCard(content, isSelected, false, func() {
+		wtCopy := wt     // capture for closure
+		card := makeCard(content, isSelected, false, func() {
 			d.state.SelectedCard = cardIdx
 			if d.OnCardSelected != nil {
 				d.OnCardSelected(cardIdx)
 			}
 			d.Rebuild()
-		}))
+		})
+		card.SetOnSecondaryTap(func() {
+			if d.OnNoteRequested != nil {
+				d.OnNoteRequested(wtCopy)
+			}
+		})
+		cards = append(cards, card)
 	}
 
 	// Section header.
@@ -355,7 +373,7 @@ func (d *Dashboard) helpBar() fyne.CanvasObject {
 	if d.state.ViewMode == ViewKanban {
 		viewHint = "[g] grid"
 	}
-	help := monoText("↑↓ nav  [Tab] panel  [⏎] open  [e] editor  [r] refresh  [d] delete  [p] pull  [P] PR  "+viewHint, colorDimGray, false)
+	help := monoText("↑↓ nav  [Tab] panel  [⏎] open  [e] editor  [m] note  [r] refresh  [d] delete  [p] pull  [P] PR  "+viewHint, colorDimGray, false)
 	help.TextSize = scaledSize(9)
 
 	return container.NewStack(bg, container.NewPadded(help))

--- a/internal/gui/dialogs.go
+++ b/internal/gui/dialogs.go
@@ -333,7 +333,14 @@ func displayLabel(k kits.Kit) string {
 	return fmt.Sprintf("%s  (%s)", name, k.Name)
 }
 
-func showSendPRConfirm(parent fyne.Window, branch string, remote git.RemoteInfo, existingPR *provider.PRInfo, onDone func(), onConfirm func()) dialog.Dialog {
+// showSendPRConfirm renders the final confirmation step of the PR send flow.
+// When hasNotes is true and the action creates a new PR (existingPR == nil),
+// a checkbox lets the user opt in to using their worktree notes — both the
+// PR title (from .biomelab/pr-title.md) and description (from .biomelab/
+// note.md) — instead of the commit-derived defaults. Defaults to checked
+// since the user took the trouble to prepare notes. onConfirm receives the
+// checkbox state — callers should ignore it when no checkbox was rendered.
+func showSendPRConfirm(parent fyne.Window, branch string, remote git.RemoteInfo, existingPR *provider.PRInfo, hasNotes bool, onDone func(), onConfirm func(useNotes bool)) dialog.Dialog {
 	var d *dialog.ConfirmDialog
 	var title, action string
 	body := container.NewVBox()
@@ -354,6 +361,14 @@ func showSendPRConfirm(parent fyne.Window, branch string, remote git.RemoteInfo,
 	body.Add(monoText("Branch: "+branch, colorBranch, true))
 	body.Add(monoText("Remote: "+remote.Name+" ("+remote.Repo+")", colorGray, false))
 
+	var noteCheck *widget.Check
+	if hasNotes && existingPR == nil {
+		body.Add(widget.NewSeparator())
+		noteCheck = widget.NewCheck("Use task notes for the PR title and description", nil)
+		noteCheck.SetChecked(true)
+		body.Add(noteCheck)
+	}
+
 	keyCap := newDialogKeyCapture(
 		func() { d.Confirm() },
 		func() { d.Hide() },
@@ -363,7 +378,8 @@ func showSendPRConfirm(parent fyne.Window, branch string, remote git.RemoteInfo,
 	d = dialog.NewCustomConfirm(title, action, "Cancel", content, func(ok bool) {
 		onDone()
 		if ok {
-			onConfirm()
+			useNotes := noteCheck != nil && noteCheck.Checked
+			onConfirm(useNotes)
 		}
 	}, parent)
 	d.Resize(dialogMinSize)

--- a/internal/gui/dialogs.go
+++ b/internal/gui/dialogs.go
@@ -337,10 +337,14 @@ func displayLabel(k kits.Kit) string {
 // When hasNotes is true and the action creates a new PR (existingPR == nil),
 // a checkbox lets the user opt in to using their worktree notes — both the
 // PR title (from .biomelab/pr-title.md) and description (from .biomelab/
-// note.md) — instead of the commit-derived defaults. Defaults to checked
-// since the user took the trouble to prepare notes. onConfirm receives the
-// checkbox state — callers should ignore it when no checkbox was rendered.
-func showSendPRConfirm(parent fyne.Window, branch string, remote git.RemoteInfo, existingPR *provider.PRInfo, hasNotes bool, onDone func(), onConfirm func(useNotes bool)) dialog.Dialog {
+// note.md) — instead of the commit-derived defaults, and a Review button
+// opens the note editor for a final pass before sending. The editor is a
+// non-modal window so this dialog stays put while the user reviews.
+// Defaults to checked since the user took the trouble to prepare notes.
+// onConfirm receives the checkbox state — callers should ignore it when no
+// checkbox was rendered. onReview is invoked when the user clicks Review;
+// callers pass nil when there are no notes to review.
+func showSendPRConfirm(parent fyne.Window, branch string, remote git.RemoteInfo, existingPR *provider.PRInfo, hasNotes bool, onDone func(), onConfirm func(useNotes bool), onReview func()) dialog.Dialog {
 	var d *dialog.ConfirmDialog
 	var title, action string
 	body := container.NewVBox()
@@ -367,13 +371,24 @@ func showSendPRConfirm(parent fyne.Window, branch string, remote git.RemoteInfo,
 		noteCheck = widget.NewCheck("Use task notes for the PR title and description", nil)
 		noteCheck.SetChecked(true)
 		body.Add(noteCheck)
+		reviewBtn := widget.NewButton("Review notes", func() {
+			if onReview != nil {
+				onReview()
+			}
+		})
+		reviewBtn.Importance = widget.LowImportance
+		body.Add(reviewBtn)
 	}
 
 	keyCap := newDialogKeyCapture(
 		func() { d.Confirm() },
 		func() { d.Hide() },
 	)
-	content := container.NewStack(body, keyCap)
+	// keyCap goes BENEATH body in the Stack so it doesn't intercept mouse
+	// clicks meant for the checkbox / Review button. keyCap still receives
+	// Enter/Escape via focus (set below) — hit-test and keyboard dispatch
+	// are independent.
+	content := container.NewStack(keyCap, body)
 
 	d = dialog.NewCustomConfirm(title, action, "Cancel", content, func(ok bool) {
 		onDone()

--- a/internal/gui/kanban.go
+++ b/internal/gui/kanban.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mdelapenya/biomelab/internal/agent"
 	"github.com/mdelapenya/biomelab/internal/git"
+	"github.com/mdelapenya/biomelab/internal/notes"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/terminal"
 )
@@ -117,7 +118,13 @@ func buildKanbanCardContent(
 	}
 	branchLabel := monoText(prefix+wt.Branch, branchColor, true)
 	branchLabel.TextSize = scaledSize(12)
-	rows = append(rows, container.NewHBox(dot, branchLabel))
+	row := []fyne.CanvasObject{dot, branchLabel}
+	if notes.Exists(wt.Path) {
+		noteIcon := monoText(" 📝", colorYellow, false)
+		noteIcon.TextSize = scaledSize(10)
+		row = append(row, noteIcon)
+	}
+	rows = append(rows, container.NewHBox(row...))
 
 	// ── Row 2: ● agent-name (omitted when no agent) ─────────────────────
 	if len(agents) > 0 {
@@ -189,7 +196,7 @@ func newKanbanCardWrapper(inner *tappableCard) *kanbanCardWrapper {
 }
 
 func (w *kanbanCardWrapper) Tapped(e *fyne.PointEvent)          { w.inner.Tapped(e) }
-func (w *kanbanCardWrapper) TappedSecondary(_ *fyne.PointEvent) {}
+func (w *kanbanCardWrapper) TappedSecondary(e *fyne.PointEvent) { w.inner.TappedSecondary(e) }
 func (w *kanbanCardWrapper) CreateRenderer() fyne.WidgetRenderer {
 	return &kanbanCardWrapperRenderer{w: w}
 }
@@ -363,12 +370,18 @@ func (d *Dashboard) buildKanbanView() fyne.CanvasObject {
 					isSelected,
 				)
 				cardWtIdx := wtIdx // capture for closure
+				wtCopy := wt       // capture for closure
 				card := makeCard(content, isSelected, false, func() {
 					d.state.SelectedCard = cardWtIdx
 					if d.OnCardSelected != nil {
 						d.OnCardSelected(cardWtIdx)
 					}
 					d.Rebuild()
+				})
+				card.SetOnSecondaryTap(func() {
+					if d.OnNoteRequested != nil {
+						d.OnNoteRequested(wtCopy)
+					}
 				})
 				// Wrap each card so its MinSize.Width = 1, forcing the VScroll to
 				// size it to the column width rather than the natural text width.

--- a/internal/gui/note_dialog.go
+++ b/internal/gui/note_dialog.go
@@ -1,0 +1,143 @@
+package gui
+
+import (
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/mdelapenya/biomelab/internal/git"
+	"github.com/mdelapenya/biomelab/internal/notes"
+)
+
+var noteWindowInitialSize = fyne.NewSize(720, 500)
+
+// noteEntry is a multi-line Entry that invokes onEscape on Escape, so the
+// caller can close its container (a dialog or a standalone window) without
+// Fyne's default focus manager swallowing the key.
+type noteEntry struct {
+	widget.Entry
+	onEscape func()
+}
+
+func newNoteEntry(initial string, onEscape func()) *noteEntry {
+	e := &noteEntry{onEscape: onEscape}
+	e.MultiLine = true
+	e.Wrapping = fyne.TextWrapWord
+	e.SetPlaceHolder("Write notes in Markdown — # headings, **bold**, *italic*, [links](url), lists, `code`, ```code blocks```")
+	e.SetText(initial)
+	e.ExtendBaseWidget(e)
+	return e
+}
+
+func (e *noteEntry) TypedKey(key *fyne.KeyEvent) {
+	if key.Name == fyne.KeyEscape {
+		if e.onEscape != nil {
+			e.onEscape()
+		}
+		return
+	}
+	e.Entry.TypedKey(key)
+}
+
+// openNoteDialog opens the note editor as a standalone window so the user
+// can drag-resize it for long notes. The window has an H-split editor +
+// live markdown preview, plus Save / Cancel / Delete buttons. Saving an
+// empty note deletes the file; Cmd/Ctrl+S also saves; Esc cancels. The
+// window is non-modal: the main window stays usable while the editor is
+// open (useful for referencing a card while writing).
+func (a *App) openNoteDialog(wt git.Worktree) {
+	initial, _, _ := notes.Read(wt.Path)
+	noteExists := notes.Exists(wt.Path)
+
+	w := a.fyneApp.NewWindow("Note — " + wt.Branch)
+
+	preview := widget.NewRichTextFromMarkdown(initial)
+	preview.Wrapping = fyne.TextWrapWord
+	previewScroll := container.NewVScroll(preview)
+
+	entry := newNoteEntry(initial, func() { w.Close() })
+	entry.OnChanged = func(s string) {
+		preview.ParseMarkdown(s)
+	}
+
+	editorLabel := monoText("✎ Markdown", colorBranch, true)
+	editorLabel.TextSize = scaledSize(11)
+	previewLabel := monoText("👁 Preview", colorBranch, true)
+	previewLabel.TextSize = scaledSize(11)
+
+	editorPane := container.NewBorder(editorLabel, nil, nil, nil, entry)
+	previewPane := container.NewBorder(previewLabel, nil, nil, nil, previewScroll)
+
+	split := container.NewHSplit(editorPane, previewPane)
+	split.Offset = 0.5
+
+	saveAndClose := func() {
+		text := entry.Text
+		var err error
+		if strings.TrimSpace(text) == "" {
+			err = notes.Delete(wt.Path)
+		} else {
+			err = notes.Write(wt.Path, text)
+		}
+		if err != nil {
+			a.setStatus("Note save failed: "+err.Error(), true)
+		}
+		if a.dashboard != nil {
+			a.dashboard.Rebuild()
+		}
+		w.Close()
+	}
+
+	saveBtn := widget.NewButton("Save", saveAndClose)
+	saveBtn.Importance = widget.HighImportance
+	cancelBtn := widget.NewButton("Cancel", func() { w.Close() })
+
+	rightButtons := container.NewHBox(cancelBtn, saveBtn)
+	var leftSide fyne.CanvasObject
+	if noteExists {
+		deleteBtn := widget.NewButton("Delete note", func() {
+			dialog.ShowConfirm(
+				"Delete note?",
+				"This permanently removes the note for "+wt.Branch+".",
+				func(confirmed bool) {
+					if !confirmed {
+						return
+					}
+					if err := notes.Delete(wt.Path); err != nil {
+						a.setStatus("Note delete failed: "+err.Error(), true)
+					}
+					if a.dashboard != nil {
+						a.dashboard.Rebuild()
+					}
+					w.Close()
+				},
+				w,
+			)
+		})
+		deleteBtn.Importance = widget.LowImportance
+		leftSide = deleteBtn
+	}
+	bottomRow := container.NewBorder(nil, nil, leftSide, rightButtons, nil)
+
+	content := container.NewBorder(nil, bottomRow, nil, nil, split)
+	w.SetContent(content)
+	w.Resize(noteWindowInitialSize)
+	w.CenterOnScreen()
+
+	// Cmd/Ctrl+S also saves. Canvas-level shortcut fires even when the
+	// entry has focus because Cmd+S has a non-zero modifier and Entry
+	// doesn't bind it.
+	w.Canvas().AddShortcut(&desktop.CustomShortcut{
+		KeyName:  fyne.KeyS,
+		Modifier: fyne.KeyModifierShortcutDefault,
+	}, func(_ fyne.Shortcut) {
+		saveAndClose()
+	})
+
+	w.Show()
+	w.Canvas().Focus(entry)
+}

--- a/internal/gui/note_dialog.go
+++ b/internal/gui/note_dialog.go
@@ -50,10 +50,26 @@ func (e *noteEntry) TypedKey(key *fyne.KeyEvent) {
 // window is non-modal: the main window stays usable while the editor is
 // open (useful for referencing a card while writing).
 func (a *App) openNoteDialog(wt git.Worktree) {
-	initial, _, _ := notes.Read(wt.Path)
-	noteExists := notes.Exists(wt.Path)
+	// Re-focus an existing editor for this worktree rather than spawning
+	// another window. Repeated 'm' presses or Review clicks just raise
+	// the open editor.
+	if existing, ok := a.noteWindows[wt.Path]; ok {
+		existing.RequestFocus()
+		return
+	}
+
+	initial, bodyExists, _ := notes.Read(wt.Path)
+	initialTitle, titleExists, _ := notes.ReadTitle(wt.Path)
+	noteExists := bodyExists || titleExists
 
 	w := a.fyneApp.NewWindow("Note — " + wt.Branch)
+	if a.noteWindows == nil {
+		a.noteWindows = make(map[string]fyne.Window)
+	}
+	a.noteWindows[wt.Path] = w
+	w.SetOnClosed(func() {
+		delete(a.noteWindows, wt.Path)
+	})
 
 	preview := widget.NewRichTextFromMarkdown(initial)
 	preview.Wrapping = fyne.TextWrapWord
@@ -63,6 +79,14 @@ func (a *App) openNoteDialog(wt git.Worktree) {
 	entry.OnChanged = func(s string) {
 		preview.ParseMarkdown(s)
 	}
+
+	titleEntry := newDialogEntry(func() { w.Close() })
+	titleEntry.SetPlaceHolder("Conventional Commits title — feat(scope): description")
+	titleEntry.SetText(initialTitle)
+
+	titleLabel := monoText("# PR title", colorBranch, true)
+	titleLabel.TextSize = scaledSize(11)
+	titleSection := container.NewVBox(titleLabel, titleEntry)
 
 	editorLabel := monoText("✎ Markdown", colorBranch, true)
 	editorLabel.TextSize = scaledSize(11)
@@ -76,15 +100,18 @@ func (a *App) openNoteDialog(wt git.Worktree) {
 	split.Offset = 0.5
 
 	saveAndClose := func() {
-		text := entry.Text
-		var err error
-		if strings.TrimSpace(text) == "" {
-			err = notes.Delete(wt.Path)
+		var titleErr, bodyErr error
+		titleErr = notes.WriteTitle(wt.Path, titleEntry.Text)
+		if strings.TrimSpace(entry.Text) == "" {
+			bodyErr = notes.Delete(wt.Path)
 		} else {
-			err = notes.Write(wt.Path, text)
+			bodyErr = notes.Write(wt.Path, entry.Text)
 		}
-		if err != nil {
-			a.setStatus("Note save failed: "+err.Error(), true)
+		switch {
+		case titleErr != nil:
+			a.setStatus("Note save failed (title): "+titleErr.Error(), true)
+		case bodyErr != nil:
+			a.setStatus("Note save failed (body): "+bodyErr.Error(), true)
 		}
 		if a.dashboard != nil {
 			a.dashboard.Rebuild()
@@ -102,13 +129,16 @@ func (a *App) openNoteDialog(wt git.Worktree) {
 		deleteBtn := widget.NewButton("Delete note", func() {
 			dialog.ShowConfirm(
 				"Delete note?",
-				"This permanently removes the note for "+wt.Branch+".",
+				"This permanently removes the title and description for "+wt.Branch+".",
 				func(confirmed bool) {
 					if !confirmed {
 						return
 					}
 					if err := notes.Delete(wt.Path); err != nil {
 						a.setStatus("Note delete failed: "+err.Error(), true)
+					}
+					if err := notes.DeleteTitle(wt.Path); err != nil {
+						a.setStatus("Note delete failed (title): "+err.Error(), true)
 					}
 					if a.dashboard != nil {
 						a.dashboard.Rebuild()
@@ -123,7 +153,7 @@ func (a *App) openNoteDialog(wt git.Worktree) {
 	}
 	bottomRow := container.NewBorder(nil, nil, leftSide, rightButtons, nil)
 
-	content := container.NewBorder(nil, bottomRow, nil, nil, split)
+	content := container.NewBorder(titleSection, bottomRow, nil, nil, split)
 	w.SetContent(content)
 	w.Resize(noteWindowInitialSize)
 	w.CenterOnScreen()
@@ -139,5 +169,9 @@ func (a *App) openNoteDialog(wt git.Worktree) {
 	})
 
 	w.Show()
+	// When the editor is opened from another window's dialog overlay
+	// (e.g. the Review button in showSendPRConfirm), macOS can leave the
+	// new window behind the parent. Explicitly request focus.
+	w.RequestFocus()
 	w.Canvas().Focus(entry)
 }

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/config"
 	"github.com/mdelapenya/biomelab/internal/git"
 	"github.com/mdelapenya/biomelab/internal/kits"
+	"github.com/mdelapenya/biomelab/internal/notes"
 	"github.com/mdelapenya/biomelab/internal/ops"
 	"github.com/mdelapenya/biomelab/internal/provider"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
@@ -116,6 +117,8 @@ func (a *App) handleKeyName(key fyne.KeyName) {
 		a.handleCreateOrEnrollSandbox()
 	case fyne.KeyK:
 		a.handleInstallKits()
+	case fyne.KeyM:
+		a.handleEditNote()
 	}
 }
 
@@ -660,6 +663,18 @@ func (a *App) handlePull() {
 	}()
 }
 
+func (a *App) handleEditNote() {
+	re := a.activeRepo()
+	if re == nil {
+		return
+	}
+	idx, ok := a.selectedWorktree()
+	if !ok {
+		return
+	}
+	a.openNoteDialog(re.state.Worktrees[idx])
+}
+
 func (a *App) handleOpenEditor() {
 	re := a.activeRepo()
 	if re == nil {
@@ -720,37 +735,53 @@ func (a *App) handleSendPR() {
 		existingPR = re.state.PRs[wt.Branch]
 	}
 
+	notePath := ""
+	if notes.Exists(wt.Path) {
+		notePath = notes.Path(wt.Path)
+	}
+	noteTitle := ""
+	if t, ok, _ := notes.ReadTitle(wt.Path); ok {
+		noteTitle = t
+	}
+
 	done := a.openDialog()
-	a.sendPRFlow(re, wt.Branch, remotes, needsWarning, wt.IsDirty, hasStash, existingPR, done)
+	a.sendPRFlow(re, wt.Branch, remotes, needsWarning, wt.IsDirty, hasStash, existingPR, noteTitle, notePath, done)
 }
 
-func (a *App) sendPRFlow(re *repoEntry, branch string, remotes []git.RemoteInfo, needsWarning, dirty, hasStash bool, existingPR *provider.PRInfo, done func()) {
+func (a *App) sendPRFlow(re *repoEntry, branch string, remotes []git.RemoteInfo, needsWarning, dirty, hasStash bool, existingPR *provider.PRInfo, noteTitle, notePath string, done func()) {
 	if needsWarning {
 		a.activeDialog = showSendPRDirtyWarning(a.window, branch, dirty, hasStash, done, func() {
-			a.sendPRSelectRemote(re, branch, remotes, existingPR, done)
+			a.sendPRSelectRemote(re, branch, remotes, existingPR, noteTitle, notePath, done)
 		})
 		return
 	}
-	a.sendPRSelectRemote(re, branch, remotes, existingPR, done)
+	a.sendPRSelectRemote(re, branch, remotes, existingPR, noteTitle, notePath, done)
 }
 
-func (a *App) sendPRSelectRemote(re *repoEntry, branch string, remotes []git.RemoteInfo, existingPR *provider.PRInfo, done func()) {
+func (a *App) sendPRSelectRemote(re *repoEntry, branch string, remotes []git.RemoteInfo, existingPR *provider.PRInfo, noteTitle, notePath string, done func()) {
 	if len(remotes) > 1 {
 		a.activeDialog = showSendPRRemoteSelection(a.window, remotes, done, func(idx int) {
-			a.sendPRConfirm(re, branch, remotes[idx], existingPR, done)
+			a.sendPRConfirm(re, branch, remotes[idx], existingPR, noteTitle, notePath, done)
 		})
 		return
 	}
-	a.sendPRConfirm(re, branch, remotes[0], existingPR, done)
+	a.sendPRConfirm(re, branch, remotes[0], existingPR, noteTitle, notePath, done)
 }
 
-func (a *App) sendPRConfirm(re *repoEntry, branch string, remote git.RemoteInfo, existingPR *provider.PRInfo, done func()) {
-	a.activeDialog = showSendPRConfirm(a.window, branch, remote, existingPR, done, func() {
+func (a *App) sendPRConfirm(re *repoEntry, branch string, remote git.RemoteInfo, existingPR *provider.PRInfo, noteTitle, notePath string, done func()) {
+	hasNotes := noteTitle != "" || notePath != ""
+	a.activeDialog = showSendPRConfirm(a.window, branch, remote, existingPR, hasNotes, done, func(useNotes bool) {
 		pushOnly := existingPR != nil
 		if pushOnly {
 			a.setStatus("Pushing...", false)
 		} else {
 			a.setStatus("Pushing and creating PR...", false)
+		}
+		title := ""
+		bodyFile := ""
+		if useNotes {
+			title = noteTitle
+			bodyFile = notePath
 		}
 		go func() {
 			if pushOnly {
@@ -764,7 +795,7 @@ func (a *App) sendPRConfirm(re *repoEntry, branch string, remote git.RemoteInfo,
 					a.refreshMgr.TriggerNetwork()
 				})
 			} else {
-				result := ops.SendPR(re.repo, re.prProv, branch, remote)
+				result := ops.SendPR(re.repo, re.prProv, branch, remote, title, bodyFile)
 				fyne.Do(func() {
 					if result.Err != nil {
 						a.setStatus("PR creation failed: "+result.Err.Error(), true)

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -735,42 +735,42 @@ func (a *App) handleSendPR() {
 		existingPR = re.state.PRs[wt.Branch]
 	}
 
-	notePath := ""
-	if notes.Exists(wt.Path) {
-		notePath = notes.Path(wt.Path)
-	}
-	noteTitle := ""
-	if t, ok, _ := notes.ReadTitle(wt.Path); ok {
-		noteTitle = t
-	}
-
 	done := a.openDialog()
-	a.sendPRFlow(re, wt.Branch, remotes, needsWarning, wt.IsDirty, hasStash, existingPR, noteTitle, notePath, done)
+	a.sendPRFlow(re, wt, remotes, needsWarning, wt.IsDirty, hasStash, existingPR, done)
 }
 
-func (a *App) sendPRFlow(re *repoEntry, branch string, remotes []git.RemoteInfo, needsWarning, dirty, hasStash bool, existingPR *provider.PRInfo, noteTitle, notePath string, done func()) {
+func (a *App) sendPRFlow(re *repoEntry, wt git.Worktree, remotes []git.RemoteInfo, needsWarning, dirty, hasStash bool, existingPR *provider.PRInfo, done func()) {
 	if needsWarning {
-		a.activeDialog = showSendPRDirtyWarning(a.window, branch, dirty, hasStash, done, func() {
-			a.sendPRSelectRemote(re, branch, remotes, existingPR, noteTitle, notePath, done)
+		a.activeDialog = showSendPRDirtyWarning(a.window, wt.Branch, dirty, hasStash, done, func() {
+			a.sendPRSelectRemote(re, wt, remotes, existingPR, done)
 		})
 		return
 	}
-	a.sendPRSelectRemote(re, branch, remotes, existingPR, noteTitle, notePath, done)
+	a.sendPRSelectRemote(re, wt, remotes, existingPR, done)
 }
 
-func (a *App) sendPRSelectRemote(re *repoEntry, branch string, remotes []git.RemoteInfo, existingPR *provider.PRInfo, noteTitle, notePath string, done func()) {
+func (a *App) sendPRSelectRemote(re *repoEntry, wt git.Worktree, remotes []git.RemoteInfo, existingPR *provider.PRInfo, done func()) {
 	if len(remotes) > 1 {
 		a.activeDialog = showSendPRRemoteSelection(a.window, remotes, done, func(idx int) {
-			a.sendPRConfirm(re, branch, remotes[idx], existingPR, noteTitle, notePath, done)
+			a.sendPRConfirm(re, wt, remotes[idx], existingPR, done)
 		})
 		return
 	}
-	a.sendPRConfirm(re, branch, remotes[0], existingPR, noteTitle, notePath, done)
+	a.sendPRConfirm(re, wt, remotes[0], existingPR, done)
 }
 
-func (a *App) sendPRConfirm(re *repoEntry, branch string, remote git.RemoteInfo, existingPR *provider.PRInfo, noteTitle, notePath string, done func()) {
-	hasNotes := noteTitle != "" || notePath != ""
-	a.activeDialog = showSendPRConfirm(a.window, branch, remote, existingPR, hasNotes, done, func(useNotes bool) {
+func (a *App) sendPRConfirm(re *repoEntry, wt git.Worktree, remote git.RemoteInfo, existingPR *provider.PRInfo, done func()) {
+	// Resolve note state at dialog-open time only to decide whether to
+	// render the checkbox. At confirm time we re-resolve from disk so any
+	// edits/deletes made during a Review pass are honored.
+	hasNotes := notes.Exists(wt.Path)
+	if !hasNotes {
+		if _, ok, _ := notes.ReadTitle(wt.Path); ok {
+			hasNotes = true
+		}
+	}
+	onReview := func() { a.openNoteDialog(wt) }
+	a.activeDialog = showSendPRConfirm(a.window, wt.Branch, remote, existingPR, hasNotes, done, func(useNotes bool) {
 		pushOnly := existingPR != nil
 		if pushOnly {
 			a.setStatus("Pushing...", false)
@@ -780,12 +780,16 @@ func (a *App) sendPRConfirm(re *repoEntry, branch string, remote git.RemoteInfo,
 		title := ""
 		bodyFile := ""
 		if useNotes {
-			title = noteTitle
-			bodyFile = notePath
+			if t, ok, _ := notes.ReadTitle(wt.Path); ok {
+				title = t
+			}
+			if notes.Exists(wt.Path) {
+				bodyFile = notes.Path(wt.Path)
+			}
 		}
 		go func() {
 			if pushOnly {
-				err := ops.PushBranch(re.repo, branch, remote)
+				err := ops.PushBranch(re.repo, wt.Branch, remote)
 				fyne.Do(func() {
 					if err != nil {
 						a.setStatus("Push failed: "+err.Error(), true)
@@ -795,7 +799,7 @@ func (a *App) sendPRConfirm(re *repoEntry, branch string, remote git.RemoteInfo,
 					a.refreshMgr.TriggerNetwork()
 				})
 			} else {
-				result := ops.SendPR(re.repo, re.prProv, branch, remote, title, bodyFile)
+				result := ops.SendPR(re.repo, re.prProv, wt.Branch, remote, title, bodyFile)
 				fyne.Do(func() {
 					if result.Err != nil {
 						a.setStatus("PR creation failed: "+result.Err.Error(), true)
@@ -806,7 +810,7 @@ func (a *App) sendPRConfirm(re *repoEntry, branch string, remote git.RemoteInfo,
 				})
 			}
 		}()
-	})
+	}, onReview)
 }
 
 // --- Sandbox operations ---

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -38,6 +38,41 @@ func TitlePath(worktreeDir string) string {
 	return filepath.Join(worktreeDir, noteDir, prTitleFile)
 }
 
+// WriteTitle saves a single-line PR title to the title file. Embedded
+// newlines are collapsed to spaces and surrounding whitespace is trimmed,
+// so the on-disk file is always one line + trailing newline. An empty
+// (post-trim) input is treated as a delete. The .biomelab/ exclude entry
+// is ensured here too so the title file never leaks into git status.
+func WriteTitle(worktreeDir, title string) error {
+	// Collapse any whitespace runs (including embedded newlines and tabs)
+	// into single spaces so the on-disk file is always one clean line.
+	title = strings.Join(strings.Fields(title), " ")
+	if title == "" {
+		return DeleteTitle(worktreeDir)
+	}
+	dir := filepath.Join(worktreeDir, noteDir)
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return fmt.Errorf("create note dir: %w", err)
+	}
+	if err := os.WriteFile(TitlePath(worktreeDir), []byte(title+"\n"), filePerm); err != nil {
+		return fmt.Errorf("write title: %w", err)
+	}
+	if err := ensureExcluded(worktreeDir); err != nil {
+		return fmt.Errorf("ensure excluded: %w", err)
+	}
+	return nil
+}
+
+// DeleteTitle removes the PR title file. Returns nil if the file doesn't
+// exist.
+func DeleteTitle(worktreeDir string) error {
+	err := os.Remove(TitlePath(worktreeDir))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
 // ReadTitle returns the trimmed first non-empty line of the PR title file.
 // ok is false when the file does not exist or contains only whitespace; in
 // either case title is "" and err is nil. Only the first line is honored

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -1,0 +1,209 @@
+// Package notes manages per-worktree scratchpad notes stored as markdown.
+//
+// A note for a worktree lives at <worktreeDir>/.biomelab/note.md and is kept
+// invisible to git via the per-worktree info/exclude file, so it never shows
+// up in "git status" and cannot leak into a commit by accident. Notes are
+// inside the worktree directory on purpose: the sandbox mounts the worktree,
+// so anything stored here is reachable by an agent running in the microVM.
+package notes
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	noteDir      = ".biomelab"
+	noteFile     = "note.md"
+	prTitleFile  = "pr-title.md"
+	excludeLine  = "/.biomelab/"
+	dirPerm      = 0o755
+	filePerm     = 0o644
+)
+
+// Path returns the absolute path to the note file for a worktree directory.
+func Path(worktreeDir string) string {
+	return filepath.Join(worktreeDir, noteDir, noteFile)
+}
+
+// TitlePath returns the absolute path to the PR title file for a worktree.
+// External tools (e.g. the pr-scribe skill) write a single-line Conventional
+// Commits title here; biomelab uses its content as `--title` when the user
+// opts to include task notes during the PR send flow.
+func TitlePath(worktreeDir string) string {
+	return filepath.Join(worktreeDir, noteDir, prTitleFile)
+}
+
+// ReadTitle returns the trimmed first non-empty line of the PR title file.
+// ok is false when the file does not exist or contains only whitespace; in
+// either case title is "" and err is nil. Only the first line is honored
+// because Git/CLI title arguments are single-line by design.
+func ReadTitle(worktreeDir string) (title string, ok bool, err error) {
+	data, err := os.ReadFile(TitlePath(worktreeDir))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return "", false, nil
+	}
+	if i := strings.IndexByte(text, '\n'); i >= 0 {
+		text = text[:i]
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", false, nil
+	}
+	return text, true, nil
+}
+
+// Exists reports whether a note file exists for the given worktree.
+func Exists(worktreeDir string) bool {
+	_, err := os.Stat(Path(worktreeDir))
+	return err == nil
+}
+
+// Read returns the note content. The bool is false when no note file exists,
+// in which case content is empty and err is nil.
+func Read(worktreeDir string) (string, bool, error) {
+	data, err := os.ReadFile(Path(worktreeDir))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return string(data), true, nil
+}
+
+// Write saves the note and ensures the worktree's info/exclude file ignores
+// the .biomelab/ directory. Trailing whitespace is stripped and a single
+// trailing newline is appended so accidental Enter-mashing at the end of
+// the editor doesn't leave blank lines on disk. An all-whitespace content
+// is treated as a delete.
+func Write(worktreeDir, content string) error {
+	content = strings.TrimRight(content, " \t\r\n")
+	if content == "" {
+		return Delete(worktreeDir)
+	}
+	content += "\n"
+	dir := filepath.Join(worktreeDir, noteDir)
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return fmt.Errorf("create note dir: %w", err)
+	}
+	if err := os.WriteFile(Path(worktreeDir), []byte(content), filePerm); err != nil {
+		return fmt.Errorf("write note: %w", err)
+	}
+	if err := ensureExcluded(worktreeDir); err != nil {
+		return fmt.Errorf("ensure excluded: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the note file. Returns nil if the note doesn't exist.
+func Delete(worktreeDir string) error {
+	err := os.Remove(Path(worktreeDir))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// excludeFilePath resolves the path to the info/exclude file git actually
+// consults for this worktree. Git reads info/exclude from the COMMON gitdir
+// for both the main worktree and any linked worktrees — the per-worktree
+// .git/worktrees/<name>/info/exclude is created by `git worktree add` but
+// is not honored by `git status` (verified empirically). So:
+//
+//   - main worktree: .git is a directory → exclude at .git/info/exclude
+//   - linked worktree: .git is a file with "gitdir: <wt-gitdir>" → read
+//     <wt-gitdir>/commondir to find the common gitdir, exclude at
+//     <common-gitdir>/info/exclude.
+//
+// As a side effect, all worktrees of a repo share the same exclude line.
+// That's fine: the pattern "/.biomelab/" is anchored to the worktree root
+// at match time, so each worktree's own .biomelab/ stays hidden.
+func excludeFilePath(worktreeDir string) (string, error) {
+	gitPath := filepath.Join(worktreeDir, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", fmt.Errorf("stat .git: %w", err)
+	}
+	if info.IsDir() {
+		return filepath.Join(gitPath, "info", "exclude"), nil
+	}
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", fmt.Errorf("read .git: %w", err)
+	}
+	const prefix = "gitdir:"
+	line := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf(".git file missing %q prefix", prefix)
+	}
+	wtGitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+
+	commonDir := wtGitDir
+	if raw, rerr := os.ReadFile(filepath.Join(wtGitDir, "commondir")); rerr == nil {
+		cd := strings.TrimSpace(string(raw))
+		if !filepath.IsAbs(cd) {
+			cd = filepath.Join(wtGitDir, cd)
+		}
+		commonDir = filepath.Clean(cd)
+	}
+	return filepath.Join(commonDir, "info", "exclude"), nil
+}
+
+// ensureExcluded appends excludeLine to the worktree's info/exclude if it
+// isn't already there. Idempotent.
+func ensureExcluded(worktreeDir string) error {
+	excludePath, err := excludeFilePath(worktreeDir)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(excludePath), dirPerm); err != nil {
+		return fmt.Errorf("create info dir: %w", err)
+	}
+	existing, err := os.ReadFile(excludePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read exclude: %w", err)
+	}
+	if hasExcludeLine(existing, excludeLine) {
+		return nil
+	}
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, filePerm)
+	if err != nil {
+		return fmt.Errorf("open exclude: %w", err)
+	}
+	var buf strings.Builder
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		buf.WriteString("\n")
+	}
+	buf.WriteString(excludeLine)
+	buf.WriteString("\n")
+	if _, werr := f.WriteString(buf.String()); werr != nil {
+		_ = f.Close()
+		return fmt.Errorf("write exclude: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		return fmt.Errorf("close exclude: %w", cerr)
+	}
+	return nil
+}
+
+func hasExcludeLine(content []byte, line string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == line {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -1,0 +1,309 @@
+package notes
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+// initRepo creates a fresh repo with one commit and returns its absolute path.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	f, err := wt.Filesystem.Create("README.md")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_, _ = f.Write([]byte("# Test\n"))
+	_ = f.Close()
+	if _, err := wt.Add("README.md"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := wt.Commit("init", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@t"},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	return dir
+}
+
+// addWorktree creates a linked worktree at <repo>/<rel> on a new branch.
+// Returns the absolute worktree path.
+func addWorktree(t *testing.T, repo, branch, rel string) string {
+	t.Helper()
+	wtPath := filepath.Join(repo, rel)
+	cmd := exec.Command("git", "worktree", "add", "-b", branch, wtPath)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	return wtPath
+}
+
+func TestPath(t *testing.T) {
+	got := Path("/some/worktree")
+	want := filepath.Join("/some/worktree", ".biomelab", "note.md")
+	if got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+}
+
+func TestTitlePath(t *testing.T) {
+	got := TitlePath("/some/worktree")
+	want := filepath.Join("/some/worktree", ".biomelab", "pr-title.md")
+	if got != want {
+		t.Errorf("TitlePath = %q, want %q", got, want)
+	}
+}
+
+func TestReadTitle(t *testing.T) {
+	cases := []struct {
+		name    string
+		writeFn func(dir string) // skip writing when nil → file missing
+		want    string           // empty want means ok=false
+	}{
+		{"missing", nil, ""},
+		{"single line", writeTitle("feat(x): do thing\n"), "feat(x): do thing"},
+		{"trims whitespace", writeTitle("  feat(x): do thing  \n"), "feat(x): do thing"},
+		{"first line only", writeTitle("feat(x): do thing\nignored body\nmore body\n"), "feat(x): do thing"},
+		{"empty file", writeTitle(""), ""},
+		{"only whitespace", writeTitle("  \n\n\t  \n"), ""},
+		{"blank lines then content", writeTitle("\n\nfeat(x): do thing\n"), "feat(x): do thing"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.writeFn != nil {
+				tc.writeFn(dir)
+			}
+			title, ok, err := ReadTitle(dir)
+			if err != nil {
+				t.Fatalf("ReadTitle: %v", err)
+			}
+			wantOK := tc.want != ""
+			if ok != wantOK {
+				t.Errorf("ok = %v, want %v", ok, wantOK)
+			}
+			if title != tc.want {
+				t.Errorf("title = %q, want %q", title, tc.want)
+			}
+		})
+	}
+}
+
+func writeTitle(content string) func(string) {
+	return func(dir string) {
+		_ = os.MkdirAll(filepath.Join(dir, ".biomelab"), 0o755)
+		_ = os.WriteFile(TitlePath(dir), []byte(content), 0o644)
+	}
+}
+
+func TestReadMissing(t *testing.T) {
+	dir := t.TempDir()
+	content, exists, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if exists {
+		t.Errorf("exists = true, want false")
+	}
+	if content != "" {
+		t.Errorf("content = %q, want empty", content)
+	}
+}
+
+func TestExistsMissing(t *testing.T) {
+	dir := t.TempDir()
+	if Exists(dir) {
+		t.Errorf("Exists = true on empty dir")
+	}
+}
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	repo := initRepo(t)
+	body := "# Hello\n\nSome **markdown** notes.\n"
+
+	if err := Write(repo, body); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !Exists(repo) {
+		t.Errorf("Exists = false after Write")
+	}
+	got, exists, err := Read(repo)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !exists {
+		t.Errorf("exists = false after Write")
+	}
+	if got != body {
+		t.Errorf("Read = %q, want %q", got, body)
+	}
+}
+
+func TestWriteTrimsTrailingWhitespace(t *testing.T) {
+	repo := initRepo(t)
+	if err := Write(repo, "hello\n\n\n   \n\t\n"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, _, err := Read(repo)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	want := "hello\n"
+	if got != want {
+		t.Errorf("Read = %q, want %q", got, want)
+	}
+}
+
+func TestWriteAllWhitespaceDeletes(t *testing.T) {
+	repo := initRepo(t)
+	if err := Write(repo, "hi"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !Exists(repo) {
+		t.Fatalf("note should exist before whitespace overwrite")
+	}
+	if err := Write(repo, "\n\n   \t\n"); err != nil {
+		t.Fatalf("Write whitespace: %v", err)
+	}
+	if Exists(repo) {
+		t.Errorf("note should have been deleted by all-whitespace Write")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	repo := initRepo(t)
+	if err := Write(repo, "x"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := Delete(repo); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if Exists(repo) {
+		t.Errorf("Exists = true after Delete")
+	}
+	// Delete on missing is a no-op.
+	if err := Delete(repo); err != nil {
+		t.Fatalf("Delete on missing: %v", err)
+	}
+}
+
+func TestWriteExcludesNoteInMainWorktree(t *testing.T) {
+	repo := initRepo(t)
+	if err := Write(repo, "hi"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	data, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if !strings.Contains(string(data), excludeLine) {
+		t.Errorf("exclude file missing %q:\n%s", excludeLine, data)
+	}
+}
+
+func TestWriteExcludesNoteInLinkedWorktree(t *testing.T) {
+	repo := initRepo(t)
+	wtPath := addWorktree(t, repo, "feature/notes", ".biomelab-worktrees/notes")
+
+	if err := Write(wtPath, "linked note"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Git only consults info/exclude from the common gitdir, not the
+	// per-worktree gitdir, so the exclude entry must land in the MAIN
+	// repo's .git/info/exclude — anything else and `git status` in the
+	// linked worktree would still flag .biomelab/note.md as untracked.
+	mainExclude := filepath.Join(repo, ".git", "info", "exclude")
+	data, err := os.ReadFile(mainExclude)
+	if err != nil {
+		t.Fatalf("read main exclude: %v", err)
+	}
+	if !strings.Contains(string(data), excludeLine) {
+		t.Errorf("main exclude file missing %q:\n%s", excludeLine, data)
+	}
+}
+
+func TestWriteExcludesIdempotentAcrossWorktrees(t *testing.T) {
+	repo := initRepo(t)
+	wtPath := addWorktree(t, repo, "feature/notes", ".biomelab-worktrees/notes")
+
+	// All worktrees share the common gitdir's exclude file. Writing notes
+	// in both the main and linked worktrees must still produce only one
+	// exclude entry.
+	if err := Write(repo, "main note"); err != nil {
+		t.Fatalf("Write main: %v", err)
+	}
+	if err := Write(wtPath, "linked note"); err != nil {
+		t.Fatalf("Write linked: %v", err)
+	}
+
+	mainExclude := filepath.Join(repo, ".git", "info", "exclude")
+	data, err := os.ReadFile(mainExclude)
+	if err != nil {
+		t.Fatalf("read main exclude: %v", err)
+	}
+	count := strings.Count(string(data), excludeLine)
+	if count != 1 {
+		t.Errorf("exclude line appears %d times across worktree writes, want 1:\n%s", count, data)
+	}
+}
+
+func TestEnsureExcludedIdempotent(t *testing.T) {
+	repo := initRepo(t)
+	for i := range 3 {
+		if err := Write(repo, "x"); err != nil {
+			t.Fatalf("Write #%d: %v", i, err)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	count := strings.Count(string(data), excludeLine)
+	if count != 1 {
+		t.Errorf("exclude line appears %d times, want 1:\n%s", count, data)
+	}
+}
+
+func TestEnsureExcludedAppendsNewlineWhenMissing(t *testing.T) {
+	repo := initRepo(t)
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pre-existing content without a trailing newline.
+	if err := os.WriteFile(excludePath, []byte("# user-added\nfoo.txt"), 0o644); err != nil {
+		t.Fatalf("seed exclude: %v", err)
+	}
+
+	if err := Write(repo, "x"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	data, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	// The previous "foo.txt" line must still terminate properly and our
+	// entry must appear on its own line.
+	want := "# user-added\nfoo.txt\n" + excludeLine + "\n"
+	if string(data) != want {
+		t.Errorf("exclude = %q, want %q", data, want)
+	}
+}

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -1,6 +1,7 @@
 package notes
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -108,6 +109,68 @@ func writeTitle(content string) func(string) {
 	return func(dir string) {
 		_ = os.MkdirAll(filepath.Join(dir, ".biomelab"), 0o755)
 		_ = os.WriteFile(TitlePath(dir), []byte(content), 0o644)
+	}
+}
+
+func TestWriteTitleRoundTrip(t *testing.T) {
+	repo := initRepo(t)
+	if err := WriteTitle(repo, "feat(x): do thing"); err != nil {
+		t.Fatalf("WriteTitle: %v", err)
+	}
+	got, ok, err := ReadTitle(repo)
+	if err != nil {
+		t.Fatalf("ReadTitle: %v", err)
+	}
+	if !ok || got != "feat(x): do thing" {
+		t.Errorf("ReadTitle = %q, ok=%v, want %q, ok=true", got, ok, "feat(x): do thing")
+	}
+}
+
+func TestWriteTitleCollapsesNewlines(t *testing.T) {
+	repo := initRepo(t)
+	if err := WriteTitle(repo, "feat(x):\ndo\rthing\n"); err != nil {
+		t.Fatalf("WriteTitle: %v", err)
+	}
+	data, err := os.ReadFile(TitlePath(repo))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "feat(x): do thing\n"
+	if string(data) != want {
+		t.Errorf("on-disk = %q, want %q", data, want)
+	}
+}
+
+func TestWriteTitleEmptyDeletes(t *testing.T) {
+	repo := initRepo(t)
+	if err := WriteTitle(repo, "feat(x): do thing"); err != nil {
+		t.Fatalf("WriteTitle: %v", err)
+	}
+	if _, err := os.Stat(TitlePath(repo)); err != nil {
+		t.Fatalf("title should exist before whitespace overwrite: %v", err)
+	}
+	if err := WriteTitle(repo, "  \n\t  "); err != nil {
+		t.Fatalf("WriteTitle whitespace: %v", err)
+	}
+	if _, err := os.Stat(TitlePath(repo)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("title should have been deleted, got err=%v", err)
+	}
+}
+
+func TestDeleteTitle(t *testing.T) {
+	repo := initRepo(t)
+	if err := WriteTitle(repo, "feat(x): do thing"); err != nil {
+		t.Fatalf("WriteTitle: %v", err)
+	}
+	if err := DeleteTitle(repo); err != nil {
+		t.Fatalf("DeleteTitle: %v", err)
+	}
+	if _, err := os.Stat(TitlePath(repo)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("title should be gone, got err=%v", err)
+	}
+	// Idempotent on missing.
+	if err := DeleteTitle(repo); err != nil {
+		t.Fatalf("DeleteTitle missing: %v", err)
 	}
 }
 

--- a/internal/ops/worktree.go
+++ b/internal/ops/worktree.go
@@ -120,12 +120,16 @@ type SendPRResult struct {
 	Err error
 }
 
-// SendPR pushes a branch to a remote and creates a PR.
-func SendPR(repo *git.Repository, prProv provider.PRProvider, branch string, remote git.RemoteInfo) SendPRResult {
+// SendPR pushes a branch to a remote and creates a PR. title, when
+// non-empty, becomes the PR title (overriding the usual commit-subject
+// derivation). bodyFile, when non-empty, must be an absolute path to a
+// markdown file whose contents will replace the default commit-derived
+// description.
+func SendPR(repo *git.Repository, prProv provider.PRProvider, branch string, remote git.RemoteInfo, title, bodyFile string) SendPRResult {
 	if err := repo.Push(remote.Name, branch); err != nil {
 		return SendPRResult{Err: fmt.Errorf("push: %w", err)}
 	}
-	pr, err := prProv.CreatePR(repo.Root(), branch, remote.Repo)
+	pr, err := prProv.CreatePR(repo.Root(), branch, remote.Repo, title, bodyFile)
 	if err != nil {
 		return SendPRResult{Err: err}
 	}

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -34,10 +34,34 @@ func (g *GitHubProvider) Name() string { return "GitHub" }
 func (g *GitHubProvider) Provider() Provider { return ProviderGitHub }
 
 // CreatePR creates a pull request on GitHub using the gh CLI.
-// It runs "gh pr create --fill --head <branch>" with an optional "--repo <targetRepo>".
-// After creation, it fetches full PR info via "gh pr view".
-func (g *GitHubProvider) CreatePR(repoDir, branch, targetRepo string) (*PRInfo, error) {
-	args := []string{"pr", "create", "--fill", "--head", branch}
+// Without either override, it runs "gh pr create --fill --head <branch>" so
+// commit messages become the title and body. When title is non-empty, it is
+// passed as --title; when bodyFile is non-empty, it is passed as --body-file.
+// Mixed cases fill in the remaining side from defaults (commit subject for
+// title, --fill for body). An optional "--repo <targetRepo>" is passed
+// through in any case. After creation, full PR info is fetched via
+// "gh pr view".
+func (g *GitHubProvider) CreatePR(repoDir, branch, targetRepo, title, bodyFile string) (*PRInfo, error) {
+	args := []string{"pr", "create", "--head", branch}
+	hasOverride := title != "" || bodyFile != ""
+	if hasOverride {
+		effectiveTitle := title
+		if effectiveTitle == "" {
+			subj, terr := commitSubject(repoDir, branch)
+			if terr != nil || subj == "" {
+				subj = branch
+			}
+			effectiveTitle = subj
+		}
+		args = append(args, "--title", effectiveTitle)
+		if bodyFile != "" {
+			args = append(args, "--body-file", bodyFile)
+		} else {
+			args = append(args, "--fill")
+		}
+	} else {
+		args = append(args, "--fill")
+	}
 	if targetRepo != "" {
 		args = append(args, "--repo", targetRepo)
 	}
@@ -60,6 +84,19 @@ func (g *GitHubProvider) CreatePR(repoDir, branch, targetRepo string) (*PRInfo, 
 		return &PRInfo{URL: url, State: "open"}, nil
 	}
 	return pr, nil
+}
+
+// commitSubject returns the subject line of the latest commit on branch.
+// Used to derive a PR title when the caller supplies a custom body and we
+// need to fill in the title gh would otherwise have computed from --fill.
+func commitSubject(repoDir, branch string) (string, error) {
+	cmd := exec.Command("git", "log", "-1", "--pretty=%s", branch)
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git log: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func fetchGitHubPR(repoDir, branch string) *PRInfo {

--- a/internal/provider/gitlab.go
+++ b/internal/provider/gitlab.go
@@ -34,10 +34,34 @@ func (g *GitLabProvider) Name() string { return "GitLab" }
 func (g *GitLabProvider) Provider() Provider { return ProviderGitLab }
 
 // CreatePR creates a merge request on GitLab using the glab CLI.
-// It runs "glab mr create --fill --source-branch <branch>" with an optional "--repo <targetRepo>".
-// After creation, it fetches full MR info via "glab mr view".
-func (g *GitLabProvider) CreatePR(repoDir, branch, targetRepo string) (*PRInfo, error) {
-	args := []string{"mr", "create", "--fill", "--source-branch", branch}
+// Without either override, it runs "glab mr create --fill --source-branch <branch>"
+// so commit messages become the title and description. When title is non-empty,
+// it is passed as --title; when bodyFile is non-empty, it is passed as
+// --description-file. Mixed cases fill in the remaining side from defaults
+// (commit subject for title, --fill for description). An optional
+// "--repo <targetRepo>" is passed through in any case. After creation, full
+// MR info is fetched via "glab mr view".
+func (g *GitLabProvider) CreatePR(repoDir, branch, targetRepo, title, bodyFile string) (*PRInfo, error) {
+	args := []string{"mr", "create", "--source-branch", branch}
+	hasOverride := title != "" || bodyFile != ""
+	if hasOverride {
+		effectiveTitle := title
+		if effectiveTitle == "" {
+			subj, terr := commitSubject(repoDir, branch)
+			if terr != nil || subj == "" {
+				subj = branch
+			}
+			effectiveTitle = subj
+		}
+		args = append(args, "--title", effectiveTitle)
+		if bodyFile != "" {
+			args = append(args, "--description-file", bodyFile)
+		} else {
+			args = append(args, "--fill")
+		}
+	} else {
+		args = append(args, "--fill")
+	}
 	if targetRepo != "" {
 		args = append(args, "--repo", targetRepo)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -91,7 +91,13 @@ type PRProvider interface {
 	// CreatePR pushes the branch (if needed) and creates a PR/MR.
 	// targetRepo is "owner/repo" derived from the selected remote;
 	// if empty, the CLI's default repo detection is used.
-	CreatePR(repoDir, branch, targetRepo string) (*PRInfo, error)
+	// title, when non-empty, is passed as the PR/MR title (overriding the
+	// usual commit-subject derivation). When empty, the implementation
+	// derives the title from the branch's latest commit.
+	// bodyFile, when non-empty, is the absolute path to a markdown file
+	// whose contents become the PR/MR description (replacing the default
+	// commit-derived body). When empty, the CLI's --fill default is used.
+	CreatePR(repoDir, branch, targetRepo, title, bodyFile string) (*PRInfo, error)
 
 	// Name returns the display name of the provider (e.g., "GitHub", "GitLab").
 	Name() string
@@ -149,7 +155,7 @@ func (u *UnsupportedProvider) FetchPRs(_ string, _ []string) PRResult {
 }
 
 // CreatePR always returns an error for unsupported providers.
-func (u *UnsupportedProvider) CreatePR(_, _, _ string) (*PRInfo, error) {
+func (u *UnsupportedProvider) CreatePR(_, _, _, _, _ string) (*PRInfo, error) {
 	return nil, fmt.Errorf("PR creation not supported for %s", u.provider)
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -111,7 +111,7 @@ func TestUnsupportedProvider(t *testing.T) {
 		t.Errorf("expected empty PRResult, got %d entries", len(result))
 	}
 
-	pr, err := p.CreatePR("/tmp", "feature", "owner/repo")
+	pr, err := p.CreatePR("/tmp", "feature", "owner/repo", "", "")
 	if err == nil {
 		t.Error("expected error from UnsupportedProvider.CreatePR")
 	}

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -635,6 +635,7 @@ nav .container {
 .problem,
 .sandbox,
 .parallel,
+.notes,
 .keyboard {
   background: linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 90%, transparent), color-mix(in srgb, var(--bg-secondary) 95%, transparent));
   border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
@@ -661,6 +662,7 @@ nav .container {
 .dashboard>p,
 .sandbox>.container>p,
 .workflow>.container>p,
+.notes>.container>p,
 .keyboard>.container>p,
 .install-copy {
   max-width: 65ch
@@ -1665,14 +1667,16 @@ footer {
   margin-bottom: 3rem
 }
 
-.kanban-features {
+.kanban-features,
+.notes-features {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
   margin-bottom: 3rem
 }
 
-.kanban-feat-card {
+.kanban-feat-card,
+.notes-feat-card {
   background: linear-gradient(180deg,
     color-mix(in srgb, var(--bg-card) 100%, transparent),
     color-mix(in srgb, var(--bg-tertiary) 100%, transparent));
@@ -1684,24 +1688,28 @@ footer {
   transition: .22s transform ease, .22s border-color ease, .22s box-shadow ease
 }
 
-.kanban-feat-card:hover {
+.kanban-feat-card:hover,
+.notes-feat-card:hover {
   transform: translateY(-3px);
   border-color: var(--border-strong);
   box-shadow: var(--shadow-card)
 }
 
-.kanban-feat-card .icon {
+.kanban-feat-card .icon,
+.notes-feat-card .icon {
   font-size: 2rem;
   margin-bottom: 1rem;
   display: block
 }
 
-.kanban-feat-card p {
+.kanban-feat-card p,
+.notes-feat-card p {
   font-size: .93rem;
   line-height: 1.55
 }
 
-.kanban-feat-card kbd {
+.kanban-feat-card kbd,
+.notes-feat-card kbd {
   display: inline-block;
   background: var(--code-bg);
   border: 1px solid var(--border);
@@ -1950,4 +1958,85 @@ footer {
   .kanban-features {
     grid-template-columns: 1fr
   }
+
+  .notes-features {
+    grid-template-columns: 1fr
+  }
+}
+
+/* ── Task Notes ──────────────────────────────────────────── */
+.notes-accent {
+  background: linear-gradient(135deg, var(--yellow), var(--magenta) 60%, var(--cyan));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent !important;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 1px 6px rgba(0,0,0,.2))
+}
+
+[data-theme="light"] .notes-accent {
+  filter: none
+}
+
+.notes-intro {
+  font-size: 1.12rem;
+  margin-top: 1rem;
+  margin-bottom: 3rem
+}
+
+.notes-snippet {
+  margin-top: 1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--bg-card) 100%, transparent),
+    color-mix(in srgb, var(--bg-tertiary) 100%, transparent));
+  box-shadow: var(--shadow-soft)
+}
+
+.notes-snippet .snippet-title {
+  font-size: .82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  color: var(--text-muted);
+  margin: 0 0 1rem
+}
+
+.notes-snippet pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  font-family: var(--font-mono);
+  font-size: .9rem;
+  color: var(--cyan);
+  line-height: 1.65;
+  overflow-x: auto;
+  margin: 0
+}
+
+.notes-snippet .notes-comment {
+  color: var(--text-muted)
+}
+
+.notes-snippet .notes-arg {
+  color: var(--green)
+}
+
+.notes-snippet-foot {
+  font-size: .9rem;
+  color: var(--text-secondary);
+  margin: 1rem 0 0
+}
+
+.notes-snippet-foot code {
+  font-family: var(--font-mono);
+  font-size: .85rem;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: .05rem .4rem;
+  color: var(--cyan)
 }

--- a/website/index.html
+++ b/website/index.html
@@ -53,6 +53,7 @@
         <li><a href="#dashboard">Dashboard</a></li>
         <li><a href="#sandboxes">Sandboxes</a></li>
         <li><a href="#workflow">Workflow</a></li>
+        <li><a href="#notes">Notes</a></li>
         <li><a href="#kanban">Kanban</a></li>
         <li><a href="#install">Install</a></li>
         <li>
@@ -330,6 +331,40 @@
     </div>
   </section>
 
+  <section id="notes" class="notes">
+    <div class="container">
+      <span class="section-label">Task Notes</span>
+      <h2>Brief your agent, draft your PR — <span class="notes-accent">in the same place</span></h2>
+      <p class="notes-intro">A Markdown editor scoped to each worktree. Lives next to the code, mounted into the sandbox, and lands as your PR title and description when you ship.</p>
+      <div class="notes-features">
+        <div class="notes-feat-card"><span class="icon">📝</span>
+          <h3>Note next to the code</h3>
+          <p>Press <kbd>m</kbd> or right-click a card to open the editor. Single-line PR title above, multi-line Markdown body with a live preview pane.</p>
+        </div>
+        <div class="notes-feat-card"><span class="icon">🐋</span>
+          <h3>Reaches your agent</h3>
+          <p>Stored inside the worktree, so the file gets mounted into the sandbox microVM. Your agent reads your intent as an ordinary file at the working tree root.</p>
+        </div>
+        <div class="notes-feat-card"><span class="icon">🚀</span>
+          <h3>Becomes the PR</h3>
+          <p>On <kbd>P</kbd>, biomelab offers to use your prepared title and description in place of the commit-derived defaults. Skip the rewrite — the note <em>is</em> the description.</p>
+        </div>
+      </div>
+
+      <div class="notes-snippet">
+        <h4 class="snippet-title">Extension point</h4>
+        <pre><span class="notes-comment"># Any skill, agent, or script can populate the two artifact files:</span>
+&lt;worktree&gt;/.biomelab/pr-title.md      <span class="notes-comment"># single-line PR title</span>
+&lt;worktree&gt;/.biomelab/note.md          <span class="notes-comment"># PR description (Markdown)</span>
+
+<span class="notes-comment"># biomelab turns them into the actual PR on Shift+P:</span>
+gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</span> \
+             --body-file <span class="notes-arg">.biomelab/note.md</span></pre>
+        <p class="notes-snippet-foot">Write to those paths and biomelab handles the rest. Falls back to commit-derived <code>--fill</code> when files are absent.</p>
+      </div>
+    </div>
+  </section>
+
   <section id="kanban" class="kanban-board">
     <div class="container">
       <span class="section-label">Kanban Board</span>
@@ -568,6 +603,7 @@
         <div class="key-item"><span class="key-cap key-green">c</span><span class="key-action">Create worktree</span></div>
         <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span></div>
         <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span></div>
+        <div class="key-item"><span class="key-cap key-yellow">m</span><span class="key-action">Open note editor</span></div>
         <div class="key-item"><span class="key-cap key-blue">f</span><span class="key-action">Fetch PR / MR</span></div>
         <div class="key-item"><span class="key-cap key-cyan">g</span><span class="key-action">Toggle kanban / grid</span></div>
         <div class="key-item"><span class="key-cap">n</span><span class="key-action">New sandbox</span></div>


### PR DESCRIPTION
## What's changed

Add a per-worktree Markdown notes feature so each worktree gets a private scratchpad and a draft PR description. The note for a worktree lives at `<worktree>/.biomelab/note.md` (description) and `<worktree>/.biomelab/pr-title.md` (single-line title), both auto-excluded from git via the common gitdir's `info/exclude`. Because the files sit inside the worktree directory, they're mounted into the sandbox microVM and reachable by any agent running there.

The notes feed directly into the PR send flow: pressing `Shift+P` offers a "Use task notes for the PR title and description" checkbox; when ticked, biomelab passes the title and body file to `gh pr create` (or `glab mr create --description-file` for GitLab) in place of the commit-derived defaults. A Review button on the same dialog lets the user open the editor for a final pass — biomelab re-reads both files at confirm time, so post-review edits are honored.

## Why is this important?

AI coding agents benefit from per-task intent context that lives next to the code, not in chat history or external docs. Today there's no surface for "here's what I want this branch to accomplish" that the agent can read alongside the source. A Markdown note that's part of the worktree, visible to agents in the sandbox, and naturally becomes the PR title and description on ship closes that loop without polluting the repo. It also creates a stable extension point: any skill (e.g. `/pr-scribe`), agent, or script that writes to those two paths becomes a contributor to the next PR — no biomelab-specific knowledge required.

## Changes

**New package `internal/notes/`**
- `Path` / `Read` / `Write` / `Delete` / `Exists` for `note.md`; `TitlePath` / `ReadTitle` / `WriteTitle` / `DeleteTitle` for `pr-title.md`.
- `Write` trims trailing whitespace and normalizes to a single trailing newline; all-whitespace input deletes the file.
- `WriteTitle` collapses whitespace runs (newlines/tabs) into single spaces via `strings.Fields` + `Join` so the file is always one clean line.
- Auto-excludes `.biomelab/` by appending `/.biomelab/` to the **common gitdir's** `info/exclude` (resolved via `<wt-gitdir>/commondir` for linked worktrees). The per-worktree `info/exclude` file `git worktree add` creates is **not** consulted by `git status` — verified empirically.

**GUI editor**
- New `note_dialog.go` opens a standalone `fyne.NewWindow` (resizable, centered, non-modal) with an H-split: single-line PR title above, multi-line Markdown body with live `widget.RichText` preview. Cmd/Ctrl+S saves; Esc cancels; Delete prompts for confirmation and removes both files.
- Right-click on any card (main, linked grid, kanban) or pressing `m` on the selected card opens the editor. `tappableCard` gained `SetOnSecondaryTap`; `kanbanCardWrapper` now forwards `TappedSecondary`.
- One editor window per worktree: `App.noteWindows` tracks open editors so repeated `m` / Review just raises the existing window.
- A 📝 badge renders next to the branch label in both grid and kanban cards when a note exists. The dirty-state computation now ignores `.biomelab/` entries (go-git's `Worktree.Status()` doesn't honor `info/exclude`).

**PR send integration**
- `provider.PRProvider.CreatePR` and `ops.SendPR` grow `title` and `bodyFile` parameters. Empty falls back to today's `--fill` behavior; non-empty switches to `--title <T> --body-file <F>` on GitHub or `--title <T> --description-file <F>` on GitLab. Mixed cases (only title, only body) fill the missing side from the commit subject / `--fill` respectively.
- `showSendPRConfirm` renders a "Use task notes for the PR title and description" checkbox (default checked) when either file exists for a new PR, plus a Review button that opens the editor. The editor is non-modal so the dialog stays put while the user reviews; note paths are re-resolved from disk at confirm time.

**Docs and website**
- `README.md`: new Task notes bullet in the Features list and a row in the keyboard shortcuts table for `m`.
- `ARCHITECTURE.md`: dedicated Task notes section with file paths, contract, lifecycle, and the exact `gh` / `glab` invocation biomelab issues — explicitly identifying the convention as an extension point for tools like `/pr-scribe`.
- `website/`: new Notes section between Workflow and Kanban with three feature cards (📝 Note next to the code / 🐋 Reaches your agent / 🚀 Becomes the PR) and an Extension point code snippet; `m` keycap added to the keyboard cheatsheet.

## Test plan

- [x] `internal/notes/` unit tests cover read/write/delete round-trip for both files, trim/normalize, all-whitespace-deletes, multi-line title collapse, first-non-blank-line title parsing, idempotent exclude in the common gitdir, and cross-worktree exclude idempotency.
- [x] `go test -race ./...` and `task lint` clean.
- [ ] Right-click and `m` open the editor on selected and unselected cards in both grid and kanban views.
- [ ] Live preview updates as you type; window is resizable via the OS frame and centered on open.
- [ ] Pressing `m` repeatedly raises the existing window instead of opening duplicates.
- [ ] Saving an empty body removes `note.md`; saving an empty title removes `pr-title.md`.
- [ ] Delete prompts for confirmation; confirming removes both files.
- [ ] After saving a note, `git status` in the worktree shows nothing under `.biomelab/`, and the card is not flagged dirty.
- [ ] Sending a PR with notes present shows the checkbox; ticking + Review opens the editor; edits saved during review are reflected in the final `gh pr create --title ... --body-file ...` invocation.
