### PR TITLE
feat(notes): ensure .biomelab directory exists for all worktrees

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -18,6 +18,8 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	githttp "github.com/go-git/go-git/v6/plumbing/transport/http"
 	xworktree "github.com/go-git/go-git/v6/x/plumbing/worktree"
+
+	"github.com/mdelapenya/biomelab/internal/notes"
 )
 
 // SyncStatus indicates whether a branch is up-to-date with its remote tracking branch.
@@ -615,6 +617,9 @@ func (r *Repository) CreateWorktree(branchName string) error {
 	if err := r.wt.Add(wtFS, safe); err != nil {
 		return err
 	}
+	// Ensure .biomelab dir exists for new worktree so external tools can write
+	// files without needing to create the directory themselves.
+	_ = r.ensureBiomelabDir(wtPath)
 	r.generation.Add(1)
 	return nil
 }
@@ -983,6 +988,27 @@ func (r *Repository) HasStash() (bool, error) {
 		return false, nil // no stash ref means no stash entries
 	}
 	return true, nil
+}
+
+// ensureBiomelabDir ensures the .biomelab directory exists in the given
+// worktree path so external tools can write files without creating it themselves.
+// Errors are silently ignored as this is a best-effort initialization.
+func (r *Repository) ensureBiomelabDir(wtPath string) error {
+	return notes.EnsureDir(wtPath)
+}
+
+// MigrateWorktreeDirs ensures .biomelab exists for all worktrees in the
+// repository (migration for older projects created before this feature).
+// This ensures external tools like pr-scribe can write files to the directory.
+// Errors are silently ignored as this is a best-effort background task.
+func (r *Repository) MigrateWorktreeDirs() {
+	wts, err := r.ListWorktrees()
+	if err != nil {
+		return
+	}
+	for _, wt := range wts {
+		_ = r.ensureBiomelabDir(wt.Path)
+	}
 }
 
 // RepoRoot finds the root of the git repository containing the given path.

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -264,6 +264,9 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 		refreshMgr: rm,
 	}
 
+	// Migrate existing worktrees to ensure .biomelab dir exists (background task).
+	go repo.MigrateWorktreeDirs()
+
 	rm.OnRefresh = func(result ops.RefreshResult) {
 		fyne.Do(func() {
 			// Reconcile the stored sandbox name FIRST so ApplyRefresh's

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -99,6 +99,21 @@ func ReadTitle(worktreeDir string) (title string, ok bool, err error) {
 	return text, true, nil
 }
 
+// EnsureDir creates the .biomelab directory for the worktree if it doesn't
+// exist, and ensures it's added to the worktree's info/exclude. This allows
+// other tools to write files into the directory (e.g. pr-title.md, future
+// metadata files) without needing to create the directory themselves.
+func EnsureDir(worktreeDir string) error {
+	dir := filepath.Join(worktreeDir, noteDir)
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return fmt.Errorf("create note dir: %w", err)
+	}
+	if err := ensureExcluded(worktreeDir); err != nil {
+		return fmt.Errorf("ensure excluded: %w", err)
+	}
+	return nil
+}
+
 // Exists reports whether a note file exists for the given worktree.
 func Exists(worktreeDir string) bool {
 	_, err := os.Stat(Path(worktreeDir))

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -370,3 +370,27 @@ func TestEnsureExcludedAppendsNewlineWhenMissing(t *testing.T) {
 		t.Errorf("exclude = %q, want %q", data, want)
 	}
 }
+
+func TestEnsureDir(t *testing.T) {
+	repo := initRepo(t)
+	if err := EnsureDir(repo); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	noteDir := filepath.Join(repo, ".biomelab")
+	if _, err := os.Stat(noteDir); err != nil {
+		t.Errorf("note dir not created: %v", err)
+	}
+	// Verify the exclude entry is set.
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	data, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if !strings.Contains(string(data), excludeLine) {
+		t.Errorf("exclude file missing %q:\n%s", excludeLine, data)
+	}
+	// EnsureDir on existing dir should be idempotent.
+	if err := EnsureDir(repo); err != nil {
+		t.Fatalf("EnsureDir again: %v", err)
+	}
+}


### PR DESCRIPTION
## What's changed

Added automatic creation of `.biomelab/` directories for both new and existing worktrees. New worktrees now have the directory created immediately upon creation, and existing worktrees are migrated when a project is first loaded.

The `.biomelab/` directory is excluded from git via the worktree's info/exclude file, ensuring it never appears in `git status` and won't leak into commits.

## Why is this important?

External tools (like pr-scribe) need the `.biomelab/` directory to exist to write files like `pr-title.md`. Previously, this directory was only created on-demand when saving notes. Now it's guaranteed to exist for all worktrees, making it a reliable location for tools to write metadata.

## Changes

**notes package:**
- Added `EnsureDir()` function to create `.biomelab/` and configure git exclusion (idempotent)

**git package:**
- Added `ensureBiomelabDir()` helper method to create the directory for a worktree
- Modified `CreateWorktree()` to ensure the directory exists immediately after creating a new worktree
- Added `MigrateWorktreeDirs()` to cycle through all existing worktrees and create the directory

**gui package:**
- Added background task in `buildRepoEntry()` to run the migration when a project is loaded

**tests:**
- Added `TestEnsureDir()` to verify directory and git exclusion setup

## Test plan

- Create a new worktree and verify `.biomelab/` directory exists
- Open a project with existing worktrees and verify the migration creates `.biomelab/` for all of them
- Verify `git status` doesn't show `.biomelab/` entries
- Run `go test -race ./...` to verify all tests pass

