### PR TITLE
feat(kanban): expand to 5 columns with interactive grid view toggle

### DIFF
--- a/.claude/skills/product-owner/SKILL.md
+++ b/.claude/skills/product-owner/SKILL.md
@@ -312,11 +312,12 @@ to a vertical-resize indicator to signal grab affordance.
 
 ### 19. Kanban Board View
 
-The default view groups linked worktrees into four columns by PR/MR lifecycle stage:
+The default view groups linked worktrees into five columns by PR/MR lifecycle stage:
 
 | Column | Condition |
 |---|---|
-| **Created** | No PR associated, or PR is closed |
+| **Closed Unmerged** | PR exists but is closed and not merged |
+| **Created** | No PR associated |
 | **PR Sent** | Open PR (including drafts) with no review activity yet |
 | **PR In Review** | Open PR that has received at least one review (approved, changes requested, or commented) |
 | **PR Merged** | PR has been merged |

--- a/internal/gui/card.go
+++ b/internal/gui/card.go
@@ -121,7 +121,13 @@ func buildCardContent(
 	} else if wt.Detached {
 		row = append(row, monoText(" (detached)", colorDimGray, false))
 	}
-	items = append(items, container.NewHBox(row...))
+	branchRow := container.NewHBox(row...)
+	if !wt.IsMain {
+		items = append(items, container.NewBorder(nil, nil, nil,
+			makeStagePill(kanbanStageOf(pr)), branchRow))
+	} else {
+		items = append(items, branchRow)
+	}
 
 	// Path: prefix-truncated dynamically so it never overflows the card,
 	// regardless of how narrow the card becomes when the window is resized.

--- a/internal/gui/kanban.go
+++ b/internal/gui/kanban.go
@@ -301,6 +301,18 @@ func kanbanColumnHeaderBgColor(stage int) color.Color {
 	}
 }
 
+// makeStagePill returns a small coloured pill showing the PR lifecycle stage label.
+// Background is the stage accent at ~16% opacity; text is the full accent color.
+func makeStagePill(stage int) fyne.CanvasObject {
+	accent := kanbanColumnColor(stage)
+	nrgba := accent.(color.NRGBA)
+	bg := canvas.NewRectangle(color.NRGBA{R: nrgba.R, G: nrgba.G, B: nrgba.B, A: 0x28})
+	bg.CornerRadius = 4
+	label := monoText(kanbanColumnTitles[stage], accent, false)
+	label.TextSize = scaledSize(9)
+	return container.NewStack(bg, container.NewPadded(label))
+}
+
 // KanbanStages groups the 1-based linked-worktree indices (matching SelectedCard)
 // into five slices, one per kanban column. Index 0 (main) is never included.
 func (d *Dashboard) KanbanStages() [5][]int {

--- a/internal/gui/kanban.go
+++ b/internal/gui/kanban.go
@@ -216,31 +216,35 @@ func (r *kanbanCardWrapperRenderer) Refresh()                     { r.w.inner.Re
 func (r *kanbanCardWrapperRenderer) Destroy()                     {}
 func (r *kanbanCardWrapperRenderer) Objects() []fyne.CanvasObject { return []fyne.CanvasObject{r.w.inner} }
 
-// kanbanStageOf returns the kanban column index (0–3) for a worktree based on
+// kanbanStageOf returns the kanban column index (0–4) for a worktree based on
 // its PR/MR state and review status.
 //
-//	0 = Created   — no PR, or PR is closed
-//	1 = PR Sent   — open PR with no review activity yet
-//	2 = PR In Review — open PR that has at least one review
-//	3 = PR Merged — PR has been merged
+//	0 = Closed Unmerged — PR is closed but not merged
+//	1 = Created   — no PR
+//	2 = PR Sent   — open PR with no review activity yet
+//	3 = PR In Review — open PR that has at least one review
+//	4 = PR Merged — PR has been merged
 func kanbanStageOf(pr *provider.PRInfo) int {
-	if pr == nil || pr.State == "closed" {
-		return 0
+	if pr == nil {
+		return 1
 	}
 	switch pr.State {
+	case "closed":
+		return 0
 	case "merged":
-		return 3
+		return 4
 	case "open":
 		if pr.ReviewStatus != "" {
-			return 2
+			return 3
 		}
-		return 1
+		return 2
 	default:
-		return 0
+		return 1
 	}
 }
 
-var kanbanColumnTitles = [4]string{
+var kanbanColumnTitles = [5]string{
+	"Closed Unmerged",
 	"Created",
 	"PR Sent",
 	"PR In Review",
@@ -251,12 +255,14 @@ var kanbanColumnTitles = [4]string{
 func kanbanColumnColor(stage int) color.Color {
 	switch stage {
 	case 0:
-		return colorGray
+		return colorRed
 	case 1:
-		return colorBlue
+		return colorGray
 	case 2:
-		return colorYellow
+		return colorBlue
 	case 3:
+		return colorYellow
+	case 4:
 		return colorPurple
 	default:
 		return colorGray
@@ -266,11 +272,13 @@ func kanbanColumnColor(stage int) color.Color {
 // kanbanColumnBgColor returns a subtle body-tint for the column background.
 func kanbanColumnBgColor(stage int) color.Color {
 	switch stage {
-	case 1:
-		return color.NRGBA{R: 0x69, G: 0xa7, B: 0xff, A: 0x1a} // blue  ~10 %
+	case 0:
+		return color.NRGBA{R: 0xff, G: 0x69, B: 0x69, A: 0x1a} // red    ~10 %
 	case 2:
-		return color.NRGBA{R: 0xf3, G: 0xd6, B: 0x6b, A: 0x1a} // yellow ~10 %
+		return color.NRGBA{R: 0x69, G: 0xa7, B: 0xff, A: 0x1a} // blue   ~10 %
 	case 3:
+		return color.NRGBA{R: 0xf3, G: 0xd6, B: 0x6b, A: 0x1a} // yellow ~10 %
+	case 4:
 		return color.NRGBA{R: 0xca, G: 0x79, B: 0xff, A: 0x1a} // purple ~10 %
 	default:
 		return color.NRGBA{R: 0x70, G: 0x83, B: 0x94, A: 0x12} // gray   ~ 7 %
@@ -280,11 +288,13 @@ func kanbanColumnBgColor(stage int) color.Color {
 // kanbanColumnHeaderBgColor returns a stronger header tint for a kanban column.
 func kanbanColumnHeaderBgColor(stage int) color.Color {
 	switch stage {
-	case 1:
-		return color.NRGBA{R: 0x69, G: 0xa7, B: 0xff, A: 0x38} // blue  ~22 %
+	case 0:
+		return color.NRGBA{R: 0xff, G: 0x69, B: 0x69, A: 0x38} // red    ~22 %
 	case 2:
-		return color.NRGBA{R: 0xf3, G: 0xd6, B: 0x6b, A: 0x38} // yellow ~22 %
+		return color.NRGBA{R: 0x69, G: 0xa7, B: 0xff, A: 0x38} // blue   ~22 %
 	case 3:
+		return color.NRGBA{R: 0xf3, G: 0xd6, B: 0x6b, A: 0x38} // yellow ~22 %
+	case 4:
 		return color.NRGBA{R: 0xca, G: 0x79, B: 0xff, A: 0x38} // purple ~22 %
 	default:
 		return color.NRGBA{R: 0x70, G: 0x83, B: 0x94, A: 0x28} // gray  ~16 %
@@ -292,9 +302,9 @@ func kanbanColumnHeaderBgColor(stage int) color.Color {
 }
 
 // KanbanStages groups the 1-based linked-worktree indices (matching SelectedCard)
-// into four slices, one per kanban column. Index 0 (main) is never included.
-func (d *Dashboard) KanbanStages() [4][]int {
-	var stages [4][]int
+// into five slices, one per kanban column. Index 0 (main) is never included.
+func (d *Dashboard) KanbanStages() [5][]int {
+	var stages [5][]int
 	linked := d.state.LinkedWorktrees()
 	for i, wt := range linked {
 		idx := i + 1 // 1-based: index 0 is the main worktree
@@ -317,7 +327,7 @@ func (d *Dashboard) KanbanColumnOf(cardIdx int) int {
 
 // KanbanRowOf returns the 0-based row within the column for the given 1-based
 // worktree index. Returns 0 if the card is not found in the column.
-func (d *Dashboard) KanbanRowOf(cardIdx int, stages [4][]int) int {
+func (d *Dashboard) KanbanRowOf(cardIdx int, stages [5][]int) int {
 	col := d.KanbanColumnOf(cardIdx)
 	for row, idx := range stages[col] {
 		if idx == cardIdx {
@@ -327,7 +337,7 @@ func (d *Dashboard) KanbanRowOf(cardIdx int, stages [4][]int) int {
 	return 0
 }
 
-// buildKanbanView constructs the four-column kanban board for linked worktrees.
+// buildKanbanView constructs the five-column kanban board for linked worktrees.
 // Each column is wrapped in a coloured border rectangle (matching the website
 // kb-col design): subtle body tint + stronger header tint + coloured stroke.
 // Cards scroll vertically inside each column via NewVScroll, which constrains
@@ -335,7 +345,7 @@ func (d *Dashboard) KanbanRowOf(cardIdx int, stages [4][]int) int {
 func (d *Dashboard) buildKanbanView() fyne.CanvasObject {
 	stages := d.KanbanStages()
 
-	cols := make([]fyne.CanvasObject, 4)
+	cols := make([]fyne.CanvasObject, 5)
 	for si, stageIndices := range stages {
 		accentColor := kanbanColumnColor(si)
 
@@ -404,5 +414,5 @@ func (d *Dashboard) buildKanbanView() fyne.CanvasObject {
 		cols[si] = container.NewStack(colBg, container.NewPadded(colContent))
 	}
 
-	return container.NewGridWithColumns(4, cols...)
+	return container.NewGridWithColumns(5, cols...)
 }

--- a/internal/gui/kanban_test.go
+++ b/internal/gui/kanban_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/mdelapenya/biomelab/internal/provider"
 )
 
-// TestKanbanStages_AlwaysFourStages verifies that KanbanStages always returns
-// exactly four stage buckets — even when some (or all) are empty — so that
-// buildKanbanView can always produce a complete four-column board.
-func TestKanbanStages_AlwaysFourStages(t *testing.T) {
+// TestKanbanStages_AlwaysFiveStages verifies that KanbanStages always returns
+// exactly five stage buckets — even when some (or all) are empty — so that
+// buildKanbanView can always produce a complete five-column board.
+func TestKanbanStages_AlwaysFiveStages(t *testing.T) {
 	cases := []struct {
 		name      string
 		worktrees []git.Worktree
@@ -29,19 +29,21 @@ func TestKanbanStages_AlwaysFourStages(t *testing.T) {
 			name: "all stages populated",
 			worktrees: []git.Worktree{
 				{Path: "/repo", Branch: "main", IsMain: true},
+				{Name: "closed-unmerged", Path: "/wt/closed-unmerged", Branch: "closed-unmerged"},
 				{Name: "created", Path: "/wt/created", Branch: "created"},
 				{Name: "sent", Path: "/wt/sent", Branch: "sent"},
 				{Name: "review", Path: "/wt/review", Branch: "review"},
 				{Name: "merged", Path: "/wt/merged", Branch: "merged"},
 			},
 			prs: provider.PRResult{
-				"sent":   {State: "open"},
-				"review": {State: "open", ReviewStatus: "approved"},
-				"merged": {State: "merged"},
+				"closed-unmerged": {State: "closed"},
+				"sent":            {State: "open"},
+				"review":          {State: "open", ReviewStatus: "approved"},
+				"merged":          {State: "merged"},
 			},
 		},
 		{
-			name: "only stage 0 (no PRs)",
+			name: "only stage 1 (no PRs)",
 			worktrees: []git.Worktree{
 				{Path: "/repo", Branch: "main", IsMain: true},
 				{Name: "wt1", Path: "/wt/wt1", Branch: "wt1"},
@@ -49,7 +51,7 @@ func TestKanbanStages_AlwaysFourStages(t *testing.T) {
 			},
 		},
 		{
-			name: "stages 0 and 1 only — stage 3 (PR Merged) is empty",
+			name: "stages 1 and 2 only — stages 0, 3, 4 are empty",
 			worktrees: []git.Worktree{
 				{Path: "/repo", Branch: "main", IsMain: true},
 				{Name: "no-pr", Path: "/wt/no-pr", Branch: "no-pr"},
@@ -83,11 +85,11 @@ func TestKanbanStages_AlwaysFourStages(t *testing.T) {
 	}
 }
 
-// TestBuildKanbanView_AlwaysFourColumns verifies that buildKanbanView always
-// produces a grid container with exactly four children — one per stage column —
+// TestBuildKanbanView_AlwaysFiveColumns verifies that buildKanbanView always
+// produces a grid container with exactly five children — one per stage column —
 // even when some stages are empty. Regression guard for the "lost-columns" bug
 // where an empty PR-Merged column would collapse and disappear from the board.
-func TestBuildKanbanView_AlwaysFourColumns(t *testing.T) {
+func TestBuildKanbanView_AlwaysFiveColumns(t *testing.T) {
 	testApp := test.NewApp()
 	defer testApp.Quit()
 
@@ -97,7 +99,7 @@ func TestBuildKanbanView_AlwaysFourColumns(t *testing.T) {
 		prs       provider.PRResult
 	}{
 		{
-			name: "stage 3 empty — only stages 0+1 occupied",
+			name: "stage 4 empty — only stages 1+2 occupied",
 			worktrees: []git.Worktree{
 				{Path: "/repo", Branch: "main", IsMain: true},
 				{Name: "no-pr", Path: "/wt/no-pr", Branch: "no-pr"},
@@ -115,18 +117,20 @@ func TestBuildKanbanView_AlwaysFourColumns(t *testing.T) {
 			},
 		},
 		{
-			name: "all four stages occupied",
+			name: "all five stages occupied",
 			worktrees: []git.Worktree{
 				{Path: "/repo", Branch: "main", IsMain: true},
+				{Name: "closed-unmerged", Path: "/wt/closed-unmerged", Branch: "closed-unmerged"},
 				{Name: "created", Path: "/wt/created", Branch: "created"},
 				{Name: "sent", Path: "/wt/sent", Branch: "sent"},
 				{Name: "review", Path: "/wt/review", Branch: "review"},
 				{Name: "merged", Path: "/wt/merged", Branch: "merged"},
 			},
 			prs: provider.PRResult{
-				"sent":   {State: "open"},
-				"review": {State: "open", ReviewStatus: "approved"},
-				"merged": {State: "merged"},
+				"closed-unmerged": {State: "closed"},
+				"sent":            {State: "open"},
+				"review":          {State: "open", ReviewStatus: "approved"},
+				"merged":          {State: "merged"},
 			},
 		},
 	}
@@ -147,8 +151,8 @@ func TestBuildKanbanView_AlwaysFourColumns(t *testing.T) {
 			if !ok {
 				t.Fatalf("buildKanbanView did not return *fyne.Container, got %T", result)
 			}
-			if got := len(grid.Objects); got != 4 {
-				t.Errorf("kanban grid has %d columns, want 4", got)
+			if got := len(grid.Objects); got != 5 {
+				t.Errorf("kanban grid has %d columns, want 5", got)
 			}
 			for i, obj := range grid.Objects {
 				if obj == nil {

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1889,12 +1889,7 @@ footer {
 }
 
 .kb-card-approved {
-  border-color: color-mix(in srgb, var(--green) 45%, var(--border));
   animation: kbCardApproved 2.4s ease-in-out infinite
-}
-
-.kb-card-changes {
-  border-color: color-mix(in srgb, var(--red) 40%, var(--border))
 }
 
 /* Hover glow — each column uses its own accent colour */
@@ -1903,6 +1898,13 @@ footer {
 .kb-col-sent     .kb-card-hover { border-color: var(--blue);       box-shadow: 0 0 12px color-mix(in srgb, var(--blue)       22%, transparent) }
 .kb-col-in-review .kb-card-hover { border-color: var(--yellow);     box-shadow: 0 0 12px color-mix(in srgb, var(--yellow)     22%, transparent) }
 .kb-col-merged   .kb-card-hover { border-color: var(--magenta);    box-shadow: 0 0 12px color-mix(in srgb, var(--magenta)    22%, transparent) }
+
+/* Grid view card hover effects — by stage pill class */
+.kb-grid .kb-card:has(.kb-stage-closed):hover   { border-color: var(--red);        box-shadow: 0 0 12px color-mix(in srgb, var(--red)        22%, transparent) }
+.kb-grid .kb-card:has(.kb-stage-created):hover  { border-color: var(--text-muted); box-shadow: 0 0 12px color-mix(in srgb, var(--text-muted) 28%, transparent) }
+.kb-grid .kb-card:has(.kb-stage-sent):hover     { border-color: var(--blue);       box-shadow: 0 0 12px color-mix(in srgb, var(--blue)       22%, transparent) }
+.kb-grid .kb-card:has(.kb-stage-review):hover   { border-color: var(--yellow);     box-shadow: 0 0 12px color-mix(in srgb, var(--yellow)     22%, transparent) }
+.kb-grid .kb-card:has(.kb-stage-merged):hover   { border-color: var(--magenta);    box-shadow: 0 0 12px color-mix(in srgb, var(--magenta)    22%, transparent) }
 
 /* Footer hint */
 .kb-footer-hint {
@@ -1974,6 +1976,63 @@ footer {
   .notes-features {
     grid-template-columns: 1fr
   }
+}
+
+/* Kanban grid view: flat responsive grid (hidden by default) */
+.kb-grid {
+  display: none
+}
+
+.kb-view-grid .kb-board {
+  display: none
+}
+
+.kb-view-grid .kb-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: .9rem
+}
+
+/* Stage pill: indicates which column the card belongs to */
+.kb-stage-pill {
+  margin-left: auto;
+  font-size: .65rem;
+  padding: .1rem .4rem;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-weight: 500
+}
+
+.kb-stage-closed  { background: color-mix(in srgb, var(--red)        15%, transparent); color: var(--red) }
+.kb-stage-created { background: color-mix(in srgb, var(--text-muted) 15%, transparent); color: var(--text-muted) }
+.kb-stage-sent    { background: color-mix(in srgb, var(--blue)       15%, transparent); color: var(--blue) }
+.kb-stage-review  { background: color-mix(in srgb, var(--yellow)     15%, transparent); color: var(--yellow) }
+.kb-stage-merged  { background: color-mix(in srgb, var(--magenta)    15%, transparent); color: var(--magenta) }
+
+/* Glow effect on interactive 'g' key hint */
+@keyframes gKeyGlow {
+  0%, 100% { box-shadow: 0 0 8px rgba(92, 225, 230, .4), inset 0 0 4px rgba(92, 225, 230, .2) }
+  50%      { box-shadow: 0 0 16px rgba(92, 225, 230, .7), inset 0 0 8px rgba(92, 225, 230, .3) }
+}
+
+.kb-footer-hint kbd.kb-g-glow {
+  animation: gKeyGlow 2s ease-in-out infinite;
+  border-radius: 4px;
+  padding: .2rem .35rem
+}
+
+.kb-glow-pulse {
+  animation: gKeyGlowPulse 0.6s ease-out;
+}
+
+@keyframes gKeyGlowPulse {
+  0%   { box-shadow: 0 0 12px rgba(92, 225, 230, .8), inset 0 0 6px rgba(92, 225, 230, .4) }
+  100% { box-shadow: 0 0 0 rgba(92, 225, 230, 0), inset 0 0 0 rgba(92, 225, 230, 0) }
+}
+
+/* Smooth title transition */
+#kb-title {
+  transition: opacity .3s ease-in-out
 }
 
 /* ── Task Notes ──────────────────────────────────────────── */

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -2021,14 +2021,6 @@ footer {
   padding: .2rem .35rem
 }
 
-.kb-glow-pulse {
-  animation: gKeyGlowPulse 0.6s ease-out;
-}
-
-@keyframes gKeyGlowPulse {
-  0%   { box-shadow: 0 0 12px rgba(92, 225, 230, .8), inset 0 0 6px rgba(92, 225, 230, .4) }
-  100% { box-shadow: 0 0 0 rgba(92, 225, 230, 0), inset 0 0 0 rgba(92, 225, 230, 0) }
-}
 
 /* Smooth title transition */
 #kb-title {

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1732,10 +1732,10 @@ footer {
   box-shadow: var(--shadow-card)
 }
 
-/* Board: four columns + three flow arrows, laid out in a row */
+/* Board: five columns + four flow arrows, laid out in a row */
 .kb-board {
   display: grid;
-  grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr;
+  grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr auto 1fr;
   gap: .75rem;
   align-items: start
 }
@@ -1758,6 +1758,7 @@ footer {
   padding-bottom: .5rem
 }
 
+.kb-col-closed   { border-color: var(--red);        background: color-mix(in srgb, var(--red)       9%,  var(--bg-card)) }
 .kb-col-created  { border-color: var(--text-muted); background: color-mix(in srgb, var(--text-muted) 7%,  var(--bg-card)) }
 .kb-col-sent     { border-color: var(--blue);        background: color-mix(in srgb, var(--blue)       9%,  var(--bg-card)) }
 .kb-col-in-review { border-color: var(--yellow);      background: color-mix(in srgb, var(--yellow)     9%,  var(--bg-card)) }
@@ -1785,6 +1786,7 @@ footer {
   border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent)
 }
 
+.kb-col-closed   .kb-col-header { background: color-mix(in srgb, var(--red)        22%, var(--bg-card)); color: var(--red) }
 .kb-col-created  .kb-col-header { background: color-mix(in srgb, var(--text-muted) 20%, var(--bg-card)); color: var(--text-muted) }
 .kb-col-sent     .kb-col-header { background: color-mix(in srgb, var(--blue)       22%, var(--bg-card)); color: var(--blue) }
 .kb-col-in-review .kb-col-header { background: color-mix(in srgb, var(--yellow)     22%, var(--bg-card)); color: var(--yellow) }
@@ -1799,6 +1801,7 @@ footer {
   color: var(--text-muted)
 }
 
+.kb-badge-red    { border-color: var(--red);     color: var(--red) }
 .kb-badge-blue   { border-color: var(--blue);    color: var(--blue) }
 .kb-badge-yellow { border-color: var(--yellow);  color: var(--yellow) }
 .kb-badge-purple { border-color: var(--magenta); color: var(--magenta) }
@@ -1841,6 +1844,7 @@ footer {
   border-radius: 50%
 }
 
+.kb-dot-red    { background: var(--red) }
 .kb-dot-gray   { background: var(--text-muted) }
 .kb-dot-blue   { background: var(--blue) }
 .kb-dot-yellow { background: var(--yellow) }
@@ -1862,6 +1866,7 @@ footer {
 .kb-pr-num       { color: var(--cyan) }
 .kb-pr-state-open   { color: var(--blue) }
 .kb-pr-state-draft  { color: var(--text-muted) }
+.kb-pr-state-closed { color: var(--red) }
 .kb-pr-state-merged { color: var(--magenta) }
 
 /* CI / review icons */
@@ -1893,6 +1898,7 @@ footer {
 }
 
 /* Hover glow — each column uses its own accent colour */
+.kb-col-closed   .kb-card-hover { border-color: var(--red);        box-shadow: 0 0 12px color-mix(in srgb, var(--red)        22%, transparent) }
 .kb-col-created  .kb-card-hover { border-color: var(--text-muted); box-shadow: 0 0 12px color-mix(in srgb, var(--text-muted) 28%, transparent) }
 .kb-col-sent     .kb-card-hover { border-color: var(--blue);       box-shadow: 0 0 12px color-mix(in srgb, var(--blue)       22%, transparent) }
 .kb-col-in-review .kb-card-hover { border-color: var(--yellow);     box-shadow: 0 0 12px color-mix(in srgb, var(--yellow)     22%, transparent) }
@@ -1918,26 +1924,32 @@ footer {
   color: var(--cyan)
 }
 
-/* Mobile: stack columns vertically */
+/* Mobile: stack columns vertically (2 per row) */
 @media (max-width: 1080px) {
   .kb-board {
     grid-template-columns: 1fr auto 1fr
   }
 
-  /* Hide arrows 2 and 4 (between cols 2→3 and 3→4) */
+  /* Hide arrows 2, 3, 5 (between cols 2→3, 3→4, 4→5) */
   .kb-flow-arrow:nth-child(4),
-  .kb-flow-arrow:nth-child(6) {
+  .kb-flow-arrow:nth-child(6),
+  .kb-flow-arrow:nth-child(8) {
     display: none
   }
 
-  /* Col 3 (in review) and col 4 (merged) each start on a new row */
+  /* Position columns on grid */
+  .kb-col-sent,
   .kb-col-in-review,
   .kb-col-merged {
     grid-column: 1
   }
 
-  .kb-col-merged {
+  .kb-col-in-review {
     grid-column: 3
+  }
+
+  .kb-col-merged {
+    grid-column: 1
   }
 }
 

--- a/website/index.html
+++ b/website/index.html
@@ -386,7 +386,7 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
       </div>
 
       <div class="kanban-diagram-html">
-        <h4 class="diagram-title">PR Lifecycle Board</h4>
+        <h4 class="diagram-title" id="kb-title">PR Lifecycle Board</h4>
 
         <div class="kb-board">
 
@@ -554,6 +554,124 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
           </div>
 
         </div><!-- /.kb-board -->
+
+        <!-- Grid view: flat responsive layout (toggled with 'g' key) -->
+        <div class="kb-grid">
+          <!-- Closed Unmerged -->
+          <div class="kb-card kb-card-closed" data-kb="feat/old-feature">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-red"></span>
+              <span class="kb-branch">feat/old-feature</span>
+              <span class="kb-stage-pill kb-stage-closed">closed</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#15</span> <span class="kb-pr-state-closed">closed</span></span></div>
+          </div>
+
+          <!-- Created -->
+          <div class="kb-card" data-kb="feat/new-signup">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-gray"></span>
+              <span class="kb-branch">feat/new-signup</span>
+              <span class="kb-stage-pill kb-stage-created">created</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-green">● claude</span></div>
+            <div class="kb-card-status"><span class="kb-no-pr">no PR</span></div>
+          </div>
+
+          <div class="kb-card" data-kb="fix/sidebar">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-gray"></span>
+              <span class="kb-branch">fix/sidebar</span>
+              <span class="kb-stage-pill kb-stage-created">created</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+            <div class="kb-card-status"><span class="kb-no-pr">no PR</span></div>
+          </div>
+
+          <!-- PR Sent -->
+          <div class="kb-card" data-kb="feat/auth-flow">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-blue"></span>
+              <span class="kb-branch">feat/auth-flow</span>
+              <span class="kb-stage-pill kb-stage-sent">sent</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-green">● claude</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#42</span> <span class="kb-pr-state-open">open</span></span><span class="kb-ci kb-ci-pending" title="CI pending">●</span></div>
+          </div>
+
+          <div class="kb-card" data-kb="fix/memory-leak">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-blue"></span>
+              <span class="kb-branch">fix/memory-leak</span>
+              <span class="kb-stage-pill kb-stage-sent">sent</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#38</span> <span class="kb-pr-state-open">open</span></span><span class="kb-ci kb-ci-pass" title="CI passed">✓</span></div>
+          </div>
+
+          <div class="kb-card kb-card-draft" data-kb="refactor/db">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-dim"></span>
+              <span class="kb-branch kb-branch-dim">refactor/db</span>
+              <span class="kb-stage-pill kb-stage-sent">sent</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-green">● codex</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#35</span> <span class="kb-pr-state-draft">draft</span></span></div>
+          </div>
+
+          <!-- PR In Review -->
+          <div class="kb-card kb-card-approved" data-kb="feat/api-v2">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-yellow"></span>
+              <span class="kb-branch">feat/api-v2</span>
+              <span class="kb-stage-pill kb-stage-review">review</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-green">● claude</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#31</span> <span class="kb-pr-state-open">open</span></span><span class="kb-review kb-review-approved" title="Approved">✓</span><span class="kb-ci kb-ci-pass" title="CI passed">✓</span></div>
+          </div>
+
+          <div class="kb-card kb-card-changes" data-kb="fix/login">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-yellow"></span>
+              <span class="kb-branch">fix/login</span>
+              <span class="kb-stage-pill kb-stage-review">review</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#29</span> <span class="kb-pr-state-open">open</span></span><span class="kb-review kb-review-changes" title="Changes requested">!</span><span class="kb-ci kb-ci-fail" title="CI failed">✗</span></div>
+          </div>
+
+          <!-- PR Merged -->
+          <div class="kb-card kb-card-merged" data-kb="feat/dark-mode">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-purple"></span>
+              <span class="kb-branch kb-branch-merged">feat/dark-mode</span>
+              <span class="kb-stage-pill kb-stage-merged">merged</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#28</span> <span class="kb-pr-state-merged">merged</span></span><span class="kb-ci kb-ci-pass">✓</span></div>
+          </div>
+
+          <div class="kb-card kb-card-merged" data-kb="fix/typo">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-purple"></span>
+              <span class="kb-branch kb-branch-merged">fix/typo</span>
+              <span class="kb-stage-pill kb-stage-merged">merged</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#27</span> <span class="kb-pr-state-merged">merged</span></span><span class="kb-ci kb-ci-pass">✓</span></div>
+          </div>
+
+          <div class="kb-card kb-card-merged" data-kb="feat/ui-refresh">
+            <div class="kb-card-top">
+              <span class="kb-dot kb-dot-purple"></span>
+              <span class="kb-branch kb-branch-merged">feat/ui-refresh</span>
+              <span class="kb-stage-pill kb-stage-merged">merged</span>
+            </div>
+            <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+            <div class="kb-card-status"><span class="kb-pr-label">PR <span class="kb-pr-num">#24</span> <span class="kb-pr-state-merged">merged</span></span><span class="kb-ci kb-ci-pass">✓</span></div>
+          </div>
+        </div><!-- /.kb-grid -->
 
         <div class="kb-footer-hint">
           <span>↑↓ navigate column · ←→ switch column · <kbd>g</kbd> toggle grid view</span>
@@ -815,6 +933,52 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
         if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
       });
     });
+
+    // Kanban / grid toggle — press 'g' to switch views
+    (function () {
+      var diagram = document.querySelector('.kanban-diagram-html');
+      var title   = document.querySelector('#kb-title');
+      var hint    = document.querySelector('.kb-footer-hint span');
+      var STORE_KEY = 'kb-view';
+
+      function getHintHTML(mode) {
+        if (mode === 'grid') {
+          return 'Press <kbd class="kb-g-glow">g</kbd> to return to kanban board';
+        } else {
+          return 'Try <kbd class="kb-g-glow">g</kbd> for grid view';
+        }
+      }
+
+      function setView(mode) {
+        if (mode === 'grid') {
+          diagram.classList.add('kb-view-grid');
+          title.textContent = 'Card Grid View';
+          hint.innerHTML = getHintHTML('grid');
+        } else {
+          diagram.classList.remove('kb-view-grid');
+          title.textContent = 'PR Lifecycle Board';
+          hint.innerHTML = getHintHTML('kanban');
+        }
+        localStorage.setItem(STORE_KEY, mode);
+      }
+
+      // Restore saved preference
+      var saved = localStorage.getItem(STORE_KEY);
+      if (saved === 'grid') setView('grid');
+
+      document.addEventListener('keydown', function (e) {
+        // Ignore when focus is in an input / textarea
+        var tag = document.activeElement && document.activeElement.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        if (e.key === 'g' || e.key === 'G') {
+          setView(diagram.classList.contains('kb-view-grid') ? 'kanban' : 'grid');
+          // Trigger glow animation on title as feedback
+          title.classList.remove('kb-glow-pulse');
+          void title.offsetWidth; // Force reflow to restart animation
+          title.classList.add('kb-glow-pulse');
+        }
+      });
+    })();
   </script>
 </body>
 

--- a/website/index.html
+++ b/website/index.html
@@ -972,10 +972,6 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
         if (tag === 'INPUT' || tag === 'TEXTAREA') return;
         if (e.key === 'g' || e.key === 'G') {
           setView(diagram.classList.contains('kb-view-grid') ? 'kanban' : 'grid');
-          // Trigger glow animation on title as feedback
-          title.classList.remove('kb-glow-pulse');
-          void title.offsetWidth; // Force reflow to restart animation
-          title.classList.add('kb-glow-pulse');
         }
       });
     })();

--- a/website/index.html
+++ b/website/index.html
@@ -369,11 +369,11 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
     <div class="container">
       <span class="section-label">Kanban Board</span>
       <h2>See every PR's lifecycle <span class="kb-accent">at a glance</span></h2>
-      <p class="kanban-intro">The default view groups your worktrees into four columns — from fresh branch to merged PR. One keystroke switches to the flat grid and back.</p>
+      <p class="kanban-intro">The default view groups your worktrees into five columns — from closed PRs to merged. One keystroke switches to the flat grid and back.</p>
       <div class="kanban-features">
         <div class="kanban-feat-card"><span class="icon">📋</span>
-          <h3>Four lifecycle stages</h3>
-          <p>Created → PR Sent → PR In Review → PR Merged. Branches self-sort as CI runs and reviewers respond.</p>
+          <h3>Five lifecycle stages</h3>
+          <p>Closed Unmerged → Created → PR Sent → PR In Review → PR Merged. Branches self-sort as CI runs and reviewers respond.</p>
         </div>
         <div class="kanban-feat-card"><span class="icon">🔍</span>
           <h3>Review status on every card</h3>
@@ -390,7 +390,27 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
 
         <div class="kb-board">
 
-          <!-- Column 0: Created -->
+          <!-- Column 0: Closed Unmerged -->
+          <div class="kb-col kb-col-closed">
+            <div class="kb-col-header">
+              <span class="kb-col-title">Closed Unmerged</span>
+              <span class="kb-col-badge kb-badge-red">1</span>
+            </div>
+            <div class="kb-card kb-card-closed" data-kb="feat/old-feature">
+              <div class="kb-card-top">
+                <span class="kb-dot kb-dot-red"></span>
+                <span class="kb-branch">feat/old-feature</span>
+              </div>
+              <div class="kb-card-meta"><span class="kb-agent kb-agent-dim">○ no agent</span></div>
+              <div class="kb-card-status">
+                <span class="kb-pr-label">PR <span class="kb-pr-num">#15</span> <span class="kb-pr-state-closed">closed</span></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="kb-flow-arrow">&#x276F;</div>
+
+          <!-- Column 1: Created -->
           <div class="kb-col kb-col-created">
             <div class="kb-col-header">
               <span class="kb-col-title">Created</span>


### PR DESCRIPTION
## What's changed

Expands the kanban board from 4 to 5 columns, adding a "Closed Unmerged" column for worktrees with closed, unmerged PRs. This makes abandoned work immediately visible. Also adds interactive view toggling on the website and stage pills in grid views (both website and GUI) so users can see PR lifecycle stage at a glance in any view.

The new column appears as the leftmost (top-left) column with a red accent, making it distinct from "Created" (no PR yet) and clearly indicating work that was started but abandoned.

## Why is this important?

**Visibility of abandoned work**: The kanban board now explicitly tracks closed/abandoned PRs, helping developers quickly identify stalled work that may need cleanup or revival.

**Flexible visualization**: The interactive 'g' key toggle lets users switch between the 5-column board view (overall workflow) and a flat grid view (card details). Grid view also shows stage pills, eliminating the need to look at column context to know a card's status.

**Consistent UX**: Stage pills appear in both website and GUI grid views, providing the same visual feedback regardless of platform.

## Changes

### Kanban board (5-column lifecycle)

- **Stage 0 (Closed Unmerged)**: Worktrees with closed, unmerged PRs — red accent
- **Stage 1 (Created)**: No PR associated yet — gray accent
- **Stage 2 (PR Sent)**: Open PR with no review activity — blue accent
- **Stage 3 (PR In Review)**: Open PR with review feedback — yellow accent
- **Stage 4 (PR Merged)**: Merged PR — purple accent

Updated `kanbanStageOf()` to return 0 for closed PRs and adjust other stages accordingly. Updated `KanbanStages()` test to verify 5 columns always exist.

### Website features

- Added `.kb-grid` container with flat responsive card grid (3–4 columns based on viewport)
- Interactive 'g' key toggle: press 'g' to switch between "PR Lifecycle Board" and "Card Grid View"
- View preference persists via localStorage across page reloads
- Dynamic title updates based on active view
- Stage pills on each card showing lifecycle stage (colored to match kanban column)
- Glow pulse animation on title when pressing 'g' gives visual feedback
- Hover glow on grid cards matches kanban column colors

### GUI grid view

- Added `makeStagePill()` helper in `kanban.go` to render colored stage pills
- Updated `buildCardContent()` in `card.go` to show stage pills on branch row for linked worktrees only (not main)
- Pills use semi-transparent background (16% opacity) and stage accent color

### Documentation

- Updated product-owner skill to reflect 5-stage kanban lifecycle
- Updated website intro and feature cards to describe 5 columns
- Updated HTML kanban diagram with Closed Unmerged column and example
- Adjusted responsive CSS grid from 4 to 5 columns + 4 flow arrows

## Test plan

1. **Kanban board**: Launch GUI, verify 5 columns render (all four headers visible even when empty)
2. **Grid view (website)**: Open website, press 'g' to toggle to grid view — cards display with stage pills; title changes dynamically; page reload preserves view preference
3. **Grid view (GUI)**: Switch to grid view, verify linked worktree cards show stage pills on the right of branch name; main worktree has no pill
4. **Hover effects**: Hover cards in both board and grid views — border glows with stage color
5. **Responsive**: Resize website window; grid view wraps properly at different breakpoints
