### PR TITLE
feat(regent): integrate re_gent audit trail for AI agents

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,20 +14,23 @@ cmd/biomelab/
 
 internal/
   gui/
-    app.go             FyneApp: window, HSplit layout, multi-repo management, mode switching
-    dashboard.go       Right panel: main card + scrollable linked cards grid, refresh timestamps
-    card.go            Worktree card rendering: branch, path, PR, agents, IDEs, status
-    repo_panel.go      Left panel: tappable VBox of repo/mode items (NOT widget.Tree)
-    repo_panel_drag.go Drag-handle widget + reorder math for repo panel
-    shortcuts.go       All keyboard handling: handleKeyName + handleRune, navigation, operations
-    keycapture.go      desktop.Canvas.SetOnKeyDown setup, zoom shortcuts
-    dialogs.go         Confirmation dialogs (delete, sandbox create/remove, send PR flow)
-    input_dialogs.go   Input dialogs (branch, PR ref, repo path, agent select)
-    refresh.go         RefreshManager: goroutine tickers for local (5s) and network refresh
-    state.go           RepoState: domain + UI state, worktree sorting
-    theme.go           Dark theme with zoom support (Ctrl+/Ctrl-)
-    icon.go            AppIcon resource (set from embedded icon at startup)
-    systray.go         System tray: Show/Hide toggle, Quit
+    app.go                  FyneApp: window, HSplit layout, multi-repo management, mode switching
+    dashboard.go            Right panel: main card + scrollable linked cards grid, refresh timestamps
+    card.go                 Worktree card rendering: branch, path, PR, agents, IDEs, status
+    repo_panel.go           Left panel: tappable VBox of repo/mode items (NOT widget.Tree)
+    repo_panel_drag.go      Drag-handle widget + reorder math for repo panel
+    shortcuts.go            All keyboard handling: handleKeyName + handleRune, navigation, operations
+    keycapture.go           desktop.Canvas.SetOnKeyDown setup, zoom shortcuts
+    dialogs.go              Confirmation dialogs (delete, sandbox create/remove, send PR flow)
+    input_dialogs.go        Input dialogs (branch, PR ref, repo path, agent select)
+    refresh.go              RefreshManager: goroutine tickers for local (5s) and network refresh
+    state.go                RepoState: domain + UI state, worktree sorting
+    theme.go                Dark theme with zoom support (Ctrl+/Ctrl-)
+    icon.go                 AppIcon resource (set from embedded icon at startup)
+    systray.go              System tray: Show/Hide toggle, Quit, Dependencies summary
+    sysdeps_dialog.go       System Dependencies modal + first-run banner
+    regent_log_dialog.go    Regent activity window (single instance, resizable, JSON export)
+    save_file.go            OS-native save dialog (osascript/zenity/PowerShell) + Fyne fallback
 
   ops/
     refresh.go         QuickRefresh, LocalRefresh, NetworkRefresh, CardRefresh
@@ -36,6 +39,7 @@ internal/
 
   config/config.go     Repo list persistence (~/.config/biomelab/repos.json)
   git/worktree.go      Go-git v6 wrapper: list, create, remove, pull, fetch, sync status
+  git/exclude.go       Per-worktree git info/exclude writer (used by notes + regent)
   git/credential.go    Git credential helper protocol (git credential fill)
   agent/               Agent kind registry + process detection
   ide/                 IDE kind registry + process detection
@@ -44,6 +48,9 @@ internal/
   sandbox/sandbox.go   Docker Sandbox (sbx) CLI wrapper
   terminal/terminal.go Open new terminal window (macOS .command / Linux x-terminal-emulator)
   github/pr.go         GitHub-specific PR helpers (ParsePRRef, ValidatePR)
+  notes/notes.go       Per-worktree Markdown notes (.biomelab/note.md, pr-title.md)
+  regent/              re_gent (rgt) integration: detection, init, hook install, log fetch
+  sysdeps/             External CLI dependency checks (gh/glab/sbx/rgt) + cache
 ```
 
 ## Key dependencies
@@ -176,6 +183,80 @@ skill (and similar tools) target: write the generated title and description
 to those two paths, and biomelab turns them into the actual PR on the next
 `Shift+P`.
 
+## re_gent integration
+
+[re_gent](https://github.com/regent-vcs/re_gent) captures every agent turn
+(prompt, reply, tool calls) into a content-addressed `.regent/` directory
+per worktree. Biomelab wraps it so the integration is invisible until the
+user installs `rgt`:
+
+- **Auto-init on host worktrees.** `ops.CreateWorktree` runs
+  `regent.EnsureInit` after every new worktree creation, and
+  `app.buildRepoEntry` walks existing worktrees on startup
+  (`migrateRegentForRepo`) so an `rgt install` retroactively wires up
+  every regular-mode worktree on the next refresh. Sandbox worktrees
+  skip this path — rgt belongs inside the container, installed via the
+  regent kit.
+- **`EnsureInit` runs `rgt init --skip-hook --skip-skills`** with
+  `cmd.Dir = wtPath`. `rgt init` ignores positional path args and always
+  operates on `cwd`, so `cmd.Dir` is mandatory. The `--skip-hook` flag is
+  used because rgt's interactive installer needs a TTY biomelab can't
+  provide; we install Claude hooks ourselves.
+- **`EnsureClaudeHooks` writes `.claude/settings.json`** with three event
+  hooks (`UserPromptSubmit`, `Stop`, `PostToolBatch`) pointing at
+  `rgt message-hook` / `rgt tool-batch-hook`. Idempotent: rgt-related
+  entries are deduplicated on each call, non-rgt entries are preserved.
+  The JSON shape is ported from rgt's own installer
+  (`internal/cli/init.go`, Apache-2.0, attributed in source).
+- **Git exclude.** `git.EnsureExcluded` writes `/.regent/` (and
+  `/.biomelab/`) to the worktree's common `info/exclude` so neither
+  directory shows up in `git status`. Extracted to `internal/git` so
+  both `notes` and `regent` share one helper (used to live in `notes`,
+  caused a `git → notes` import that prevented `notes → git`).
+- **Log viewer.** `l` shortcut opens `regent_log_dialog.go`, a single
+  top-level resizable window. Content comes from `rgt log --json`
+  (parsed in `internal/regent/log_json.go`) and renders structured rows:
+  `sha · timestamp · origin`, `Human:` prompt, `Agent:` reply, then a
+  `▶ N tools` toggle that reveals one row per tool call with the
+  primary arg inline (file_path / command / query) and the rest below.
+  Full file paths, no truncation. Single window: pressing `l` on a
+  different card reuses the open window (`App.regentLogWindow` +
+  `regentLogReload`).
+- **JSON export.** The window's `Export JSON…` button calls
+  `regent.LogJSONRaw` and saves the bytes via the OS-native save dialog
+  helper (`gui/save_file.go`: osascript on macOS, zenity/kdialog on
+  Linux, PowerShell on Windows; falls back to `dialog.NewFileSave`).
+
+## System dependencies
+
+`internal/sysdeps` is the registry of external CLIs biomelab cares
+about. Each `Check` has a `Probe` that returns `Result{Status, Version,
+Note}`; a `Cache` (default TTL 30s) memoizes results across the systray
+menu, the dialog, and the first-run banner.
+
+Two filtering layers apply before rendering:
+
+- `ApplySuppression` drops `Missing` entries whose `SuppressIfAny` list
+  names another check that is currently `OK` or `Degraded`. Used so
+  `glab missing` doesn't appear when `gh` is installed.
+- `ApplyVisibility` drops `Missing` entries whose `Applies(cfg)` callback
+  says the tool isn't relevant. Used so `sbx` doesn't appear at all
+  when the user has no sandbox-mode repo. **Important:** `Applies`
+  gates visibility of missing entries only — installed tools always
+  show as green even when the user's config doesn't strictly need them.
+  That way `sbx v0.29.0` is reported correctly on machines where the
+  user just happens to have it.
+- `Partition` splits the surviving entries into a primary list and an
+  optional list (`Optional && Missing`). The dialog renders the
+  primary list at the top and the optional list (currently just `rgt`)
+  under an "Optional tools" heading.
+
+The systray label is `Dependencies: N/M ✓` (or
+`Dependencies: N/M (X need attention)`), where N/M counts only the
+visible primary entries. Clicking opens the dialog; the dialog's
+**Re-check** button invalidates the cache and refreshes the systray
+label in one call.
+
 ## Pitfalls
 
 - go-git v6 is a pseudo-version. Do NOT use a `replace` directive.
@@ -185,3 +266,7 @@ to those two paths, and biomelab turns them into the actual PR on the next
 - `widget.Button` implements Focusable — don't put buttons in the main content.
 - IDE `ProcessPatterns` order matters: specific before broad (`"nvim"` before `"vim"`).
 - Always bounds-check `a.active < len(a.repos)` before accessing repos.
+- `rgt init` ignores positional path args and operates on `cwd`. Use `cmd.Dir`, not `rgt init <path>`.
+- `rgt init` hook installer needs a TTY; biomelab writes `.claude/settings.json` itself via `regent.EnsureClaudeHooks`. Don't rely on `--agent claude` to skip the prompt — it doesn't.
+- `widget.Accordion` misbehaves inside `container.NewVScroll` (clicks don't toggle). Use a button + visibility toggle instead — see the regent log dialog's tools collapsible.
+- The shared regent log window is keyed by `App.regentLogWindow` (single instance). Don't spawn a new window per worktree; reuse via `regentLogReload`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Go version: 1.25+ (check `go env GOROOT` if you hit version mismatches).
 - **go-git v6** (unreleased, from main branch) -- All git operations.
 - **gopsutil** -- Cross-platform process detection.
 - **gh CLI / glab CLI** -- External tools for PR/MR status.
+- **rgt CLI** ([re_gent](https://github.com/regent-vcs/re_gent)) -- Optional. When installed, biomelab auto-initializes `.regent/` per worktree and wires Claude Code hooks.
 
 ## Package layout
 
@@ -46,16 +47,21 @@ Go version: 1.25+ (check `go env GOROOT` if you hit version mismatches).
 cmd/biomelab/          Entry point, icon embedding, PATH expansion
 internal/
   gui/                 Fyne GUI: app, dashboard, cards, repo panel, dialogs,
-                       keyboard handling, theme, refresh manager, system tray
+                       keyboard handling, theme, refresh manager, system tray,
+                       sysdeps dialog + banner, regent log window, OS-native
+                       save dialog helper
   ops/                 Shared business operations (refresh, worktree CRUD,
                        sandbox ops) — extracted from old TUI for reuse
   config/              Repo list persistence (~/.config/biomelab/repos.json)
-  git/                 Go-git v6 wrapper
+  git/                 Go-git v6 wrapper + EnsureExcluded helper
   agent/               Agent process detection
   ide/                 IDE process detection
   process/             Shared process enumeration
   provider/            PR/MR provider abstraction (GitHub, GitLab)
   sandbox/             Docker Sandbox (sbx) CLI wrapper
+  notes/               Per-worktree Markdown notes (.biomelab/note.md)
+  regent/              re_gent (rgt) integration: detect, init, hooks, log
+  sysdeps/             External CLI dependency checks (gh/glab/sbx/rgt)
   terminal/            Open new terminal window
   github/              GitHub-specific PR helpers
 ```
@@ -88,6 +94,17 @@ Always run `go test -race ./...`.
   prefix truncation (`truncatePath`), PR text uses suffix truncation.
 - **Card grid navigation** — up/down jump by column count, left/right by 1.
   Column count computed from `dashSlot.Size().Width / cardCellSize().Width`.
+- **`rgt init` ignores positional path args** — it always operates on `cwd`.
+  Use `cmd.Dir = wtPath`, not `rgt init <wtPath>`.
+- **rgt hook installer needs a TTY** — `--agent claude` doesn't skip the
+  prompt in a non-TTY environment. Biomelab writes `.claude/settings.json`
+  itself via `regent.EnsureClaudeHooks` (ported from rgt upstream, Apache-2.0).
+- **`widget.Accordion` misbehaves inside `VScroll`** — clicks don't toggle.
+  Use a `widget.Button` that flips the inner container's visibility instead;
+  see the regent log dialog's tools collapsible for the pattern.
+- **One regent log window at a time** — keyed by `App.regentLogWindow` plus
+  a `regentLogReload` closure. Different cards reuse the same window via
+  reload; don't spawn a new one per worktree.
 
 ## Release process
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 - **Open in terminal** -- Press `Enter` to open a worktree in a terminal. If a terminal is already detected for that worktree, it is brought to the foreground instead of opening a new one. On macOS, activation uses TTY matching via AppleScript (requires Automation permission on first use).
 - **Open in editor** -- Press `e` to open in `$BIOME_EDITOR` (defaults to VS Code).
 - **Task notes** -- Press `m` (or right-click a card) to open a Markdown editor with a live preview, scoped to that worktree. Notes are stored at `<worktree>/.biomelab/note.md` (description) and `<worktree>/.biomelab/pr-title.md` (single-line title), auto-excluded from git, and mounted into the sandbox alongside the source so agents can read them. When you `Shift+P` to send a PR, biomelab offers to use the prepared title and description in place of the commit-derived defaults. External tools that write to those two paths become contributors to the next PR.
+- **Agent audit trail** ([re_gent](https://github.com/regent-vcs/re_gent)) -- When `rgt` is installed, biomelab auto-initializes `.regent/` in every regular-mode worktree and writes Claude Code hooks into `.claude/settings.json` — no terminal step. Press `l` (or systray → Dependencies) to open the activity window: one resizable view per session with `Human` / `Agent` rows, collapsible tool lists (full file paths, no truncation), and an **Export JSON…** button that writes the raw `rgt log --json` via the OS-native save dialog.
+- **System dependencies dialog** -- Systray entry (`Dependencies: N/M ✓`) opens a modal listing every external CLI biomelab relies on (`gh`, `glab`, `sbx`, `rgt`) with status dot, version, install hint, and docs link. A first-run banner above the dashboard nags only when a primary tool is missing or degraded; redundant CLIs (e.g. `glab` when `gh` is fine) are suppressed.
 - **Zoom** -- `Ctrl+=` / `Ctrl+-` / `Ctrl+0` to scale the UI font.
 - **System tray** -- Closing the window hides to system tray. Tray menu toggles Show/Hide.
 - **Auto-refresh** -- Local state refreshes every 5s, network state every 30s (configurable).
@@ -126,6 +128,7 @@ Launch `biomelab` from any directory, or open `Biomelab.app` from Spotlight/Find
 | `Enter` | Activate existing terminal or open new | Any card |
 | `e` | Open in editor | Any card |
 | `m` | Open note editor (right-click also works) | Any card |
+| `l` | Open regent activity log | Any card |
 | `c` | Create worktree | Main card |
 | `f` | Fetch PR/MR | Main card |
 | `d` | Delete worktree / remove sandbox | Linked: delete; Main+sandbox: remove |
@@ -136,6 +139,9 @@ Launch `biomelab` from any directory, or open `Biomelab.app` from Spotlight/Find
 | `s` | Start stopped sandbox | Main card |
 | `Shift+S` | Stop running sandbox | Main card |
 | `k` | Pick kits → create (if missing) or recreate sandbox with `--kit` flags | Sandbox mode |
+| `g` | Toggle kanban / grid view | Global |
+| `Tab` | Toggle focus between panels | Global |
+| `Ctrl+T` | Toggle dark / light theme | Global |
 | `Ctrl+=` | Zoom in | Global |
 | `Ctrl+-` | Zoom out | Global |
 | `Ctrl+0` | Reset zoom | Global |

--- a/internal/git/exclude.go
+++ b/internal/git/exclude.go
@@ -1,0 +1,111 @@
+package git
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// excludeDirPerm and excludeFilePerm are the standard git info/exclude
+// file permissions (mirrors what `git worktree add` produces).
+const (
+	excludeDirPerm  = 0o755
+	excludeFilePerm = 0o644
+)
+
+// EnsureExcluded appends line to the worktree's info/exclude file if it
+// isn't already present. Idempotent. Used by sidecar packages (notes,
+// regent) to hide per-worktree directories from `git status`.
+//
+// Git reads info/exclude from the common gitdir for both the main worktree
+// and any linked worktrees — the per-worktree
+// .git/worktrees/<name>/info/exclude is created by `git worktree add` but
+// is not honored by `git status` (verified empirically). This function
+// resolves the right file in both cases:
+//
+//   - main worktree: .git is a directory → <wt>/.git/info/exclude
+//   - linked worktree: .git is a file with "gitdir: <wt-gitdir>" → read
+//     <wt-gitdir>/commondir to find the common gitdir, then
+//     <common-gitdir>/info/exclude.
+//
+// As a side effect, all worktrees of a repo share the same exclude file.
+// Patterns are anchored to the worktree root at match time (e.g.
+// "/.regent/"), so each worktree's own sidecar dir stays hidden.
+func EnsureExcluded(worktreeDir, line string) error {
+	excludePath, err := excludeFilePath(worktreeDir)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(excludePath), excludeDirPerm); err != nil {
+		return fmt.Errorf("create info dir: %w", err)
+	}
+	existing, err := os.ReadFile(excludePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read exclude: %w", err)
+	}
+	if hasExcludeLine(existing, line) {
+		return nil
+	}
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, excludeFilePerm)
+	if err != nil {
+		return fmt.Errorf("open exclude: %w", err)
+	}
+	var buf strings.Builder
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		buf.WriteString("\n")
+	}
+	buf.WriteString(line)
+	buf.WriteString("\n")
+	if _, werr := f.WriteString(buf.String()); werr != nil {
+		_ = f.Close()
+		return fmt.Errorf("write exclude: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		return fmt.Errorf("close exclude: %w", cerr)
+	}
+	return nil
+}
+
+func excludeFilePath(worktreeDir string) (string, error) {
+	gitPath := filepath.Join(worktreeDir, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", fmt.Errorf("stat .git: %w", err)
+	}
+	if info.IsDir() {
+		return filepath.Join(gitPath, "info", "exclude"), nil
+	}
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", fmt.Errorf("read .git: %w", err)
+	}
+	const prefix = "gitdir:"
+	line := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf(".git file missing %q prefix", prefix)
+	}
+	wtGitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+
+	commonDir := wtGitDir
+	if raw, rerr := os.ReadFile(filepath.Join(wtGitDir, "commondir")); rerr == nil {
+		cd := strings.TrimSpace(string(raw))
+		if !filepath.IsAbs(cd) {
+			cd = filepath.Join(wtGitDir, cd)
+		}
+		commonDir = filepath.Clean(cd)
+	}
+	return filepath.Join(commonDir, "info", "exclude"), nil
+}
+
+func hasExcludeLine(content []byte, line string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == line {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -18,8 +18,14 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	githttp "github.com/go-git/go-git/v6/plumbing/transport/http"
 	xworktree "github.com/go-git/go-git/v6/x/plumbing/worktree"
+)
 
-	"github.com/mdelapenya/biomelab/internal/notes"
+// biomelabDir is the per-worktree sidecar directory that biomelab uses
+// to store notes, PR drafts, and other transient state. Kept under the
+// worktree so it travels with the sandbox bind mount.
+const (
+	biomelabDir         = ".biomelab"
+	biomelabExcludeLine = "/.biomelab/"
 )
 
 // SyncStatus indicates whether a branch is up-to-date with its remote tracking branch.
@@ -991,10 +997,15 @@ func (r *Repository) HasStash() (bool, error) {
 }
 
 // ensureBiomelabDir ensures the .biomelab directory exists in the given
-// worktree path so external tools can write files without creating it themselves.
+// worktree path and that it's git-excluded. External tools (pr-scribe,
+// note editor) write files inside without needing to create the directory
+// themselves, and the entries never show up in `git status`.
 // Errors are silently ignored as this is a best-effort initialization.
 func (r *Repository) ensureBiomelabDir(wtPath string) error {
-	return notes.EnsureDir(wtPath)
+	if err := os.MkdirAll(filepath.Join(wtPath, biomelabDir), 0o755); err != nil {
+		return err
+	}
+	return EnsureExcluded(wtPath, biomelabExcludeLine)
 }
 
 // MigrateWorktreeDirs ensures .biomelab exists for all worktrees in the

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -1,14 +1,12 @@
 package gui
 
 import (
-	"net/url"
 	"time"
 
 	"fyne.io/fyne/v2"
 	fyneapp "fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/widget"
 
@@ -19,7 +17,9 @@ import (
 	"github.com/mdelapenya/biomelab/internal/ops"
 	"github.com/mdelapenya/biomelab/internal/process"
 	"github.com/mdelapenya/biomelab/internal/provider"
+	"github.com/mdelapenya/biomelab/internal/regent"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
+	"github.com/mdelapenya/biomelab/internal/sysdeps"
 	"github.com/mdelapenya/biomelab/internal/terminal"
 )
 
@@ -59,11 +59,6 @@ type App struct {
 	procLister      process.Lister
 	refreshInterval time.Duration
 
-	// warnSbxMissing is set during buildContent when at least one configured
-	// repo uses sandbox mode but the sbx CLI is not on PATH. Run() shows a
-	// one-shot informational dialog after the window appears.
-	warnSbxMissing bool
-
 	focus        focusPanel
 	dialogOpen   bool
 	activeDialog interface{ Hide() } // current dialog, for Escape dismissal
@@ -71,10 +66,22 @@ type App struct {
 	// the worktree path so a repeated 'm' or Review click raises the
 	// existing window instead of spawning duplicates.
 	noteWindows map[string]fyne.Window
+	// regentLogWindow is the single shared regent log window. Pressing
+	// 'l' on any card reuses this window (updating title + content via
+	// regentLogReload), so the user always has at most one open.
+	regentLogWindow fyne.Window
+	regentLogReload func(wt git.Worktree)
 	trayMenu    *fyne.Menu
 	// System tray theme submenu items, held so we can update Checked state.
 	trayThemeLight *fyne.MenuItem
 	trayThemeDark  *fyne.MenuItem
+	// trayDepsItem is the "Dependencies: N/M ✓" line; held so we can
+	// rewrite its label after re-probing.
+	trayDepsItem *fyne.MenuItem
+	// sysdepsCache memoizes Probe results for the dependencies dialog and
+	// systray summary. TTL is short enough to feel live; the dialog also
+	// exposes an explicit Re-check button that forces a refresh.
+	sysdepsCache *sysdeps.Cache
 }
 
 // NewApp creates a new biomelab Fyne application.
@@ -94,8 +101,14 @@ func NewApp(
 		procLister:      procLister,
 		refreshInterval: refreshInterval,
 		sbxStatuses:     make(map[string]sandbox.Status),
+		sysdepsCache:    sysdeps.NewCache(sysdepsCacheTTL),
 	}
 }
+
+// sysdepsCacheTTL bounds how long the dependencies cache memoizes probe
+// results. Short enough that "user just installed rgt" feels live; long
+// enough that opening the systray menu twice in a row doesn't re-exec.
+const sysdepsCacheTTL = 30 * time.Second
 
 // Run initializes the GUI and starts the event loop. Blocks until the window is closed.
 func (a *App) Run() {
@@ -132,27 +145,7 @@ func (a *App) Run() {
 	// SetCloseIntercept is set inside setupSystemTray.
 	a.setupSystemTray()
 
-	if a.warnSbxMissing {
-		// fyne.Do queues onto the UI thread; the queued work fires once
-		// ShowAndRun starts the event loop, so the dialog appears over the
-		// freshly painted window.
-		go fyne.Do(a.showSbxMissingDialog)
-	}
-
 	a.window.ShowAndRun()
-}
-
-func (a *App) showSbxMissingDialog() {
-	installURL, _ := url.Parse(sbxInstallURL)
-	content := container.NewVBox(
-		widget.NewLabel("One or more configured repositories use sandbox mode,"),
-		widget.NewLabel("but the sbx CLI was not found in PATH."),
-		widget.NewLabel("Sandbox actions will fail until you install it."),
-		widget.NewHyperlink("Install sbx", installURL),
-	)
-	d := dialog.NewCustom("Sandbox CLI Missing", "OK", content, a.window)
-	d.Resize(dialogMinSize)
-	d.Show()
 }
 
 func (a *App) buildContent() fyne.CanvasObject {
@@ -161,24 +154,14 @@ func (a *App) buildContent() fyne.CanvasObject {
 		return a.emptyState()
 	}
 
-	// Check sandbox statuses once up front.
+	// Check sandbox statuses once up front. When sbx isn't installed, the
+	// deps banner + dialog surface that — buildContent doesn't need to
+	// emit a separate warning here.
 	a.sbxStatuses = make(map[string]sandbox.Status)
 	if sandbox.Available() {
 		statusMap := sandbox.CheckAllStatuses()
 		for k, v := range statusMap {
 			a.sbxStatuses[k] = v
-		}
-	} else {
-		for _, entry := range cfg.Repos {
-			for _, m := range entry.Modes {
-				if m.Type == "sandbox" {
-					a.warnSbxMissing = true
-					break
-				}
-			}
-			if a.warnSbxMissing {
-				break
-			}
 		}
 	}
 
@@ -266,6 +249,16 @@ func (a *App) buildRepoEntry(entry config.RepoEntry) *repoEntry {
 
 	// Migrate existing worktrees to ensure .biomelab dir exists (background task).
 	go repo.MigrateWorktreeDirs()
+
+	// Bootstrap re_gent on existing worktrees too, but only when at least
+	// one of the repo's configured modes is non-sandbox. Sandbox-only repos
+	// install rgt inside the container (via the regent kit), not on the
+	// host. EnsureInit is itself a no-op when rgt is missing, so this is
+	// safe to schedule unconditionally — the mode gate just keeps us from
+	// creating empty .regent/ dirs for sandbox-only repos.
+	if hasNonSandboxMode(entry.Modes) {
+		go migrateRegentForRepo(repo)
+	}
 
 	rm.OnRefresh = func(result ops.RefreshResult) {
 		fyne.Do(func() {
@@ -427,7 +420,16 @@ func (a *App) buildMainLayout() fyne.CanvasObject {
 	split := container.NewHSplit(a.repoPanel.Content(), a.dashSlot)
 	split.Offset = 0.18
 
-	return container.NewBorder(titleBar, nil, nil, nil, split)
+	// First-run banner: shown above the split when one or more primary
+	// dependencies are missing or degraded. Click → opens the dialog.
+	// buildDepsBanner returns nil when everything is OK, in which case
+	// we omit the row entirely.
+	top := fyne.CanvasObject(titleBar)
+	if banner := a.buildDepsBanner(); banner != nil {
+		top = container.NewVBox(titleBar, banner)
+	}
+
+	return container.NewBorder(top, nil, nil, nil, split)
 }
 
 func (a *App) switchMode(groupIdx, modeIdx int) {
@@ -482,6 +484,34 @@ func (a *App) loadInitialVariant() ThemeVariant {
 		return VariantLight
 	}
 	return VariantDark
+}
+
+// hasNonSandboxMode returns true when any mode in the list is not "sandbox".
+// Used to gate host-side regent bootstrap: a sandbox-only repo has rgt
+// installed inside the container (via the regent kit), so the host has no
+// business creating .regent/ for it.
+func hasNonSandboxMode(modes []config.ModeEntry) bool {
+	for _, m := range modes {
+		if m.Type != "sandbox" {
+			return true
+		}
+	}
+	return false
+}
+
+// migrateRegentForRepo lists the repo's worktrees and runs regent.EnsureInit
+// on each. Safe to call when rgt isn't installed (EnsureInit no-ops).
+// Runs as a background goroutine — no return value, errors are best-effort.
+func migrateRegentForRepo(repo *git.Repository) {
+	wts, err := repo.ListWorktrees()
+	if err != nil {
+		return
+	}
+	paths := make([]string, 0, len(wts))
+	for _, wt := range wts {
+		paths = append(paths, wt.Path)
+	}
+	regent.MigrateAll(paths)
 }
 
 // toggleTheme flips the theme variant. Used by the Ctrl+T shortcut.

--- a/internal/gui/dashboard.go
+++ b/internal/gui/dashboard.go
@@ -373,7 +373,7 @@ func (d *Dashboard) helpBar() fyne.CanvasObject {
 	if d.state.ViewMode == ViewKanban {
 		viewHint = "[g] grid"
 	}
-	help := monoText("↑↓ nav  [Tab] panel  [⏎] open  [e] editor  [m] note  [r] refresh  [d] delete  [p] pull  [P] PR  "+viewHint, colorDimGray, false)
+	help := monoText("↑↓ nav  [Tab] panel  [⏎] open  [e] editor  [m] note  [l] log  [r] refresh  [d] delete  [p] pull  [P] PR  "+viewHint, colorDimGray, false)
 	help.TextSize = scaledSize(9)
 
 	return container.NewStack(bg, container.NewPadded(help))

--- a/internal/gui/regent_log_dialog.go
+++ b/internal/gui/regent_log_dialog.go
@@ -1,0 +1,320 @@
+package gui
+
+import (
+	"fmt"
+	"image/color"
+	"os/exec"
+	"sort"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/mdelapenya/biomelab/internal/git"
+	"github.com/mdelapenya/biomelab/internal/regent"
+)
+
+// regentLogWindowInitialSize is wide enough for typical prompts and full
+// file paths inside tool args; the window is user-resizable.
+var regentLogWindowInitialSize = fyne.NewSize(900, 640)
+
+// regentLogLimit caps how many recent steps the window fetches. Matches
+// rgt's own default; we surface a Refresh button rather than paging.
+const regentLogLimit = 50
+
+// showRegentLogModal opens (or reuses) a single top-level window showing
+// `rgt log` for the given worktree. Subsequent presses of 'l' — same or
+// different card — repopulate this same window rather than spawning new
+// ones, so the user always has at most one regent log window open.
+//
+// Implementation: App keeps a single window handle plus a closure that
+// re-renders content for a different worktree. When the window is closed,
+// both are cleared so the next 'l' press creates a fresh one.
+func (a *App) showRegentLogModal(wt git.Worktree) {
+	if a.regentLogWindow != nil && a.regentLogReload != nil {
+		a.regentLogReload(wt)
+		a.regentLogWindow.RequestFocus()
+		return
+	}
+
+	w := a.fyneApp.NewWindow("Regent activity — " + wt.Branch)
+	a.regentLogWindow = w
+
+	body := container.NewVBox()
+	scroll := container.NewVScroll(body)
+
+	current := wt
+	render := func(target git.Worktree) {
+		current = target
+		w.SetTitle("Regent activity — " + target.Branch)
+		body.Objects = a.buildRegentLogContent(target)
+		body.Refresh()
+	}
+	render(wt)
+
+	refresh := widget.NewButton("Refresh", func() { render(current) })
+	refresh.Importance = widget.HighImportance
+	exportBtn := widget.NewButton("Export JSON…", func() {
+		a.exportRegentLog(current, w)
+	})
+	closeBtn := widget.NewButton("Close", func() { w.Close() })
+	footer := container.NewBorder(nil, nil,
+		container.NewHBox(refresh, exportBtn),
+		closeBtn,
+	)
+
+	w.SetContent(container.NewBorder(nil, footer, nil, nil, scroll))
+	w.Resize(regentLogWindowInitialSize)
+	w.CenterOnScreen()
+
+	a.regentLogReload = render
+	w.SetOnClosed(func() {
+		a.regentLogWindow = nil
+		a.regentLogReload = nil
+	})
+
+	w.Show()
+	w.RequestFocus()
+}
+
+// buildRegentLogContent returns the rendered children for the scrollable
+// body: a session header followed by a step row per Step. Handles all
+// "no data" states (rgt missing, no .regent/, no activity) with a
+// friendly inline message.
+func (a *App) buildRegentLogContent(wt git.Worktree) []fyne.CanvasObject {
+	if _, err := exec.LookPath("rgt"); err != nil {
+		// OS-agnostic message — install hints live in the deps dialog.
+		return []fyne.CanvasObject{
+			monoText("re_gent (rgt) is not installed.", colorYellow, true),
+			monoText("See install instructions: https://github.com/regent-vcs/re_gent", colorDimGray, false),
+			monoText("Or open the Dependencies dialog from the system tray.", colorDimGray, false),
+		}
+	}
+
+	sessionID, steps, err := regent.LogJSON(wt.Path, regentLogLimit)
+	if err != nil {
+		return []fyne.CanvasObject{
+			monoText("rgt log failed:", colorRed, true),
+			monoText(err.Error(), colorRed, false),
+		}
+	}
+	if len(steps) == 0 {
+		return []fyne.CanvasObject{
+			monoText("No regent activity yet.", colorGray, true),
+			monoText("Run an agent in this worktree and the log will populate here.", colorDimGray, false),
+		}
+	}
+
+	items := make([]fyne.CanvasObject, 0, len(steps)+1)
+	header := monoText(fmt.Sprintf("Session %s · %d steps", sessionID, len(steps)), colorBranch, true)
+	header.TextSize = scaledSize(11)
+	items = append(items, header)
+	items = append(items, widget.NewSeparator())
+
+	for i, s := range steps {
+		if i > 0 {
+			items = append(items, widget.NewSeparator())
+		}
+		items = append(items, buildRegentStepRow(s))
+	}
+	return items
+}
+
+// buildRegentStepRow renders one Step as a stacked block: header line
+// (sha · timestamp · origin), Human prompt, Agent reply, and a
+// "[▶ N tools]" toggle button that reveals the tool list when clicked.
+// The toggle is a button (not widget.Accordion, which misbehaves inside
+// VScroll) — same proven pattern other surfaces in biomelab use.
+func buildRegentStepRow(s Step) fyne.CanvasObject {
+	rows := []fyne.CanvasObject{}
+
+	// Header: short sha · timestamp · origin.
+	headerText := fmt.Sprintf("● %s · %s", s.ShortHash(), s.Timestamp.Format("2006-01-02 15:04:05"))
+	if s.Origin != "" {
+		headerText += " · " + s.Origin
+	}
+	header := monoText(headerText, colorBranch, true)
+	header.TextSize = scaledSize(11)
+	rows = append(rows, header)
+
+	if s.HumanPrompt != "" {
+		rows = append(rows, roleLine("Human", s.HumanPrompt, colorBlue))
+	}
+	if s.AgentReply != "" {
+		rows = append(rows, roleLine("Agent", s.AgentReply, colorGreen))
+	}
+
+	if len(s.Tools) > 0 {
+		rows = append(rows, buildToolsCollapsible(s.Tools))
+	}
+
+	return container.NewVBox(rows...)
+}
+
+// roleLine renders a "Role: message" pair with the role bolded in its
+// signature color and the message body underneath in word-wrapped Label
+// form (so long prompts stay readable inside the window's width).
+func roleLine(role, body string, c color.Color) fyne.CanvasObject {
+	roleText := monoText(role+":", c, true)
+	roleText.TextSize = scaledSize(11)
+
+	msg := widget.NewLabel(body)
+	msg.Wrapping = fyne.TextWrapWord
+	return container.NewVBox(roleText, msg)
+}
+
+// buildToolsCollapsible renders a toggle button that expands/collapses
+// the tools list under it. The list shows one row per tool with the
+// tool name and its most important arg (file_path / command / query),
+// then a key=value dump of any remaining args — all with full paths,
+// no truncation.
+func buildToolsCollapsible(tools []ToolCall) fyne.CanvasObject {
+	count := len(tools)
+	plural := "tool"
+	if count != 1 {
+		plural = "tools"
+	}
+
+	list := container.NewVBox()
+	for _, t := range tools {
+		list.Add(buildToolRow(t))
+	}
+	list.Hide()
+
+	var toggle *widget.Button
+	expanded := false
+	toggle = widget.NewButton(fmt.Sprintf("▶ %d %s", count, plural), func() {
+		expanded = !expanded
+		if expanded {
+			toggle.SetText(fmt.Sprintf("▼ %d %s", count, plural))
+			list.Show()
+		} else {
+			toggle.SetText(fmt.Sprintf("▶ %d %s", count, plural))
+			list.Hide()
+		}
+	})
+	toggle.Alignment = widget.ButtonAlignLeading
+
+	return container.NewVBox(toggle, list)
+}
+
+// buildToolRow renders one tool invocation: name in bold, primary arg
+// inline next to it, secondary args one-per-line beneath.
+func buildToolRow(t ToolCall) fyne.CanvasObject {
+	primaryKey, primaryValue := pickPrimaryArg(t)
+
+	head := monoText("└─ "+t.Name, colorPurple, true)
+	head.TextSize = scaledSize(11)
+	rows := []fyne.CanvasObject{}
+	if primaryKey != "" {
+		line := monoText(fmt.Sprintf("   %s: %s", primaryKey, primaryValue), colorDimGray, false)
+		line.TextSize = scaledSize(10)
+		rows = append(rows, container.NewVBox(head, line))
+	} else {
+		rows = append(rows, head)
+	}
+
+	// Secondary args (anything other than the primary key) on extra
+	// lines, sorted for stable rendering.
+	keys := make([]string, 0, len(t.Args))
+	for k := range t.Args {
+		if k == primaryKey {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		line := monoText(fmt.Sprintf("   %s: %s", k, formatArgValue(t.Args[k])), colorDimGray, false)
+		line.TextSize = scaledSize(10)
+		rows = append(rows, line)
+	}
+	return container.NewVBox(rows...)
+}
+
+// pickPrimaryArg chooses the most informative arg for a tool's primary
+// display line: file_path for file ops, command for Bash, query for
+// search-like tools. Falls back to "" so the caller can render just the
+// tool name.
+func pickPrimaryArg(t ToolCall) (string, string) {
+	priority := []string{"file_path", "path", "command", "query", "url", "pattern", "prompt"}
+	for _, k := range priority {
+		if v, ok := t.Args[k]; ok {
+			return k, formatArgValue(v)
+		}
+	}
+	return "", ""
+}
+
+// formatArgValue renders an arg value as a single line. Strings pass
+// through; everything else gets a short %v form. Newlines collapse to a
+// single space so the line stays a line.
+func formatArgValue(v any) string {
+	s := fmt.Sprintf("%v", v)
+	// Collapse newlines so multi-line args (commands, content blocks)
+	// stay on one line in the row view. Users wanting full content can
+	// click through to `rgt show <hash>` later.
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r == '\n' || r == '\r' {
+			out = append(out, ' ')
+			continue
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+// Step / ToolCall aliases so this file doesn't have to import the regent
+// package's types inline at every signature. These mirror the public
+// types one-to-one.
+type (
+	Step     = regent.Step
+	ToolCall = regent.ToolCall
+)
+
+// exportRegentLog runs `rgt log --json` once more and writes the raw
+// bytes to a user-chosen file. Errors surface via the dashboard's status
+// line and dialog.ShowError so failures aren't silent. Empty results
+// (no .regent/, no rgt) short-circuit with an informational dialog —
+// there's nothing useful to write.
+func (a *App) exportRegentLog(wt git.Worktree, parent fyne.Window) {
+	data, err := regent.LogJSONRaw(wt.Path, regentLogLimit)
+	if err != nil {
+		dialog.ShowError(err, parent)
+		return
+	}
+	if len(data) == 0 {
+		dialog.ShowInformation("No data", "There is no regent activity to export for this worktree.", parent)
+		return
+	}
+
+	defaultName := fmt.Sprintf("regent-log-%s-%s.json",
+		sanitizeFilename(wt.Branch),
+		time.Now().Format("20060102-150405"),
+	)
+
+	a.saveBytesNative(parent, defaultName, data)
+}
+
+// sanitizeFilename strips characters that are awkward in filenames
+// (slashes, spaces) so a branch like "feat/new-thing" doesn't try to
+// create nested directories on save.
+func sanitizeFilename(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		switch r {
+		case '/', '\\', ' ', ':', '*', '?', '"', '<', '>', '|':
+			out = append(out, '-')
+		default:
+			out = append(out, r)
+		}
+	}
+	if len(out) == 0 {
+		return "branch"
+	}
+	return string(out)
+}
+

--- a/internal/gui/save_file.go
+++ b/internal/gui/save_file.go
@@ -1,0 +1,161 @@
+package gui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/storage"
+)
+
+// saveBytesNative prompts the user to pick a save location using the
+// OS-native dialog (NSSavePanel via osascript on macOS, zenity / kdialog
+// on Linux, PowerShell SaveFileDialog on Windows) and writes data there.
+// Falls back to Fyne's dialog.NewFileSave when no native tool is
+// available — that keeps the feature working on minimal Linux setups
+// and on unsupported platforms.
+//
+// The default file extension comes from defaultName's suffix and is also
+// applied to the Fyne fallback's filter so the dialog UX is consistent.
+// User cancellation in either path is silent (no error popup).
+func (a *App) saveBytesNative(parent fyne.Window, defaultName string, data []byte) {
+	path, err := nativeSaveDialog(defaultName)
+	if err == nil {
+		// Native succeeded (or user cancelled — path == "" in that case).
+		if path == "" {
+			return
+		}
+		if werr := os.WriteFile(path, data, 0o644); werr != nil {
+			dialog.ShowError(werr, parent)
+		}
+		return
+	}
+	// No native tool available — fall back to Fyne's bundled dialog.
+	a.saveBytesFyne(parent, defaultName, data)
+}
+
+// nativeSaveDialog dispatches to the per-OS helper. Returns ("", nil) on
+// user cancellation; a non-nil error means no native tool was usable and
+// the caller should fall back. Per-OS helpers swallow user cancellation
+// internally so callers don't have to inspect the underlying tool's
+// exit code.
+func nativeSaveDialog(defaultName string) (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return nativeSaveDarwin(defaultName)
+	case "linux":
+		return nativeSaveLinux(defaultName)
+	case "windows":
+		return nativeSaveWindows(defaultName)
+	default:
+		return "", fmt.Errorf("no native save dialog for %s", runtime.GOOS)
+	}
+}
+
+// nativeSaveDarwin invokes NSSavePanel via osascript. The AppleScript
+// "choose file name" coercion to POSIX path returns an empty stdout on
+// cancellation (osascript exits non-zero in that case), so we treat any
+// non-zero exit as cancellation.
+func nativeSaveDarwin(defaultName string) (string, error) {
+	bin, err := exec.LookPath("osascript")
+	if err != nil {
+		return "", err
+	}
+	// AppleScript treats backslash and double-quote as escape characters
+	// inside string literals. Escape both so unusual branch names don't
+	// break the script.
+	safe := strings.ReplaceAll(defaultName, `\`, `\\`)
+	safe = strings.ReplaceAll(safe, `"`, `\"`)
+	script := fmt.Sprintf(`POSIX path of (choose file name with prompt "Save file" default name "%s")`, safe)
+	out, runErr := exec.Command(bin, "-e", script).Output()
+	if runErr != nil {
+		// User cancelled; no error to surface.
+		return "", nil
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// nativeSaveLinux tries zenity first, then kdialog. Either's exit-1
+// (cancel) is treated as cancellation. Returns a non-nil error only
+// when neither tool is on PATH so the caller can fall back.
+func nativeSaveLinux(defaultName string) (string, error) {
+	if bin, err := exec.LookPath("zenity"); err == nil {
+		out, runErr := exec.Command(bin, "--file-selection", "--save", "--confirm-overwrite", "--filename", defaultName).Output()
+		if runErr != nil {
+			return "", nil
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+	if bin, err := exec.LookPath("kdialog"); err == nil {
+		out, runErr := exec.Command(bin, "--getsavefilename", defaultName).Output()
+		if runErr != nil {
+			return "", nil
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+	return "", fmt.Errorf("no native save dialog (install zenity or kdialog)")
+}
+
+// nativeSaveWindows uses System.Windows.Forms.SaveFileDialog via
+// PowerShell. ShowDialog returns OK / Cancel; we emit the chosen path
+// only on OK so an empty stdout cleanly signals cancellation.
+func nativeSaveWindows(defaultName string) (string, error) {
+	bin, err := exec.LookPath("powershell")
+	if err != nil {
+		return "", err
+	}
+	// Single-quote string literals in PowerShell: '' escapes a literal '.
+	safe := strings.ReplaceAll(defaultName, `'`, `''`)
+	script := fmt.Sprintf(`Add-Type -AssemblyName System.Windows.Forms;
+$dlg = New-Object System.Windows.Forms.SaveFileDialog;
+$dlg.FileName = '%s';
+if ($dlg.ShowDialog() -eq 'OK') { Write-Output $dlg.FileName }`, safe)
+	out, runErr := exec.Command(bin, "-NoProfile", "-Command", script).Output()
+	if runErr != nil {
+		return "", nil
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// saveBytesFyne is the cross-platform fallback used when no native save
+// dialog is reachable. Same widget that powered the export flow before
+// the native helper landed — kept here so callers don't have to.
+func (a *App) saveBytesFyne(parent fyne.Window, defaultName string, data []byte) {
+	save := dialog.NewFileSave(func(writer fyne.URIWriteCloser, ferr error) {
+		if ferr != nil {
+			dialog.ShowError(ferr, parent)
+			return
+		}
+		if writer == nil {
+			return // user cancelled
+		}
+		if _, werr := writer.Write(data); werr != nil {
+			_ = writer.Close()
+			dialog.ShowError(werr, parent)
+			return
+		}
+		if cerr := writer.Close(); cerr != nil {
+			dialog.ShowError(cerr, parent)
+		}
+	}, parent)
+	save.SetFileName(defaultName)
+	if ext := extOf(defaultName); ext != "" {
+		save.SetFilter(storage.NewExtensionFileFilter([]string{ext}))
+	}
+	save.Show()
+}
+
+// extOf returns the .ext suffix of name (with the leading dot), or ""
+// when name has no extension. Used to seed the Fyne file filter so the
+// fallback dialog shows the right file kind.
+func extOf(name string) string {
+	i := strings.LastIndexByte(name, '.')
+	if i < 0 || i == len(name)-1 {
+		return ""
+	}
+	return name[i:]
+}

--- a/internal/gui/shortcuts.go
+++ b/internal/gui/shortcuts.go
@@ -119,6 +119,8 @@ func (a *App) handleKeyName(key fyne.KeyName) {
 		a.handleInstallKits()
 	case fyne.KeyM:
 		a.handleEditNote()
+	case fyne.KeyL:
+		a.handleRegentLog()
 	}
 }
 
@@ -661,6 +663,22 @@ func (a *App) handlePull() {
 			a.refreshMgr.TriggerLocal()
 		})
 	}()
+}
+
+// handleRegentLog opens the regent log modal for the currently selected
+// worktree. A no-op when no card is selected — the modal would be empty
+// of context. Bound to the 'l' shortcut so users can reach the log without
+// hunting for the pill on the card.
+func (a *App) handleRegentLog() {
+	re := a.activeRepo()
+	if re == nil {
+		return
+	}
+	idx, ok := a.selectedWorktree()
+	if !ok {
+		return
+	}
+	a.showRegentLogModal(re.state.Worktrees[idx])
 }
 
 func (a *App) handleEditNote() {

--- a/internal/gui/sysdeps_dialog.go
+++ b/internal/gui/sysdeps_dialog.go
@@ -1,0 +1,295 @@
+package gui
+
+import (
+	"image/color"
+	"net/url"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/mdelapenya/biomelab/internal/config"
+	"github.com/mdelapenya/biomelab/internal/sysdeps"
+)
+
+// sysDepsDialogSize is the preferred initial size for the dependencies modal.
+// Wider so action buttons sit comfortably to the right of long version
+// strings; tall enough to render every primary check plus the optional
+// section without the inner VScroll having to engage.
+var sysDepsDialogSize = fyne.NewSize(760, 600)
+
+// showSysDepsDialog opens the System Dependencies modal, listing each Check
+// with a status dot, version, action buttons, and an "Optional tools"
+// expander for opt-in tools that aren't installed.
+func (a *App) showSysDepsDialog() dialog.Dialog {
+	cfg := a.loadConfigForSysDeps()
+
+	var d *dialog.CustomDialog
+	body := container.NewVBox()
+
+	visible := func() []sysdeps.Reported {
+		raw := a.sysdepsCache.Get(cfg)
+		return sysdeps.ApplyVisibility(sysdeps.ApplySuppression(raw), cfg)
+	}
+
+	rebuild := func() {
+		a.sysdepsCache.Invalidate()
+		body.Objects = []fyne.CanvasObject{a.buildSysDepsContent(visible())}
+		body.Refresh()
+		// Keep the systray summary line in sync after a manual re-probe.
+		a.refreshSysdepsTray()
+	}
+
+	body.Objects = []fyne.CanvasObject{a.buildSysDepsContent(visible())}
+
+	recheck := widget.NewButton("Re-check", rebuild)
+	recheck.Importance = widget.HighImportance
+	footer := container.NewBorder(nil, nil, recheck, nil)
+
+	// No keyCap overlay here: dialog.NewCustom already dismisses on Escape
+	// via its own dismiss button, and a transparent Stack overlay would sit
+	// on top of the Copy/Docs/Re-check buttons and starve them of hover
+	// feedback. Buttons inside the content need a clear path to the cursor.
+	content := container.NewBorder(nil, footer, nil, nil, container.NewVScroll(body))
+
+	d = dialog.NewCustom("System Dependencies", "Close", content, a.window)
+	d.Resize(sysDepsDialogSize)
+	d.Show()
+	return d
+}
+
+// loadConfigForSysDeps loads the on-disk config so the cache can decide which
+// checks Apply (sbx/docker hide when no sandbox-mode repo is configured).
+// Errors are swallowed: a nil-but-present config still drives sane defaults.
+func (a *App) loadConfigForSysDeps() *config.Config {
+	cfg, err := config.Load(a.configPath)
+	if err != nil || cfg == nil {
+		return &config.Config{}
+	}
+	return cfg
+}
+
+// buildSysDepsContent assembles the dialog body from a probed Reported list:
+// primary checks first, then a collapsed "Optional tools" accordion when
+// there are missing optional tools.
+func (a *App) buildSysDepsContent(reps []sysdeps.Reported) fyne.CanvasObject {
+	primary, optional := sysdeps.Partition(reps)
+
+	items := make([]fyne.CanvasObject, 0, len(primary)*2+4)
+	for i, r := range primary {
+		if i > 0 {
+			items = append(items, widget.NewSeparator())
+		}
+		items = append(items, a.buildSysDepsRow(r))
+	}
+
+	if len(optional) > 0 {
+		items = append(items, widget.NewSeparator())
+		heading := monoText("Optional tools", colorGray, true)
+		heading.TextSize = scaledSize(11)
+		items = append(items, heading)
+		for i, r := range optional {
+			if i > 0 {
+				items = append(items, widget.NewSeparator())
+			}
+			items = append(items, a.buildSysDepsRow(r))
+		}
+	}
+
+	return container.NewVBox(items...)
+}
+
+// buildSysDepsRow renders one check as a stacked block:
+//
+//	● re_gent                                      [Copy install cmd] [Docs]
+//	    re_gent version dev (commit: unknown)              (smaller)
+//	    Surface AI agent audit trails on worktree cards.   (smaller, dim)
+//
+// The version sits on its own line at name-size minus two so a long version
+// string never crowds the action buttons. Reason/Note is one step smaller
+// still and dimmer. Both indent slightly so they read as belonging to the
+// name above them.
+func (a *App) buildSysDepsRow(r sysdeps.Reported) fyne.CanvasObject {
+	dot := monoText(statusDot(r.Result.Status), statusColor(r.Result.Status), true)
+	dot.TextSize = scaledSize(14)
+
+	name := monoText(r.Check.DisplayName, colorForeground, true)
+
+	header := container.NewHBox(dot, name)
+	actions := a.buildSysDepsActions(r)
+	top := container.NewBorder(nil, nil, header, actions)
+
+	rows := []fyne.CanvasObject{top}
+
+	if metaStr := rowMetaText(r); metaStr != "" {
+		metaColor := colorDimGray
+		if r.Result.Status == sysdeps.StatusOK {
+			metaColor = colorGray
+		}
+		meta := monoText(metaStr, metaColor, false)
+		meta.TextSize = scaledSize(12)
+		rows = append(rows, indented(meta))
+	}
+
+	noteStr := r.Result.Note
+	if noteStr == "" {
+		noteStr = r.Check.Reason
+	}
+	if noteStr != "" {
+		note := monoText(noteStr, colorGray, false)
+		note.TextSize = scaledSize(11)
+		rows = append(rows, indented(note))
+	}
+
+	return container.NewVBox(rows...)
+}
+
+// indented returns o wrapped with a left gutter so secondary row lines
+// (version, reason) read as belonging to the name above them. The gutter
+// width roughly matches the dot+space prefix on the header line.
+func indented(o fyne.CanvasObject) fyne.CanvasObject {
+	spacer := canvas.NewRectangle(color.Transparent)
+	spacer.SetMinSize(fyne.NewSize(scaledSize(18), 0))
+	return container.NewBorder(nil, nil, spacer, nil, o)
+}
+
+// rowMetaText picks the right hint to display after the tool name. Version
+// wins when known; otherwise we fall back to a short status word so the row
+// is informative even for tools that don't ship a version probe.
+func rowMetaText(r sysdeps.Reported) string {
+	if r.Result.Version != "" {
+		return r.Result.Version
+	}
+	switch r.Result.Status {
+	case sysdeps.StatusMissing:
+		return "not installed"
+	case sysdeps.StatusNA:
+		return "n/a"
+	case sysdeps.StatusDegraded:
+		return "needs attention"
+	default:
+		return ""
+	}
+}
+
+// buildSysDepsActions renders the per-row affordances: a "Copy" button for
+// the install hint and a "Docs" hyperlink. Returns an empty container when
+// neither applies so the row layout stays consistent.
+func (a *App) buildSysDepsActions(r sysdeps.Reported) fyne.CanvasObject {
+	var btns []fyne.CanvasObject
+
+	wantsCopy := r.Check.InstallHint != "" &&
+		(r.Result.Status == sysdeps.StatusMissing || r.Result.Status == sysdeps.StatusDegraded)
+	if wantsCopy {
+		hint := r.Check.InstallHint
+		copyBtn := widget.NewButton("Copy install cmd", func() {
+			if a.fyneApp != nil && a.fyneApp.Clipboard() != nil {
+				a.fyneApp.Clipboard().SetContent(hint)
+			}
+		})
+		btns = append(btns, copyBtn)
+	}
+
+	if r.Check.DocsURL != "" {
+		if u, err := url.Parse(r.Check.DocsURL); err == nil {
+			btns = append(btns, widget.NewHyperlink("Docs", u))
+		}
+	}
+
+	if len(btns) == 0 {
+		return container.NewHBox()
+	}
+	return container.NewHBox(btns...)
+}
+
+// statusDot returns the glyph for a given status, mapping to the dot palette
+// used elsewhere in the GUI (● filled, ◐ half, ○ outline, – em-dash for N/A).
+func statusDot(s sysdeps.Status) string {
+	switch s {
+	case sysdeps.StatusOK:
+		return "●"
+	case sysdeps.StatusDegraded:
+		return "◐"
+	case sysdeps.StatusMissing:
+		return "○"
+	case sysdeps.StatusNA:
+		return "–"
+	default:
+		return "?"
+	}
+}
+
+// statusColor returns the palette color for a given status. Kept in sync
+// with the rest of the GUI: green=ok, yellow=degraded, red=missing,
+// dimGray=n/a.
+func statusColor(s sysdeps.Status) color.Color {
+	switch s {
+	case sysdeps.StatusOK:
+		return colorGreen
+	case sysdeps.StatusDegraded:
+		return colorYellow
+	case sysdeps.StatusMissing:
+		return colorRed
+	case sysdeps.StatusNA:
+		return colorDimGray
+	default:
+		return colorGray
+	}
+}
+
+// buildDepsBanner returns a clickable banner shown above the main layout
+// when one or more primary dependencies are missing or degraded. Returns
+// nil when everything is ready — in that case the layout omits the banner
+// row entirely. Optional tools never trigger the banner; they live in the
+// dialog's expander.
+func (a *App) buildDepsBanner() fyne.CanvasObject {
+	cfg := a.loadConfigForSysDeps()
+	reps := sysdeps.ApplyVisibility(
+		sysdeps.ApplySuppression(a.sysdepsCache.Get(cfg)),
+		cfg,
+	)
+	primary, _ := sysdeps.Partition(reps)
+
+	c := sysdeps.Summarize(primary)
+	if c.Missing == 0 && c.Degraded == 0 {
+		return nil
+	}
+
+	var bits []string
+	if s := namesByStatus(primary, sysdeps.StatusMissing, "Missing"); s != "" {
+		bits = append(bits, s)
+	}
+	if s := namesByStatus(primary, sysdeps.StatusDegraded, "Needs attention"); s != "" {
+		bits = append(bits, s)
+	}
+	msg := "⚠ " + strings.Join(bits, "; ") + " — some biomelab features will be limited."
+
+	text := monoText(msg, colorYellow, false)
+	text.TextSize = scaledSize(11)
+
+	open := widget.NewButton("Open Dependencies", func() {
+		a.showSysDepsDialog()
+	})
+
+	row := container.NewBorder(nil, nil, nil, open, container.NewPadded(text))
+	return container.NewPadded(row)
+}
+
+// namesByStatus returns "<label>: a, b, c" for entries whose status matches
+// want. Empty string when no entries match — caller uses that to skip the
+// segment in the banner.
+func namesByStatus(reps []sysdeps.Reported, want sysdeps.Status, label string) string {
+	var names []string
+	for _, r := range reps {
+		if r.Result.Status == want {
+			names = append(names, r.Check.Name)
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	return label + ": " + strings.Join(names, ", ")
+}

--- a/internal/gui/systray.go
+++ b/internal/gui/systray.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -12,6 +13,7 @@ import (
 	"fyne.io/fyne/v2/driver/desktop"
 
 	"github.com/mdelapenya/biomelab/internal/config"
+	"github.com/mdelapenya/biomelab/internal/sysdeps"
 )
 
 // setupSystemTray creates a system tray icon with Show/Hide toggle, Theme
@@ -58,12 +60,17 @@ func (a *App) setupSystemTray() {
 		}
 	})
 
+	a.trayDepsItem = fyne.NewMenuItem(a.sysdepsSummaryLabel(), func() {
+		a.showSysDepsDialog()
+	})
+
 	a.trayMenu = fyne.NewMenu("biomelab",
 		toggleItem,
 		fyne.NewMenuItemSeparator(),
 		themeItem,
 		configItem,
 		sbxDocsItem,
+		a.trayDepsItem,
 		fyne.NewMenuItemSeparator(),
 		fyne.NewMenuItem("Quit", func() {
 			a.stopAllRefresh()
@@ -105,6 +112,44 @@ func openInSystem(path string) error {
 		cmd = exec.Command("xdg-open", path)
 	}
 	return cmd.Start()
+}
+
+// sysdepsSummaryLabel returns the systray label like "Dependencies: 3/4 ✓"
+// or "Dependencies: 1 missing" when something is wrong. Builds from a fresh
+// cache read so the count reflects the latest probe (the cache itself
+// memoizes for sysdepsCacheTTL, so this is cheap to call on menu refresh).
+func (a *App) sysdepsSummaryLabel() string {
+	cfg := a.loadConfigForSysDeps()
+	reps := sysdeps.ApplyVisibility(
+		sysdeps.ApplySuppression(a.sysdepsCache.Get(cfg)),
+		cfg,
+	)
+	primary, _ := sysdeps.Partition(reps)
+	c := sysdeps.Summarize(primary)
+	total := c.Total()
+	if total == 0 {
+		return "Dependencies"
+	}
+	if c.Missing == 0 && c.Degraded == 0 {
+		return fmt.Sprintf("Dependencies: %d/%d ✓", c.OK, total)
+	}
+	missing := c.Missing + c.Degraded
+	return fmt.Sprintf("Dependencies: %d/%d (%d need attention)", c.OK, total, missing)
+}
+
+// refreshSysdepsTray re-probes the dependency cache and updates the systray
+// label and menu. Call after actions that could change the dep state
+// (e.g. dialog Re-check, future install actions).
+func (a *App) refreshSysdepsTray() {
+	if a.trayDepsItem == nil {
+		return
+	}
+	a.sysdepsCache.Invalidate()
+	a.trayDepsItem.Label = a.sysdepsSummaryLabel()
+	desk, ok := a.fyneApp.(desktop.App)
+	if ok && a.trayMenu != nil {
+		desk.SetSystemTrayMenu(a.trayMenu)
+	}
 }
 
 func (a *App) stopAllRefresh() {

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -8,12 +8,13 @@
 package notes
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/mdelapenya/biomelab/internal/git"
 )
 
 const (
@@ -166,94 +167,9 @@ func Delete(worktreeDir string) error {
 	return err
 }
 
-// excludeFilePath resolves the path to the info/exclude file git actually
-// consults for this worktree. Git reads info/exclude from the COMMON gitdir
-// for both the main worktree and any linked worktrees — the per-worktree
-// .git/worktrees/<name>/info/exclude is created by `git worktree add` but
-// is not honored by `git status` (verified empirically). So:
-//
-//   - main worktree: .git is a directory → exclude at .git/info/exclude
-//   - linked worktree: .git is a file with "gitdir: <wt-gitdir>" → read
-//     <wt-gitdir>/commondir to find the common gitdir, exclude at
-//     <common-gitdir>/info/exclude.
-//
-// As a side effect, all worktrees of a repo share the same exclude line.
-// That's fine: the pattern "/.biomelab/" is anchored to the worktree root
-// at match time, so each worktree's own .biomelab/ stays hidden.
-func excludeFilePath(worktreeDir string) (string, error) {
-	gitPath := filepath.Join(worktreeDir, ".git")
-	info, err := os.Stat(gitPath)
-	if err != nil {
-		return "", fmt.Errorf("stat .git: %w", err)
-	}
-	if info.IsDir() {
-		return filepath.Join(gitPath, "info", "exclude"), nil
-	}
-	data, err := os.ReadFile(gitPath)
-	if err != nil {
-		return "", fmt.Errorf("read .git: %w", err)
-	}
-	const prefix = "gitdir:"
-	line := strings.TrimSpace(string(data))
-	if !strings.HasPrefix(line, prefix) {
-		return "", fmt.Errorf(".git file missing %q prefix", prefix)
-	}
-	wtGitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
-
-	commonDir := wtGitDir
-	if raw, rerr := os.ReadFile(filepath.Join(wtGitDir, "commondir")); rerr == nil {
-		cd := strings.TrimSpace(string(raw))
-		if !filepath.IsAbs(cd) {
-			cd = filepath.Join(wtGitDir, cd)
-		}
-		commonDir = filepath.Clean(cd)
-	}
-	return filepath.Join(commonDir, "info", "exclude"), nil
-}
-
-// ensureExcluded appends excludeLine to the worktree's info/exclude if it
-// isn't already there. Idempotent.
+// ensureExcluded appends excludeLine to the worktree's info/exclude.
+// Thin wrapper around git.EnsureExcluded so the notes package's call
+// sites stay terse.
 func ensureExcluded(worktreeDir string) error {
-	excludePath, err := excludeFilePath(worktreeDir)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(excludePath), dirPerm); err != nil {
-		return fmt.Errorf("create info dir: %w", err)
-	}
-	existing, err := os.ReadFile(excludePath)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("read exclude: %w", err)
-	}
-	if hasExcludeLine(existing, excludeLine) {
-		return nil
-	}
-	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, filePerm)
-	if err != nil {
-		return fmt.Errorf("open exclude: %w", err)
-	}
-	var buf strings.Builder
-	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
-		buf.WriteString("\n")
-	}
-	buf.WriteString(excludeLine)
-	buf.WriteString("\n")
-	if _, werr := f.WriteString(buf.String()); werr != nil {
-		_ = f.Close()
-		return fmt.Errorf("write exclude: %w", werr)
-	}
-	if cerr := f.Close(); cerr != nil {
-		return fmt.Errorf("close exclude: %w", cerr)
-	}
-	return nil
-}
-
-func hasExcludeLine(content []byte, line string) bool {
-	scanner := bufio.NewScanner(strings.NewReader(string(content)))
-	for scanner.Scan() {
-		if strings.TrimSpace(scanner.Text()) == line {
-			return true
-		}
-	}
-	return false
+	return git.EnsureExcluded(worktreeDir, excludeLine)
 }

--- a/internal/ops/worktree.go
+++ b/internal/ops/worktree.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mdelapenya/biomelab/internal/git"
 	"github.com/mdelapenya/biomelab/internal/github"
 	"github.com/mdelapenya/biomelab/internal/provider"
+	"github.com/mdelapenya/biomelab/internal/regent"
 	"github.com/mdelapenya/biomelab/internal/sandbox"
 	"github.com/mdelapenya/biomelab/internal/terminal"
 )
@@ -33,10 +34,35 @@ func (r CreateWorktreeResult) ErrorMessage() string {
 	return r.Err.Error()
 }
 
-// CreateWorktree creates a new linked worktree for the given branch.
+// CreateWorktree creates a new linked worktree for the given branch and
+// bootstraps the re_gent audit log on it (a no-op when rgt isn't installed).
+// Init failures don't surface to the caller — the worktree itself is the
+// product; rgt is a sidecar capability that the user can wire up later.
 func CreateWorktree(repo *git.Repository, branchName string) CreateWorktreeResult {
-	err := repo.CreateWorktree(branchName)
-	return CreateWorktreeResult{BranchName: branchName, Err: err}
+	if err := repo.CreateWorktree(branchName); err != nil {
+		return CreateWorktreeResult{BranchName: branchName, Err: err}
+	}
+	if path := worktreePathForBranch(repo, branchName); path != "" {
+		_ = regent.EnsureInit(path)
+	}
+	return CreateWorktreeResult{BranchName: branchName}
+}
+
+// worktreePathForBranch resolves the on-disk path of a freshly-created
+// worktree by re-listing and matching on branch name. Returns "" when no
+// match is found — the caller treats this as "skip the optional follow-up
+// step" rather than as an error.
+func worktreePathForBranch(repo *git.Repository, branchName string) string {
+	wts, err := repo.ListWorktrees()
+	if err != nil {
+		return ""
+	}
+	for _, wt := range wts {
+		if wt.Branch == branchName {
+			return wt.Path
+		}
+	}
+	return ""
 }
 
 // CreateSandboxWorktree creates a worktree inside an existing sandbox.

--- a/internal/regent/hooks.go
+++ b/internal/regent/hooks.go
@@ -1,0 +1,200 @@
+package regent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Claude Code hook commands written into .claude/settings.json. The names
+// mirror what rgt's own installer uses; ported here so biomelab can wire
+// the hooks without an interactive TTY (the upstream `rgt init` flow only
+// installs hooks after a `huh`-based TTY prompt that fails under a GUI
+// launch).
+//
+// Source: github.com/regent-vcs/re_gent internal/cli/init.go (Apache-2.0).
+const (
+	claudeUserHook      = "rgt message-hook user"
+	claudeAssistantHook = "rgt message-hook assistant"
+	claudeToolBatchHook = "rgt tool-batch-hook"
+)
+
+// EnsureClaudeHooks writes Claude Code hook entries into
+// <wtPath>/.claude/settings.json. Idempotent: existing rgt-related entries
+// are replaced (not duplicated), non-rgt entries are preserved. Returns
+// nil when wtPath is empty. Backs up unparseable settings files to
+// settings.json.backup before overwriting.
+//
+// The JSON shape matches what `rgt init` writes under the interactive
+// installer:
+//
+//	{
+//	  "hooks": {
+//	    "UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "rgt message-hook user"}]}],
+//	    "Stop": [{...}],
+//	    "PostToolBatch": [{...}]
+//	  }
+//	}
+func EnsureClaudeHooks(wtPath string) error {
+	if wtPath == "" {
+		return nil
+	}
+	claudeDir := filepath.Join(wtPath, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return fmt.Errorf("create .claude/: %w", err)
+	}
+
+	settings := map[string]any{}
+	if data, err := os.ReadFile(settingsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+		if jerr := json.Unmarshal(data, &settings); jerr != nil {
+			backup := settingsPath + ".backup"
+			if rerr := os.Rename(settingsPath, backup); rerr != nil {
+				return fmt.Errorf("backup invalid settings.json: %w", rerr)
+			}
+			settings = map[string]any{}
+		}
+	}
+
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+		settings["hooks"] = hooks
+	}
+
+	mergeClaudeHook(hooks, "UserPromptSubmit", claudeUserHook)
+	mergeClaudeHook(hooks, "Stop", claudeAssistantHook)
+	mergeClaudeHook(hooks, "PostToolBatch", claudeToolBatchHook)
+	removeClaudeHook(hooks, "PostToolUse") // legacy cleanup
+
+	output, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings.json: %w", err)
+	}
+	if err := os.WriteFile(settingsPath, append(output, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write settings.json: %w", err)
+	}
+	return nil
+}
+
+// mergeClaudeHook adds/replaces the rgt entry for the given event while
+// preserving any other (non-rgt) hook groups the user has configured.
+func mergeClaudeHook(hooks map[string]any, event, command string) {
+	groups := filterRgtHooks(normalizeHookGroups(hooks[event]))
+	hooks[event] = append(groups, hookGroup(command))
+}
+
+// removeClaudeHook strips any rgt entry from the given event. Used to
+// clean up legacy keys (e.g. an older rgt wrote PostToolUse before
+// migrating to PostToolBatch); leaves non-rgt entries intact.
+func removeClaudeHook(hooks map[string]any, event string) {
+	groups := filterRgtHooks(normalizeHookGroups(hooks[event]))
+	if len(groups) == 0 {
+		delete(hooks, event)
+		return
+	}
+	hooks[event] = groups
+}
+
+// normalizeHookGroups accepts the various JSON-decoded shapes Claude Code
+// accepts for an event entry (single object, array of objects, etc.) and
+// returns them as a uniform []any.
+func normalizeHookGroups(value any) []any {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case []any:
+		return v
+	case map[string]any:
+		return []any{v}
+	default:
+		return []any{v}
+	}
+}
+
+// filterRgtHooks returns the input groups with any rgt-related hook
+// commands stripped out. Groups that become empty after the strip are
+// dropped so an event with only rgt entries vanishes cleanly.
+func filterRgtHooks(groups []any) []any {
+	filtered := make([]any, 0, len(groups))
+	for _, group := range groups {
+		gm, ok := group.(map[string]any)
+		if !ok {
+			filtered = append(filtered, group)
+			continue
+		}
+		entries, hasEntries := normalizeHookEntries(gm["hooks"])
+		if !hasEntries {
+			filtered = append(filtered, group)
+			continue
+		}
+		next := make([]any, 0, len(entries))
+		for _, e := range entries {
+			em, ok := e.(map[string]any)
+			if !ok {
+				next = append(next, e)
+				continue
+			}
+			cmd, _ := em["command"].(string)
+			if isRgtCommand(cmd) {
+				continue
+			}
+			next = append(next, em)
+		}
+		if len(next) == 0 {
+			continue
+		}
+		gm["hooks"] = next
+		filtered = append(filtered, gm)
+	}
+	return filtered
+}
+
+func normalizeHookEntries(value any) ([]any, bool) {
+	switch v := value.(type) {
+	case nil:
+		return nil, false
+	case []any:
+		return v, true
+	case map[string]any:
+		return []any{v}, true
+	default:
+		return []any{v}, true
+	}
+}
+
+// hookGroup is the canonical JSON shape for a single Claude Code hook
+// entry. Mirrors what rgt's interactive installer writes.
+func hookGroup(command string) map[string]any {
+	return map[string]any{
+		"matcher": "",
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": command,
+			},
+		},
+	}
+}
+
+// isRgtCommand recognizes any command that invokes rgt — whether by name
+// (`rgt …` / `regent …`), via leading env var assignments (`FOO=bar rgt …`),
+// or via `go run ./cmd/rgt …` during development. Used to dedupe entries
+// across re-runs of EnsureClaudeHooks.
+func isRgtCommand(command string) bool {
+	fields := strings.Fields(strings.TrimSpace(command))
+	for len(fields) > 0 && strings.Contains(fields[0], "=") && !strings.HasPrefix(fields[0], "=") {
+		fields = fields[1:]
+	}
+	if len(fields) == 0 {
+		return false
+	}
+	first := strings.TrimPrefix(filepath.Base(fields[0]), "./")
+	if first == "rgt" || first == "regent" {
+		return true
+	}
+	return len(fields) >= 3 && fields[0] == "go" && fields[1] == "run" && strings.Contains(fields[2], "cmd/rgt")
+}

--- a/internal/regent/hooks_test.go
+++ b/internal/regent/hooks_test.go
@@ -1,0 +1,204 @@
+package regent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// readSettings loads .claude/settings.json from wt and returns its decoded
+// map. Used by every test below — both as input setup and as the assertion
+// target after EnsureClaudeHooks runs.
+func readSettings(t *testing.T, wt string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(wt, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal settings.json: %v", err)
+	}
+	return got
+}
+
+func hookCommandsFor(t *testing.T, settings map[string]any, event string) []string {
+	t.Helper()
+	hooks, _ := settings["hooks"].(map[string]any)
+	groups := normalizeHookGroups(hooks[event])
+	out := []string{}
+	for _, group := range groups {
+		gm, ok := group.(map[string]any)
+		if !ok {
+			continue
+		}
+		entries, _ := normalizeHookEntries(gm["hooks"])
+		for _, e := range entries {
+			em, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, ok := em["command"].(string); ok {
+				out = append(out, cmd)
+			}
+		}
+	}
+	return out
+}
+
+func TestEnsureClaudeHooks_FreshInstall(t *testing.T) {
+	wt := t.TempDir()
+
+	if err := EnsureClaudeHooks(wt); err != nil {
+		t.Fatalf("EnsureClaudeHooks() = %v", err)
+	}
+
+	settings := readSettings(t, wt)
+	wantEvents := map[string]string{
+		"UserPromptSubmit": claudeUserHook,
+		"Stop":             claudeAssistantHook,
+		"PostToolBatch":    claudeToolBatchHook,
+	}
+	for event, want := range wantEvents {
+		cmds := hookCommandsFor(t, settings, event)
+		if len(cmds) != 1 || cmds[0] != want {
+			t.Errorf("%s commands = %v, want [%q]", event, cmds, want)
+		}
+	}
+}
+
+func TestEnsureClaudeHooks_IsIdempotent(t *testing.T) {
+	wt := t.TempDir()
+
+	for range 3 {
+		if err := EnsureClaudeHooks(wt); err != nil {
+			t.Fatalf("EnsureClaudeHooks() = %v", err)
+		}
+	}
+	settings := readSettings(t, wt)
+	cmds := hookCommandsFor(t, settings, "UserPromptSubmit")
+	if len(cmds) != 1 {
+		t.Errorf("UserPromptSubmit has %d entries after 3 calls, want 1: %v", len(cmds), cmds)
+	}
+}
+
+func TestEnsureClaudeHooks_PreservesUserHooks(t *testing.T) {
+	wt := t.TempDir()
+	claudeDir := filepath.Join(wt, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := map[string]any{
+		"hooks": map[string]any{
+			"UserPromptSubmit": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "echo not-rgt"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureClaudeHooks(wt); err != nil {
+		t.Fatalf("EnsureClaudeHooks() = %v", err)
+	}
+
+	settings := readSettings(t, wt)
+	cmds := hookCommandsFor(t, settings, "UserPromptSubmit")
+	if len(cmds) != 2 {
+		t.Fatalf("UserPromptSubmit has %d entries, want 2 (user + rgt): %v", len(cmds), cmds)
+	}
+	if cmds[0] != "echo not-rgt" {
+		t.Errorf("UserPromptSubmit[0] = %q, want %q (user hook preserved first)", cmds[0], "echo not-rgt")
+	}
+	if cmds[1] != claudeUserHook {
+		t.Errorf("UserPromptSubmit[1] = %q, want %q (rgt appended)", cmds[1], claudeUserHook)
+	}
+}
+
+func TestEnsureClaudeHooks_BacksUpInvalidJSON(t *testing.T) {
+	wt := t.TempDir()
+	claudeDir := filepath.Join(wt, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureClaudeHooks(wt); err != nil {
+		t.Fatalf("EnsureClaudeHooks() = %v", err)
+	}
+
+	if _, err := os.Stat(settingsPath + ".backup"); err != nil {
+		t.Errorf("backup file not created: %v", err)
+	}
+	if cmds := hookCommandsFor(t, readSettings(t, wt), "UserPromptSubmit"); len(cmds) != 1 {
+		t.Errorf("UserPromptSubmit entries after recovery = %d, want 1", len(cmds))
+	}
+}
+
+func TestEnsureClaudeHooks_RemovesLegacyPostToolUse(t *testing.T) {
+	// Older rgt versions wrote PostToolUse; current installer writes
+	// PostToolBatch. EnsureClaudeHooks should clean up the legacy entry.
+	wt := t.TempDir()
+	claudeDir := filepath.Join(wt, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := map[string]any{
+		"hooks": map[string]any{
+			"PostToolUse": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "rgt some-old-hook"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureClaudeHooks(wt); err != nil {
+		t.Fatalf("EnsureClaudeHooks() = %v", err)
+	}
+
+	settings := readSettings(t, wt)
+	hooks, _ := settings["hooks"].(map[string]any)
+	if _, exists := hooks["PostToolUse"]; exists {
+		t.Errorf("PostToolUse still present after cleanup; settings: %+v", hooks)
+	}
+}
+
+func TestIsRgtCommand(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want bool
+	}{
+		{"rgt message-hook user", true},
+		{"regent something", true},
+		{"NO_COLOR=1 rgt message-hook user", true},
+		{"go run ./cmd/rgt message-hook user", true},
+		{"echo hello", false},
+		{"", false},
+		{"  ", false},
+		{"/usr/local/bin/rgt message-hook user", true},
+	}
+	for _, tt := range cases {
+		if got := isRgtCommand(tt.cmd); got != tt.want {
+			t.Errorf("isRgtCommand(%q) = %v, want %v", tt.cmd, got, tt.want)
+		}
+	}
+}

--- a/internal/regent/init.go
+++ b/internal/regent/init.go
@@ -1,0 +1,89 @@
+package regent
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/mdelapenya/biomelab/internal/git"
+)
+
+// regentExcludeLine is the git info/exclude pattern that hides .regent/
+// from `git status` and prevents accidental commits. Mirrors the
+// "/.biomelab/" convention used by the notes package — anchored to the
+// worktree root so each worktree's own .regent/ stays hidden.
+const regentExcludeLine = "/.regent/"
+
+// EnsureInit runs `rgt init <wtPath>` so the worktree gains the .regent/
+// audit log and Claude Code hooks that re_gent ships. The call is a no-op
+// for the rgt invocation in two cases:
+//   - rgt is not in PATH (feature is opt-in; nothing to install)
+//   - <wtPath>/.regent/ already exists (idempotency)
+//
+// The git info/exclude is always refreshed when wtPath is non-empty,
+// even on the no-op branches above: a pre-existing .regent/ from a fresh
+// rgt install may pre-date this code path, so we still want it hidden
+// from `git status`. EnsureExcluded is itself idempotent.
+//
+// Returns a non-nil error only when rgt is present and the init command
+// itself fails (or the exclude write fails). Callers typically log and
+// continue — this is a best-effort capability bootstrap.
+func EnsureInit(wtPath string) error {
+	if wtPath == "" {
+		return nil
+	}
+
+	regentExists := false
+	if info, err := os.Stat(filepath.Join(wtPath, ".regent")); err == nil && info.IsDir() {
+		regentExists = true
+	}
+
+	if !regentExists {
+		bin, err := exec.LookPath("rgt")
+		if err != nil {
+			// rgt missing: skip everything — there's nothing to hide yet,
+			// and writing hooks for a tool the user hasn't installed is
+			// noise. Once rgt arrives, the next migration tick wires up.
+			return nil
+		}
+		// rgt init does NOT accept a path arg — it always operates on the
+		// current working directory. Set cmd.Dir to target wtPath.
+		// `--skip-hook --skip-skills` keeps the call non-interactive: rgt's
+		// hook installer is gated behind a TTY prompt that we can't answer
+		// from a GUI process, so we ask rgt to set up only the .regent/
+		// store and write the Claude Code hooks ourselves via
+		// EnsureClaudeHooks below.
+		cmd := exec.Command(bin, "init", "--skip-hook", "--skip-skills")
+		cmd.Dir = wtPath
+		cmd.Env = append(os.Environ(), "NO_COLOR=1")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("rgt init: %s: %w", strings.TrimSpace(string(out)), err)
+		}
+	}
+
+	// Install Claude Code hooks ourselves — always, not only on fresh
+	// init — so worktrees that previously ran `rgt init` without hooks
+	// (e.g. when rgt's installer hit the no-TTY bug) get repaired on the
+	// next migration tick. EnsureClaudeHooks is idempotent: existing rgt
+	// entries are deduplicated, non-rgt entries are preserved.
+	if err := EnsureClaudeHooks(wtPath); err != nil {
+		return fmt.Errorf("install claude hooks: %w", err)
+	}
+
+	if err := git.EnsureExcluded(wtPath, regentExcludeLine); err != nil {
+		return fmt.Errorf("exclude .regent/: %w", err)
+	}
+	return nil
+}
+
+// MigrateAll runs EnsureInit on each path, ignoring per-path errors. Used
+// at startup to retroactively initialize regent on worktrees that existed
+// before the user installed rgt (or before this feature shipped).
+func MigrateAll(wtPaths []string) {
+	for _, p := range wtPaths {
+		_ = EnsureInit(p)
+	}
+}

--- a/internal/regent/init_test.go
+++ b/internal/regent/init_test.go
@@ -1,0 +1,118 @@
+package regent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeWorktree returns a tempdir set up to look like a main worktree:
+// a real .git/ directory so notes.EnsureExcluded can write into
+// .git/info/exclude without going through go-git init.
+func fakeWorktree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func readExclude(t *testing.T, wtDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(wtDir, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	return string(data)
+}
+
+func TestEnsureInit_EmptyPath(t *testing.T) {
+	if err := EnsureInit(""); err != nil {
+		t.Errorf("EnsureInit(\"\") returned %v, want nil", err)
+	}
+}
+
+func TestEnsureInit_RegentDirExists_WritesExclude(t *testing.T) {
+	// When .regent/ already exists, EnsureInit skips the rgt invocation
+	// but still ensures the git exclude line is present — the dir may
+	// pre-date this code path or have been created by another tool.
+	dir := fakeWorktree(t)
+	if err := os.Mkdir(filepath.Join(dir, ".regent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInit(dir); err != nil {
+		t.Fatalf("EnsureInit() = %v, want nil", err)
+	}
+
+	contents := readExclude(t, dir)
+	if !strings.Contains(contents, "/.regent/") {
+		t.Errorf("info/exclude missing /.regent/ entry; got:\n%s", contents)
+	}
+}
+
+func TestEnsureInit_ExcludeIsIdempotent(t *testing.T) {
+	// Calling EnsureInit twice must not duplicate the exclude line.
+	dir := fakeWorktree(t)
+	if err := os.Mkdir(filepath.Join(dir, ".regent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for range 3 {
+		if err := EnsureInit(dir); err != nil {
+			t.Fatalf("EnsureInit() = %v", err)
+		}
+	}
+	contents := readExclude(t, dir)
+	if got := strings.Count(contents, "/.regent/"); got != 1 {
+		t.Errorf("/.regent/ appears %d times in info/exclude, want 1; contents:\n%s", got, contents)
+	}
+}
+
+func TestEnsureInit_RegentMissingFromPath(t *testing.T) {
+	// Without rgt in PATH, EnsureInit must no-op. We force this by
+	// pointing PATH at a tempdir with no executables — a deliberate
+	// reset rather than depending on what the host machine has installed.
+	t.Setenv("PATH", t.TempDir())
+	dir := t.TempDir()
+	if err := EnsureInit(dir); err != nil {
+		t.Errorf("EnsureInit() = %v, want nil (no-op when rgt missing)", err)
+	}
+	// Confirm we did NOT create .regent/ as a side-effect.
+	if _, err := os.Stat(filepath.Join(dir, ".regent")); err == nil {
+		t.Error(".regent/ was created even though rgt is not in PATH")
+	}
+}
+
+func TestEnsureInit_RegentDirIsFile(t *testing.T) {
+	// A .regent file (not a dir) shouldn't be mistaken for an existing
+	// init. We need to fall through to the rgt invocation (or, in this
+	// test, the rgt-missing branch).
+	t.Setenv("PATH", t.TempDir())
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".regent"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// rgt not in PATH ⇒ no-op, returning nil; the existing file is not
+	// treated as a valid init.
+	if err := EnsureInit(dir); err != nil {
+		t.Errorf("EnsureInit() = %v, want nil", err)
+	}
+}
+
+func TestMigrateAll_AcceptsEmpty(t *testing.T) {
+	// MigrateAll on an empty slice must not panic and must not call rgt.
+	t.Setenv("PATH", t.TempDir())
+	MigrateAll(nil)
+	MigrateAll([]string{})
+}
+
+func TestMigrateAll_IgnoresErrors(t *testing.T) {
+	// MigrateAll continues past failing entries. With rgt missing,
+	// EnsureInit returns nil for each path; this exercises the loop.
+	t.Setenv("PATH", t.TempDir())
+	paths := []string{t.TempDir(), t.TempDir(), ""}
+	MigrateAll(paths)
+}

--- a/internal/regent/log.go
+++ b/internal/regent/log.go
@@ -1,0 +1,52 @@
+package regent
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ansiEscape matches CSI/OSC escape sequences emitted by tools that color
+// their output. Stripped from rgt output so the dialog renders plain text.
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07`)
+
+// Log runs `rgt log --limit <limit>` in wtPath and returns the (ANSI-
+// stripped) combined output. Returns an empty string with no error when
+// .regent/ does not exist for the worktree — rgt would emit an error in
+// that case and the GUI should render an empty state, not a panic.
+// Sets NO_COLOR=1 so well-behaved tools skip color output; the regex
+// strips anything that leaks through.
+func Log(wtPath string, limit int) (string, error) {
+	if wtPath == "" {
+		return "", nil
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, ".regent")); err != nil {
+		return "", nil
+	}
+	bin, err := exec.LookPath("rgt")
+	if err != nil {
+		return "", fmt.Errorf("rgt not found in PATH")
+	}
+	args := []string{"log"}
+	if limit > 0 {
+		args = append(args, "--limit", strconv.Itoa(limit))
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = wtPath
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	out, err := cmd.CombinedOutput()
+	clean := stripANSI(string(out))
+	if err != nil {
+		return clean, fmt.Errorf("rgt log: %s: %w", strings.TrimSpace(clean), err)
+	}
+	return clean, nil
+}
+
+// stripANSI removes ANSI escape sequences from s.
+func stripANSI(s string) string {
+	return ansiEscape.ReplaceAllString(s, "")
+}

--- a/internal/regent/log_json.go
+++ b/internal/regent/log_json.go
@@ -1,0 +1,224 @@
+package regent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Step is one re_gent step — a turn of agent activity, identified by a
+// content-addressed hash. Mirrors the JSON shape emitted by
+// `rgt log --json`, with the bits biomelab cares about pulled out for
+// easy rendering. Unknown fields are ignored.
+type Step struct {
+	Hash      string
+	Timestamp time.Time
+	Origin    string // e.g. "claude_code"
+
+	// HumanPrompt is the user prompt that triggered this step (extracted
+	// from messages[].message.content for type=user). Empty when the
+	// step has no associated user message.
+	HumanPrompt string
+
+	// AgentReply is the assistant's text reply for this step (extracted
+	// from messages[].message.content for type=assistant, concatenating
+	// any text-type content blocks). Empty when the step has no reply
+	// or only tool_use blocks.
+	AgentReply string
+
+	// Tools is the ordered list of tool invocations that ran in this
+	// step. Comes from the top-level `causes` array.
+	Tools []ToolCall
+}
+
+// ToolCall captures a single tool invocation. Args is the raw JSON map
+// so renderers can surface arbitrary tool-specific fields (file_path,
+// command, query, etc.) without us having to model every tool.
+type ToolCall struct {
+	Name string
+	Args map[string]any
+}
+
+// LogJSON runs `rgt log --json --limit <limit>` in wtPath and parses the
+// result. Returns the session ID and a slice of Steps (most recent first,
+// matching rgt's own ordering). Empty slice + nil error when there's
+// no .regent/ or no activity yet.
+func LogJSON(wtPath string, limit int) (sessionID string, steps []Step, err error) {
+	data, err := LogJSONRaw(wtPath, limit)
+	if err != nil || data == nil {
+		return "", nil, err
+	}
+	return parseLogJSON(data)
+}
+
+// LogJSONRaw runs `rgt log --json` and returns the raw bytes so callers
+// can write them to disk (for "Export to JSON" flows) without re-shelling.
+// Returns nil + nil when wtPath is missing or has no .regent/ — the
+// caller treats that as "nothing to export". Errors from rgt itself
+// propagate as non-nil err.
+func LogJSONRaw(wtPath string, limit int) ([]byte, error) {
+	if wtPath == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, ".regent")); err != nil {
+		return nil, nil
+	}
+	bin, err := exec.LookPath("rgt")
+	if err != nil {
+		return nil, fmt.Errorf("rgt not found in PATH")
+	}
+	args := []string{"log", "--json"}
+	if limit > 0 {
+		args = append(args, "--limit", strconv.Itoa(limit))
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = wtPath
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("rgt log: %w", err)
+	}
+	return out, nil
+}
+
+// rawStep mirrors the on-the-wire JSON. Decoupled from Step so the public
+// type stays clean and a schema bump only touches this file.
+type rawStep struct {
+	Hash      string    `json:"hash"`
+	Timestamp time.Time `json:"timestamp"`
+	Origin    string    `json:"origin"`
+	Causes    []rawCause   `json:"causes"`
+	Messages  []rawMessage `json:"messages"`
+}
+
+type rawCause struct {
+	Tool string         `json:"tool"`
+	Args map[string]any `json:"args"`
+}
+
+type rawMessage struct {
+	Type    string          `json:"type"` // "user" or "assistant"
+	Message json.RawMessage `json:"message"`
+}
+
+// parseLogJSON converts rgt's JSON output to Step values. Extracted from
+// LogJSON so tests can feed fixture bytes directly without shelling out.
+func parseLogJSON(data []byte) (sessionID string, steps []Step, err error) {
+	var top struct {
+		SessionID string    `json:"session_id"`
+		Steps     []rawStep `json:"steps"`
+	}
+	if err := json.Unmarshal(data, &top); err != nil {
+		return "", nil, fmt.Errorf("parse rgt log json: %w", err)
+	}
+
+	steps = make([]Step, 0, len(top.Steps))
+	for _, rs := range top.Steps {
+		s := Step{
+			Hash:      rs.Hash,
+			Timestamp: rs.Timestamp,
+			Origin:    rs.Origin,
+		}
+		for _, c := range rs.Causes {
+			s.Tools = append(s.Tools, ToolCall{Name: c.Tool, Args: c.Args})
+		}
+		for _, m := range rs.Messages {
+			switch m.Type {
+			case "user":
+				if t := extractUserText(m.Message); t != "" {
+					if s.HumanPrompt != "" {
+						s.HumanPrompt += "\n\n"
+					}
+					s.HumanPrompt += t
+				}
+			case "assistant":
+				if t := extractAssistantText(m.Message); t != "" {
+					if s.AgentReply != "" {
+						s.AgentReply += "\n\n"
+					}
+					s.AgentReply += t
+				}
+			}
+		}
+		steps = append(steps, s)
+	}
+	return top.SessionID, steps, nil
+}
+
+// extractUserText pulls the prompt text out of a user-message blob. Claude
+// Code stores user messages as `{"role": "user", "content": "…"}` with
+// content as a plain string.
+func extractUserText(raw json.RawMessage) string {
+	var m struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ""
+	}
+	// content can be a plain string OR a list of content blocks.
+	var s string
+	if err := json.Unmarshal(m.Content, &s); err == nil {
+		return s
+	}
+	return joinTextBlocks(m.Content)
+}
+
+// extractAssistantText pulls the visible reply text out of an assistant
+// message blob. Assistant messages from Claude are an array of content
+// blocks of type "text" or "tool_use"; we keep the text ones and drop
+// the rest (the tools surface separately in the Tools slice).
+func extractAssistantText(raw json.RawMessage) string {
+	var m struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(m.Content, &s); err == nil {
+		return s
+	}
+	return joinTextBlocks(m.Content)
+}
+
+// joinTextBlocks walks a content-block array and concatenates the text
+// of `type: "text"` entries. Tool-use entries are intentionally ignored
+// because they're already represented in the Step.Tools slice.
+func joinTextBlocks(raw json.RawMessage) string {
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	var out strings.Builder
+	for _, b := range blocks {
+		if b.Type != "text" {
+			continue
+		}
+		t := strings.TrimSpace(b.Text)
+		if t == "" {
+			continue
+		}
+		if out.Len() > 0 {
+			out.WriteString("\n\n")
+		}
+		out.WriteString(t)
+	}
+	return out.String()
+}
+
+// ShortHash returns the first 8 chars of a step's hash, matching rgt's
+// own log abbreviation. Convenience for renderers.
+func (s Step) ShortHash() string {
+	if len(s.Hash) <= 8 {
+		return s.Hash
+	}
+	return s.Hash[:8]
+}

--- a/internal/regent/log_json_test.go
+++ b/internal/regent/log_json_test.go
@@ -1,0 +1,146 @@
+package regent
+
+import (
+	"testing"
+)
+
+const sampleLogJSON = `{
+  "session_id": "claude_code:abc-123",
+  "steps": [
+    {
+      "hash": "deadbeefcafebabe1234567890abcdef",
+      "timestamp": "2026-05-18T17:21:38+02:00",
+      "origin": "claude_code",
+      "causes": [
+        {"tool": "Read", "args": {"file_path": "/abs/foo.go", "limit": 60}},
+        {"tool": "Write", "args": {"file_path": "/abs/bar.go", "content": "..."}}
+      ],
+      "messages": [
+        {"type": "user", "message": {"role": "user", "content": "do the thing"}},
+        {"type": "assistant", "message": {"role": "assistant", "content": [
+          {"type": "text", "text": "Done."},
+          {"type": "tool_use", "id": "x", "name": "Read", "input": {}}
+        ]}}
+      ]
+    },
+    {
+      "hash": "1234567890abcdef",
+      "timestamp": "2026-05-18T17:25:00+02:00",
+      "origin": "claude_code",
+      "causes": [],
+      "messages": [
+        {"type": "user", "message": {"role": "user", "content": "another"}}
+      ]
+    }
+  ]
+}`
+
+func TestParseLogJSON(t *testing.T) {
+	sessionID, steps, err := parseLogJSON([]byte(sampleLogJSON))
+	if err != nil {
+		t.Fatalf("parseLogJSON: %v", err)
+	}
+	if sessionID != "claude_code:abc-123" {
+		t.Errorf("sessionID = %q, want claude_code:abc-123", sessionID)
+	}
+	if len(steps) != 2 {
+		t.Fatalf("got %d steps, want 2", len(steps))
+	}
+
+	s0 := steps[0]
+	if s0.ShortHash() != "deadbeef" {
+		t.Errorf("steps[0].ShortHash = %q, want deadbeef", s0.ShortHash())
+	}
+	if s0.HumanPrompt != "do the thing" {
+		t.Errorf("steps[0].HumanPrompt = %q, want %q", s0.HumanPrompt, "do the thing")
+	}
+	if s0.AgentReply != "Done." {
+		t.Errorf("steps[0].AgentReply = %q, want %q (text block only, no tool_use)", s0.AgentReply, "Done.")
+	}
+	if len(s0.Tools) != 2 {
+		t.Fatalf("steps[0].Tools = %d, want 2", len(s0.Tools))
+	}
+	if s0.Tools[0].Name != "Read" || s0.Tools[0].Args["file_path"] != "/abs/foo.go" {
+		t.Errorf("steps[0].Tools[0] = %+v, want Read /abs/foo.go", s0.Tools[0])
+	}
+}
+
+func TestParseLogJSON_StringAssistantContent(t *testing.T) {
+	// Some agents (codex, opencode) may emit assistant content as a
+	// plain string instead of the Claude content-block array. Both must
+	// extract as the visible text.
+	in := `{
+	  "session_id": "s",
+	  "steps": [{
+		"hash": "h",
+		"timestamp": "2026-05-18T00:00:00Z",
+		"messages": [
+		  {"type": "assistant", "message": {"role": "assistant", "content": "plain reply"}}
+		]
+	  }]
+	}`
+	_, steps, err := parseLogJSON([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if steps[0].AgentReply != "plain reply" {
+		t.Errorf("AgentReply = %q, want %q", steps[0].AgentReply, "plain reply")
+	}
+}
+
+func TestParseLogJSON_UserContentAsBlocks(t *testing.T) {
+	// User content can also be an array of blocks. Concatenate the
+	// text-type ones; ignore the rest.
+	in := `{
+	  "steps": [{
+		"hash": "h",
+		"messages": [
+		  {"type": "user", "message": {"role": "user", "content": [
+			{"type": "text", "text": "part 1"},
+			{"type": "image", "url": "x"},
+			{"type": "text", "text": "part 2"}
+		  ]}}
+		]
+	  }]
+	}`
+	_, steps, err := parseLogJSON([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if steps[0].HumanPrompt != "part 1\n\npart 2" {
+		t.Errorf("HumanPrompt = %q", steps[0].HumanPrompt)
+	}
+}
+
+func TestParseLogJSON_NoSteps(t *testing.T) {
+	_, steps, err := parseLogJSON([]byte(`{"session_id": "s", "steps": []}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 0 {
+		t.Errorf("len(steps) = %d, want 0", len(steps))
+	}
+}
+
+func TestParseLogJSON_MalformedReturnsError(t *testing.T) {
+	if _, _, err := parseLogJSON([]byte("{not json")); err == nil {
+		t.Error("parseLogJSON did not error on malformed JSON")
+	}
+}
+
+func TestShortHash(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"deadbeefcafebabe", "deadbeef"},
+		{"short", "short"},
+		{"", ""},
+		{"12345678", "12345678"},
+	}
+	for _, tt := range cases {
+		s := Step{Hash: tt.in}
+		if got := s.ShortHash(); got != tt.want {
+			t.Errorf("Step{Hash:%q}.ShortHash() = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/regent/log_test.go
+++ b/internal/regent/log_test.go
@@ -1,0 +1,66 @@
+package regent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLog_EmptyPath(t *testing.T) {
+	out, err := Log("", 10)
+	if err != nil {
+		t.Errorf("Log(\"\", 10) returned %v, want nil", err)
+	}
+	if out != "" {
+		t.Errorf("Log(\"\", 10) returned %q, want empty", out)
+	}
+}
+
+func TestLog_NoRegentDir(t *testing.T) {
+	// Worktree without .regent/ → empty output, no error.
+	dir := t.TempDir()
+	out, err := Log(dir, 10)
+	if err != nil {
+		t.Errorf("Log() = err %v, want nil", err)
+	}
+	if out != "" {
+		t.Errorf("Log() = %q, want empty", out)
+	}
+}
+
+func TestLog_RgtMissingFromPath(t *testing.T) {
+	// .regent/ exists but rgt is not on PATH → error.
+	t.Setenv("PATH", t.TempDir())
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".regent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Log(dir, 10)
+	if err == nil {
+		t.Error("Log() returned nil error when rgt is missing")
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	in := "\x1b[38;5;141mStep abc\x1b[0m | 2 min ago"
+	want := "Step abc | 2 min ago"
+	if got := stripANSI(in); got != want {
+		t.Errorf("stripANSI() = %q, want %q", got, want)
+	}
+}
+
+func TestStripANSI_NoEscapes(t *testing.T) {
+	in := "plain text"
+	if got := stripANSI(in); got != in {
+		t.Errorf("stripANSI(%q) = %q, want unchanged", in, got)
+	}
+}
+
+func TestStripANSI_OSC(t *testing.T) {
+	in := "before\x1b]0;title text\x07after"
+	want := "beforeafter"
+	if got := stripANSI(in); !strings.Contains(got, "before") || !strings.Contains(got, "after") || got != want {
+		t.Errorf("stripANSI() = %q, want %q", got, want)
+	}
+}

--- a/internal/regent/regent.go
+++ b/internal/regent/regent.go
@@ -1,0 +1,86 @@
+// Package regent inspects a worktree's .regent/ directory to surface re_gent
+// (https://github.com/regent-vcs/re_gent) audit-log activity in biomelab.
+//
+// re_gent is a content-addressed audit log of AI agent activity, captured via
+// Claude Code hooks. It writes everything under <workspace>/.regent/. Because
+// the directory is on the host filesystem in regular mode and bind-mounted
+// from the container in sandbox mode, biomelab can read the same data in both
+// modes without any container introspection.
+//
+// This package intentionally does not shell out to the rgt CLI or open the
+// SQLite index. The schema is unstable at v0.1.2 and a small filesystem-only
+// read is enough for a card-level activity hint. Heavier integrations (full
+// session timeline, blame-in-diff) can layer on later.
+package regent
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Status describes the regent state of a single worktree.
+// Zero value means regent is not enabled for that worktree.
+type Status struct {
+	Enabled   bool      // .regent/ exists under the workspace
+	LastTouch time.Time // mtime of the most recent activity signal (index.db, fallback objects/)
+	Sessions  int       // count of entries under refs/sessions/
+}
+
+// Inspect reads <workspaceDir>/.regent/ and returns a Status. Missing or
+// unreadable directories yield a zero-value Status (Enabled=false) with no
+// error — regent is opt-in and most worktrees won't have it.
+func Inspect(workspaceDir string) Status {
+	if workspaceDir == "" {
+		return Status{}
+	}
+	regentDir := filepath.Join(workspaceDir, ".regent")
+	info, err := os.Stat(regentDir)
+	if err != nil || !info.IsDir() {
+		return Status{}
+	}
+
+	s := Status{Enabled: true}
+
+	if dbInfo, err := os.Stat(filepath.Join(regentDir, "index.db")); err == nil {
+		s.LastTouch = dbInfo.ModTime()
+	} else if mt, ok := newestObjectMtime(filepath.Join(regentDir, "objects")); ok {
+		s.LastTouch = mt
+	}
+
+	if entries, err := os.ReadDir(filepath.Join(regentDir, "refs", "sessions")); err == nil {
+		s.Sessions = len(entries)
+	}
+
+	return s
+}
+
+// newestObjectMtime walks one level into objects/<shard>/ and returns the
+// most recent mtime among blob files. Used as a fallback when index.db does
+// not exist yet (very fresh .regent/ before the first SQLite write).
+func newestObjectMtime(objectsDir string) (time.Time, bool) {
+	shards, err := os.ReadDir(objectsDir)
+	if err != nil {
+		return time.Time{}, false
+	}
+	var newest time.Time
+	for _, shard := range shards {
+		if !shard.IsDir() {
+			continue
+		}
+		blobs, err := os.ReadDir(filepath.Join(objectsDir, shard.Name()))
+		if err != nil {
+			continue
+		}
+		for _, b := range blobs {
+			info, err := b.Info()
+			if err != nil {
+				continue
+			}
+			if info.ModTime().After(newest) {
+				newest = info.ModTime()
+			}
+		}
+	}
+	return newest, !newest.IsZero()
+}

--- a/internal/regent/regent_test.go
+++ b/internal/regent/regent_test.go
@@ -1,0 +1,165 @@
+package regent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestInspect_NoRegentDir(t *testing.T) {
+	dir := t.TempDir()
+	got := Inspect(dir)
+	if got.Enabled {
+		t.Fatalf("Enabled = true, want false for workspace without .regent/")
+	}
+	if !got.LastTouch.IsZero() {
+		t.Errorf("LastTouch = %v, want zero", got.LastTouch)
+	}
+	if got.Sessions != 0 {
+		t.Errorf("Sessions = %d, want 0", got.Sessions)
+	}
+}
+
+func TestInspect_EmptyWorkspaceDir(t *testing.T) {
+	got := Inspect("")
+	if got.Enabled {
+		t.Fatalf("Enabled = true for empty workspaceDir, want false")
+	}
+}
+
+func TestInspect_RegentDirIsFile(t *testing.T) {
+	dir := t.TempDir()
+	// .regent as a regular file should not count as enabled.
+	if err := os.WriteFile(filepath.Join(dir, ".regent"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := Inspect(dir)
+	if got.Enabled {
+		t.Errorf("Enabled = true when .regent is a file, want false")
+	}
+}
+
+func TestInspect_EnabledMinimal(t *testing.T) {
+	dir := t.TempDir()
+	regentDir := filepath.Join(dir, ".regent")
+	if err := os.Mkdir(regentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := Inspect(dir)
+	if !got.Enabled {
+		t.Errorf("Enabled = false, want true for empty .regent/")
+	}
+	if !got.LastTouch.IsZero() {
+		t.Errorf("LastTouch = %v, want zero (no index.db, no objects)", got.LastTouch)
+	}
+	if got.Sessions != 0 {
+		t.Errorf("Sessions = %d, want 0", got.Sessions)
+	}
+}
+
+func TestInspect_IndexDBMtime(t *testing.T) {
+	dir := t.TempDir()
+	regentDir := filepath.Join(dir, ".regent")
+	if err := os.Mkdir(regentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(regentDir, "index.db")
+	if err := os.WriteFile(dbPath, []byte("fake sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	if err := os.Chtimes(dbPath, want, want); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Inspect(dir)
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true")
+	}
+	if !got.LastTouch.Equal(want) {
+		t.Errorf("LastTouch = %v, want %v", got.LastTouch, want)
+	}
+}
+
+func TestInspect_ObjectsFallback(t *testing.T) {
+	dir := t.TempDir()
+	objectsDir := filepath.Join(dir, ".regent", "objects", "ab")
+	if err := os.MkdirAll(objectsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	older := filepath.Join(objectsDir, "blob1")
+	newer := filepath.Join(objectsDir, "blob2")
+	if err := os.WriteFile(older, []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newer, []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tOld := time.Now().Add(-3 * time.Hour).Truncate(time.Second)
+	tNew := time.Now().Add(-30 * time.Minute).Truncate(time.Second)
+	if err := os.Chtimes(older, tOld, tOld); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newer, tNew, tNew); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Inspect(dir)
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true")
+	}
+	if !got.LastTouch.Equal(tNew) {
+		t.Errorf("LastTouch = %v, want newest blob mtime %v", got.LastTouch, tNew)
+	}
+}
+
+func TestInspect_IndexDBWinsOverObjects(t *testing.T) {
+	// When index.db exists, its mtime is the canonical signal even if
+	// objects/ contains newer blob files. The fallback is only for the
+	// brief window between .regent/ creation and the first SQLite write.
+	dir := t.TempDir()
+	regentDir := filepath.Join(dir, ".regent")
+	objectsDir := filepath.Join(regentDir, "objects", "ab")
+	if err := os.MkdirAll(objectsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(regentDir, "index.db")
+	if err := os.WriteFile(dbPath, []byte("db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	blobPath := filepath.Join(objectsDir, "blob")
+	if err := os.WriteFile(blobPath, []byte("blob"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dbT := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+	blobT := time.Now().Add(-5 * time.Minute).Truncate(time.Second)
+	if err := os.Chtimes(dbPath, dbT, dbT); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(blobPath, blobT, blobT); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Inspect(dir)
+	if !got.LastTouch.Equal(dbT) {
+		t.Errorf("LastTouch = %v, want index.db mtime %v", got.LastTouch, dbT)
+	}
+}
+
+func TestInspect_SessionsCount(t *testing.T) {
+	dir := t.TempDir()
+	sessionsDir := filepath.Join(dir, ".regent", "refs", "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"session-1", "session-2", "session-3"} {
+		if err := os.WriteFile(filepath.Join(sessionsDir, name), []byte("ref"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := Inspect(dir)
+	if got.Sessions != 3 {
+		t.Errorf("Sessions = %d, want 3", got.Sessions)
+	}
+}

--- a/internal/sysdeps/checks.go
+++ b/internal/sysdeps/checks.go
@@ -1,0 +1,169 @@
+package sysdeps
+
+import (
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/mdelapenya/biomelab/internal/config"
+	"github.com/mdelapenya/biomelab/internal/provider"
+	"github.com/mdelapenya/biomelab/internal/sandbox"
+)
+
+// Registry returns the standard set of checks biomelab knows about.
+// Tests can substitute their own checks via Cache.SetChecks.
+func Registry() []Check {
+	return []Check{
+		rgtCheck(),
+		ghCheck(),
+		glabCheck(),
+		sbxCheck(),
+	}
+}
+
+// rgtCheck inspects the re_gent CLI. Always applies — surfacing the audit
+// trail on cards is an opt-in feature regardless of repo mode.
+func rgtCheck() Check {
+	return Check{
+		Name:        "rgt",
+		DisplayName: "re_gent",
+		Reason:      "Surface AI agent audit trails on worktree cards.",
+		Probe: func() Result {
+			path, err := exec.LookPath("rgt")
+			if err != nil {
+				return Result{Status: StatusMissing}
+			}
+			version := probeVersion(path, "version")
+			if version == "" {
+				version = probeVersion(path, "--version")
+			}
+			return Result{Status: StatusOK, Version: version}
+		},
+		DocsURL:  "https://github.com/regent-vcs/re_gent",
+		Optional: true,
+	}
+}
+
+// ghCheck wraps provider.GitHubProvider.CheckCLI so the existing
+// authentication detection is reused without duplicating subprocess logic.
+// Suppressed when glab is installed — users on one provider don't need
+// the other CLI nagging them about being missing.
+func ghCheck() Check {
+	return Check{
+		Name:        "gh",
+		DisplayName: "GitHub CLI",
+		Reason:      "Fetch PR status for GitHub-hosted repositories.",
+		Probe: func() Result {
+			avail := (&provider.GitHubProvider{}).CheckCLI()
+			switch avail {
+			case provider.CLIAvailable:
+				return Result{Status: StatusOK, Version: probeVersion("gh", "--version")}
+			case provider.CLINotAuthenticated:
+				return Result{Status: StatusDegraded, Version: probeVersion("gh", "--version"), Note: "not authenticated — run: gh auth login"}
+			default:
+				return Result{Status: StatusMissing}
+			}
+		},
+		InstallHint:   "brew install gh",
+		DocsURL:       "https://cli.github.com/",
+		SuppressIfAny: []string{"glab"},
+	}
+}
+
+// glabCheck mirrors ghCheck for GitLab. Suppressed when gh is installed.
+func glabCheck() Check {
+	return Check{
+		Name:        "glab",
+		DisplayName: "GitLab CLI",
+		Reason:      "Fetch MR status for GitLab-hosted repositories.",
+		Probe: func() Result {
+			avail := (&provider.GitLabProvider{}).CheckCLI()
+			switch avail {
+			case provider.CLIAvailable:
+				return Result{Status: StatusOK, Version: probeVersion("glab", "--version")}
+			case provider.CLINotAuthenticated:
+				return Result{Status: StatusDegraded, Version: probeVersion("glab", "--version"), Note: "not authenticated — run: glab auth login"}
+			default:
+				return Result{Status: StatusMissing}
+			}
+		},
+		InstallHint:   "brew install glab",
+		DocsURL:       "https://gitlab.com/gitlab-org/cli",
+		SuppressIfAny: []string{"gh"},
+	}
+}
+
+// sbxCheck reports Docker Sandbox CLI readiness. Only applies when at least
+// one repo is configured in sandbox mode — otherwise it shows as N/A.
+func sbxCheck() Check {
+	return Check{
+		Name:        "sbx",
+		DisplayName: "Docker Sandbox",
+		Reason:      "Run agents inside Docker sandboxes (sandbox mode).",
+		Applies:     hasSandboxRepo,
+		Probe: func() Result {
+			if !sandbox.Available() {
+				return Result{Status: StatusMissing}
+			}
+			version := sandbox.Version().Client
+			if err := sandbox.Preflight(); err != nil {
+				return Result{Status: StatusDegraded, Version: version, Note: firstLine(err.Error())}
+			}
+			return Result{Status: StatusOK, Version: version}
+		},
+		DocsURL: "https://docs.docker.com/ai/sandboxes/",
+	}
+}
+
+// hasSandboxRepo returns true when cfg has at least one repo with a
+// sandbox mode entry. Used to gate sbx and docker checks.
+func hasSandboxRepo(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, r := range cfg.Repos {
+		for _, m := range r.Modes {
+			if m.Type == "sandbox" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ansiEscape matches CSI (`ESC [ … letter`) and OSC (`ESC ] … BEL`) escape
+// sequences emitted by tools that color their output (e.g. `rgt version`
+// prints "re_gent\x1b[38;5;141m" segments). Stripped so the dialog shows
+// clean text regardless of whether the tool respects NO_COLOR.
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07`)
+
+// probeVersion runs `<bin> <subcmd>` and returns the first non-empty line of
+// stdout, ANSI-stripped and trimmed. Sets NO_COLOR=1 so well-behaved tools
+// skip color output entirely; the regex strips anything that leaks through.
+// Returns "" on any error so the caller can decide how to render the row.
+func probeVersion(bin, subcmd string) string {
+	cmd := exec.Command(bin, subcmd)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return firstLine(stripANSI(string(out)))
+}
+
+// stripANSI removes ANSI escape sequences from s.
+func stripANSI(s string) string {
+	return ansiEscape.ReplaceAllString(s, "")
+}
+
+// firstLine returns the first non-empty trimmed line of s.
+func firstLine(s string) string {
+	for line := range strings.SplitSeq(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/sysdeps/sysdeps.go
+++ b/internal/sysdeps/sysdeps.go
@@ -1,0 +1,261 @@
+// Package sysdeps inspects external CLI dependencies biomelab relies on
+// (gh, glab, sbx, docker, rgt) and reports their availability with degraded
+// states surfaced (auth failures, daemon down, etc.).
+//
+// Each check is a Check entry in a registry: a Probe function returns a
+// Result describing what was found. Probes shell out via os/exec, so the
+// package is the centralized home for that pattern. The GUI consumes Reported
+// results through a Cache to avoid re-probing on every menu render.
+package sysdeps
+
+import (
+	"sync"
+	"time"
+
+	"github.com/mdelapenya/biomelab/internal/config"
+)
+
+// Status describes the readiness of a single dependency.
+type Status int
+
+const (
+	// StatusNA means the dependency is not relevant to the user's current
+	// configuration (e.g. sbx when no sandbox-mode repo is registered).
+	StatusNA Status = iota
+	// StatusOK means the dependency is installed and usable.
+	StatusOK
+	// StatusDegraded means the dependency is installed but not usable
+	// (e.g. gh present but not authenticated, sbx daemon not running).
+	StatusDegraded
+	// StatusMissing means the dependency is not in PATH.
+	StatusMissing
+)
+
+// String returns a short label suitable for logs and tests.
+func (s Status) String() string {
+	switch s {
+	case StatusOK:
+		return "ok"
+	case StatusDegraded:
+		return "degraded"
+	case StatusMissing:
+		return "missing"
+	case StatusNA:
+		return "n/a"
+	default:
+		return "unknown"
+	}
+}
+
+// Result describes the outcome of probing a single dependency.
+type Result struct {
+	Status  Status
+	Version string // best-effort; "" when not detected
+	Note    string // human-readable detail, e.g. "not authenticated"
+}
+
+// Check describes a single dependency biomelab knows how to inspect.
+type Check struct {
+	// Name is the binary name (e.g. "rgt"). Kept lowercase, single token.
+	Name string
+	// DisplayName is the user-facing tool name (e.g. "re_gent").
+	DisplayName string
+	// Reason explains what biomelab uses the tool for; shown in the dialog.
+	Reason string
+	// Applies returns false when the tool is not relevant for the user's
+	// current configuration. A nil Applies is treated as "always applies".
+	Applies func(*config.Config) bool
+	// Probe runs the actual check. Required.
+	Probe func() Result
+	// InstallHint is a short, copy-pasteable hint shown in the dialog when
+	// the tool is missing (e.g. "brew install gh"). Empty allowed.
+	InstallHint string
+	// DocsURL is the install-docs page for the tool (empty allowed).
+	DocsURL string
+	// Optional marks the check as opt-in: it lives in a collapsed
+	// "Optional tools" section of the dialog while missing, and is
+	// auto-promoted to the main list once installation is detected.
+	// Use for features the user must actively opt into (e.g. rgt).
+	Optional bool
+	// SuppressIfAny lists Check names that, when satisfied (StatusOK or
+	// StatusDegraded), cause this Check's Missing result to be filtered
+	// from the displayed set. Use for interchangeable tools where any one
+	// is enough (e.g. gh and glab — users on GitHub don't need glab).
+	// Has no effect when this check itself is OK/Degraded/NA.
+	SuppressIfAny []string
+}
+
+// Reported pairs a Check with its Probe Result.
+type Reported struct {
+	Check  Check
+	Result Result
+}
+
+// runAll executes the given checks. Probes always run so installed tools
+// are recognized as green even when the user's config doesn't strictly
+// "need" them (e.g. sbx installed but no sandbox-mode repo configured).
+// The Applies callback is consulted by ApplyVisibility, not here, so
+// Result.Status reflects the on-machine truth.
+func runAll(cfg *config.Config, checks []Check) []Reported {
+	out := make([]Reported, len(checks))
+	for i, c := range checks {
+		if c.Probe == nil {
+			out[i] = Reported{Check: c, Result: Result{Status: StatusMissing, Note: "no probe defined"}}
+			continue
+		}
+		out[i] = Reported{Check: c, Result: c.Probe()}
+	}
+	// Hint to keep cfg referenced; ApplyVisibility uses it later. Avoids
+	// touching cfg here so cache invalidation stays driven by pointer
+	// identity (see Cache.Get).
+	_ = cfg
+	return out
+}
+
+// RunAll runs the default registry against cfg.
+func RunAll(cfg *config.Config) []Reported {
+	return runAll(cfg, Registry())
+}
+
+// ApplyVisibility hides Missing entries whose Applies callback reports that
+// the tool is not relevant to the user's current configuration (e.g. sbx
+// when no repo uses sandbox mode). Installed tools (OK/Degraded) always
+// show — they're informational, never noise. Returns a new slice.
+func ApplyVisibility(reps []Reported, cfg *config.Config) []Reported {
+	out := make([]Reported, 0, len(reps))
+	for _, r := range reps {
+		if r.Result.Status == StatusMissing && r.Check.Applies != nil && !r.Check.Applies(cfg) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// Counts summarizes a slice of Reported.
+type Counts struct {
+	OK       int
+	Degraded int
+	Missing  int
+	NA       int
+}
+
+// Total is OK + Degraded + Missing (i.e. not N/A) — the denominator for the
+// "Dependencies: N/M ✓" systray summary.
+func (c Counts) Total() int { return c.OK + c.Degraded + c.Missing }
+
+// Partition splits Reported into a primary list and an optional list. An
+// Optional check that is currently Missing belongs in optional; everything
+// else (including an Optional check that the user has now installed) goes
+// in primary. Order within each list matches the input order.
+func Partition(reps []Reported) (primary, optional []Reported) {
+	for _, r := range reps {
+		if r.Check.Optional && r.Result.Status == StatusMissing {
+			optional = append(optional, r)
+			continue
+		}
+		primary = append(primary, r)
+	}
+	return primary, optional
+}
+
+// ApplySuppression filters out Missing entries whose SuppressIfAny list
+// contains the name of another check that is currently OK or Degraded.
+// Used to hide redundant CLIs — e.g. glab Missing is hidden when gh is
+// installed, since users on one provider don't need the other. Returns
+// a new slice; the input is not mutated.
+func ApplySuppression(reps []Reported) []Reported {
+	satisfied := make(map[string]bool, len(reps))
+	for _, r := range reps {
+		if r.Result.Status == StatusOK || r.Result.Status == StatusDegraded {
+			satisfied[r.Check.Name] = true
+		}
+	}
+	out := make([]Reported, 0, len(reps))
+	for _, r := range reps {
+		if r.Result.Status == StatusMissing && hasSatisfied(r.Check.SuppressIfAny, satisfied) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func hasSatisfied(names []string, satisfied map[string]bool) bool {
+	for _, n := range names {
+		if satisfied[n] {
+			return true
+		}
+	}
+	return false
+}
+
+// Summarize tallies a slice of Reported.
+func Summarize(reps []Reported) Counts {
+	var c Counts
+	for _, r := range reps {
+		switch r.Result.Status {
+		case StatusOK:
+			c.OK++
+		case StatusDegraded:
+			c.Degraded++
+		case StatusMissing:
+			c.Missing++
+		case StatusNA:
+			c.NA++
+		}
+	}
+	return c
+}
+
+// Cache memoizes Probe results for a fixed TTL so opening the systray menu
+// or the dialog doesn't re-exec on every interaction. The cache is keyed
+// implicitly by the Config pointer — if the caller swaps the config (e.g.
+// after a repo add), the cache invalidates automatically. Callers can also
+// force a re-probe via Invalidate.
+type Cache struct {
+	mu     sync.Mutex
+	ttl    time.Duration
+	last   time.Time
+	cfg    *config.Config
+	data   []Reported
+	checks []Check // optional override for tests
+}
+
+// NewCache returns a Cache with the given TTL.
+func NewCache(ttl time.Duration) *Cache {
+	return &Cache{ttl: ttl}
+}
+
+// Get returns memoized results, refreshing if the TTL has expired or the
+// config pointer differs from the previous call.
+func (c *Cache) Get(cfg *config.Config) []Reported {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.data != nil && c.cfg == cfg && time.Since(c.last) < c.ttl {
+		return c.data
+	}
+	checks := c.checks
+	if checks == nil {
+		checks = Registry()
+	}
+	c.data = runAll(cfg, checks)
+	c.last = time.Now()
+	c.cfg = cfg
+	return c.data
+}
+
+// Invalidate forces the next Get to re-probe.
+func (c *Cache) Invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = nil
+}
+
+// SetChecks substitutes the registry used by Get. Intended for tests.
+func (c *Cache) SetChecks(checks []Check) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.checks = checks
+	c.data = nil
+}

--- a/internal/sysdeps/sysdeps_test.go
+++ b/internal/sysdeps/sysdeps_test.go
@@ -1,0 +1,397 @@
+package sysdeps
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mdelapenya/biomelab/internal/config"
+)
+
+func TestStatusString(t *testing.T) {
+	tests := []struct {
+		s    Status
+		want string
+	}{
+		{StatusOK, "ok"},
+		{StatusDegraded, "degraded"},
+		{StatusMissing, "missing"},
+		{StatusNA, "n/a"},
+		{Status(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.s.String(); got != tt.want {
+			t.Errorf("Status(%d).String() = %q, want %q", tt.s, got, tt.want)
+		}
+	}
+}
+
+func TestRunAll_ProbesEvenWhenAppliesFalse(t *testing.T) {
+	// Probes always run, regardless of Applies. The visibility decision
+	// is made later by ApplyVisibility — that way installed tools show
+	// as green even when the user's config doesn't strictly need them.
+	called := false
+	checks := []Check{
+		{
+			Name:    "skip-me",
+			Applies: func(*config.Config) bool { return false },
+			Probe: func() Result {
+				called = true
+				return Result{Status: StatusOK, Version: "1.0"}
+			},
+		},
+	}
+	got := runAll(&config.Config{}, checks)
+	if !called {
+		t.Error("Probe must run even when Applies returns false")
+	}
+	if got[0].Result.Status != StatusOK {
+		t.Errorf("Status = %v, want StatusOK (probe truth)", got[0].Result.Status)
+	}
+}
+
+func TestApplyVisibility(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []Reported
+		want []string // surviving check names, in order
+	}{
+		{
+			name: "installed tool with applies=false stays visible",
+			in: []Reported{
+				{
+					Check:  Check{Name: "sbx", Applies: func(*config.Config) bool { return false }},
+					Result: Result{Status: StatusOK, Version: "v0.29.0"},
+				},
+			},
+			want: []string{"sbx"},
+		},
+		{
+			name: "missing tool with applies=false is hidden",
+			in: []Reported{
+				{
+					Check:  Check{Name: "sbx", Applies: func(*config.Config) bool { return false }},
+					Result: Result{Status: StatusMissing},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "missing tool with applies=true stays visible",
+			in: []Reported{
+				{
+					Check:  Check{Name: "sbx", Applies: func(*config.Config) bool { return true }},
+					Result: Result{Status: StatusMissing},
+				},
+			},
+			want: []string{"sbx"},
+		},
+		{
+			name: "missing tool with nil Applies stays visible (Applies absent ⇒ always applies)",
+			in: []Reported{
+				{Check: Check{Name: "gh"}, Result: Result{Status: StatusMissing}},
+			},
+			want: []string{"gh"},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplyVisibility(tt.in, &config.Config{})
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d entries, want %d", len(got), len(tt.want))
+			}
+			for i, w := range tt.want {
+				if got[i].Check.Name != w {
+					t.Errorf("got[%d] = %q, want %q", i, got[i].Check.Name, w)
+				}
+			}
+		})
+	}
+}
+
+func TestRunAll_NilApplies(t *testing.T) {
+	// Applies=nil means always applies.
+	checks := []Check{
+		{Name: "always", Probe: func() Result { return Result{Status: StatusOK, Version: "1.0"} }},
+	}
+	got := runAll(&config.Config{}, checks)
+	if got[0].Result.Status != StatusOK {
+		t.Errorf("Status = %v, want StatusOK", got[0].Result.Status)
+	}
+	if got[0].Result.Version != "1.0" {
+		t.Errorf("Version = %q, want 1.0", got[0].Result.Version)
+	}
+}
+
+func TestRunAll_NilProbe(t *testing.T) {
+	// A Check with no Probe should not panic; it produces a Missing result
+	// with a note so the bug surfaces in the UI rather than a crash.
+	checks := []Check{{Name: "no-probe"}}
+	got := runAll(&config.Config{}, checks)
+	if got[0].Result.Status != StatusMissing {
+		t.Errorf("Status = %v, want StatusMissing", got[0].Result.Status)
+	}
+	if got[0].Result.Note == "" {
+		t.Error("Note is empty; want explanation for missing probe")
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	reps := []Reported{
+		{Result: Result{Status: StatusOK}},
+		{Result: Result{Status: StatusOK}},
+		{Result: Result{Status: StatusDegraded}},
+		{Result: Result{Status: StatusMissing}},
+		{Result: Result{Status: StatusNA}},
+	}
+	c := Summarize(reps)
+	if c.OK != 2 || c.Degraded != 1 || c.Missing != 1 || c.NA != 1 {
+		t.Errorf("Summarize = %+v", c)
+	}
+	if c.Total() != 4 {
+		t.Errorf("Total() = %d, want 4 (excludes N/A)", c.Total())
+	}
+}
+
+func TestCache_MemoizesWithinTTL(t *testing.T) {
+	var calls atomic.Int32
+	checks := []Check{
+		{
+			Name: "counted",
+			Probe: func() Result {
+				calls.Add(1)
+				return Result{Status: StatusOK}
+			},
+		},
+	}
+	cache := NewCache(time.Hour)
+	cache.SetChecks(checks)
+
+	cfg := &config.Config{}
+	cache.Get(cfg)
+	cache.Get(cfg)
+	cache.Get(cfg)
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("Probe calls = %d, want 1 (memoized)", got)
+	}
+}
+
+func TestCache_InvalidateForcesReProbe(t *testing.T) {
+	var calls atomic.Int32
+	checks := []Check{
+		{Name: "x", Probe: func() Result {
+			calls.Add(1)
+			return Result{Status: StatusOK}
+		}},
+	}
+	cache := NewCache(time.Hour)
+	cache.SetChecks(checks)
+
+	cfg := &config.Config{}
+	cache.Get(cfg)
+	cache.Invalidate()
+	cache.Get(cfg)
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("Probe calls = %d, want 2 (post-invalidate re-probe)", got)
+	}
+}
+
+func TestCache_ConfigChangeInvalidates(t *testing.T) {
+	var calls atomic.Int32
+	checks := []Check{
+		{Name: "x", Probe: func() Result {
+			calls.Add(1)
+			return Result{Status: StatusOK}
+		}},
+	}
+	cache := NewCache(time.Hour)
+	cache.SetChecks(checks)
+
+	cfgA := &config.Config{}
+	cfgB := &config.Config{}
+	cache.Get(cfgA)
+	cache.Get(cfgB) // pointer differs → re-probe
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("Probe calls = %d, want 2", got)
+	}
+}
+
+func TestHasSandboxRepo(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"no repos", &config.Config{}, false},
+		{
+			"regular-only",
+			&config.Config{Repos: []config.RepoEntry{
+				{Modes: []config.ModeEntry{{Type: "regular"}}},
+			}},
+			false,
+		},
+		{
+			"one sandbox",
+			&config.Config{Repos: []config.RepoEntry{
+				{Modes: []config.ModeEntry{{Type: "regular"}}},
+				{Modes: []config.ModeEntry{{Type: "sandbox"}}},
+			}},
+			true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasSandboxRepo(tt.cfg); got != tt.want {
+				t.Errorf("hasSandboxRepo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegistryContents(t *testing.T) {
+	want := []string{"rgt", "gh", "glab", "sbx"}
+	got := Registry()
+	if len(got) != len(want) {
+		t.Fatalf("Registry() returned %d checks, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Errorf("Registry()[%d].Name = %q, want %q", i, got[i].Name, w)
+		}
+	}
+}
+
+func TestRegistry_OptionalSet(t *testing.T) {
+	// Only rgt is currently Optional. Optional checks live in the
+	// dialog's "Optional tools" expander while missing, and auto-promote
+	// to the main list once detected.
+	for _, c := range Registry() {
+		if c.Name == "rgt" && !c.Optional {
+			t.Error("rgt should be Optional")
+		}
+		if c.Name != "rgt" && c.Optional {
+			t.Errorf("%s is Optional but should not be", c.Name)
+		}
+	}
+}
+
+func TestApplySuppression(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []Reported
+		want []string // expected check names in result, in order
+	}{
+		{
+			name: "missing glab is hidden when gh is installed",
+			in: []Reported{
+				{Check: Check{Name: "gh"}, Result: Result{Status: StatusOK}},
+				{Check: Check{Name: "glab", SuppressIfAny: []string{"gh"}}, Result: Result{Status: StatusMissing}},
+			},
+			want: []string{"gh"},
+		},
+		{
+			name: "missing gh is hidden when glab is installed",
+			in: []Reported{
+				{Check: Check{Name: "gh", SuppressIfAny: []string{"glab"}}, Result: Result{Status: StatusMissing}},
+				{Check: Check{Name: "glab"}, Result: Result{Status: StatusOK}},
+			},
+			want: []string{"glab"},
+		},
+		{
+			name: "both missing — neither is suppressed",
+			in: []Reported{
+				{Check: Check{Name: "gh", SuppressIfAny: []string{"glab"}}, Result: Result{Status: StatusMissing}},
+				{Check: Check{Name: "glab", SuppressIfAny: []string{"gh"}}, Result: Result{Status: StatusMissing}},
+			},
+			want: []string{"gh", "glab"},
+		},
+		{
+			name: "degraded counts as satisfied",
+			in: []Reported{
+				{Check: Check{Name: "gh"}, Result: Result{Status: StatusDegraded}},
+				{Check: Check{Name: "glab", SuppressIfAny: []string{"gh"}}, Result: Result{Status: StatusMissing}},
+			},
+			want: []string{"gh"},
+		},
+		{
+			name: "suppression does not affect OK entries",
+			in: []Reported{
+				{Check: Check{Name: "gh"}, Result: Result{Status: StatusOK}},
+				{Check: Check{Name: "glab", SuppressIfAny: []string{"gh"}}, Result: Result{Status: StatusOK}},
+			},
+			want: []string{"gh", "glab"},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplySuppression(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d entries, want %d (%v)", len(got), len(tt.want), tt.want)
+			}
+			for i, w := range tt.want {
+				if got[i].Check.Name != w {
+					t.Errorf("got[%d] = %q, want %q", i, got[i].Check.Name, w)
+				}
+			}
+		})
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	// Sample copied from a real `rgt version` invocation, which embeds
+	// 256-color CSI sequences around the tool name. The output should
+	// reduce to plain text.
+	in := "\x1b[38;5;141mre_gent\x1b[0m version dev (commit: unknown)"
+	want := "re_gent version dev (commit: unknown)"
+	if got := stripANSI(in); got != want {
+		t.Errorf("stripANSI() = %q, want %q", got, want)
+	}
+}
+
+func TestPartition(t *testing.T) {
+	reps := []Reported{
+		{Check: Check{Name: "gh"}, Result: Result{Status: StatusOK}},
+		{Check: Check{Name: "rgt", Optional: true}, Result: Result{Status: StatusMissing}},
+		{Check: Check{Name: "sbx"}, Result: Result{Status: StatusDegraded}},
+		{Check: Check{Name: "rgt2", Optional: true}, Result: Result{Status: StatusOK}},
+	}
+	primary, optional := Partition(reps)
+
+	if len(primary) != 3 {
+		t.Fatalf("primary len = %d, want 3 (gh, sbx, rgt2)", len(primary))
+	}
+	wantPrimary := []string{"gh", "sbx", "rgt2"}
+	for i, w := range wantPrimary {
+		if primary[i].Check.Name != w {
+			t.Errorf("primary[%d] = %q, want %q", i, primary[i].Check.Name, w)
+		}
+	}
+	if len(optional) != 1 || optional[0].Check.Name != "rgt" {
+		t.Errorf("optional = %+v, want [rgt]", optional)
+	}
+}
+
+func TestCache_TTLExpiry(t *testing.T) {
+	var calls atomic.Int32
+	checks := []Check{
+		{Name: "x", Probe: func() Result {
+			calls.Add(1)
+			return Result{Status: StatusOK}
+		}},
+	}
+	cache := NewCache(10 * time.Millisecond)
+	cache.SetChecks(checks)
+
+	cfg := &config.Config{}
+	cache.Get(cfg)
+	time.Sleep(30 * time.Millisecond)
+	cache.Get(cfg)
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("Probe calls = %d, want 2 (post-TTL re-probe)", got)
+	}
+}

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -675,8 +675,21 @@ nav .container {
   margin-top: 3rem
 }
 
+/*
+ * Center the cards instead of left-aligning them with a CSS grid. A flex
+ * row with wrap + justify-content: center lets partial rows (e.g. 6
+ * cards = 4 + 2) sit centered in the container, with each card capped at
+ * 280px so wide viewports don't stretch the cards into oversized blocks.
+ */
 .dashboard-features {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center
+}
+
+.dashboard-features .feature-card {
+  flex: 1 1 240px;
+  max-width: 280px
 }
 
 .sandbox-grid {
@@ -1089,9 +1102,14 @@ nav .container {
   }
 }
 
+/*
+ * Centered flex-wrap so a partial last row of workflow steps lands in
+ * the middle of the section instead of pinned to one side.
+ */
 .workflow-steps {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 1.25rem;
   margin-top: 3rem
 }
@@ -1100,7 +1118,9 @@ nav .container {
   display: flex;
   gap: 1rem;
   align-items: flex-start;
-  padding: 1.4rem
+  padding: 1.4rem;
+  flex: 1 1 300px;
+  max-width: 360px
 }
 
 .step-number {
@@ -1362,9 +1382,15 @@ nav .container {
   font-family: var(--font-mono)
 }
 
+/*
+ * Same pattern as .dashboard-features: flex-wrap + justify-content:
+ * center so partial rows (e.g. 14 keybindings = 5 + 5 + 4) sit centered
+ * instead of left-aligned with empty slots on the right.
+ */
 .keyboard-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 1rem;
   margin-top: 3rem
 }
@@ -1373,7 +1399,9 @@ nav .container {
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding: .85rem 1rem
+  padding: .85rem 1rem;
+  flex: 1 1 210px;
+  max-width: 260px
 }
 
 .key-cap {

--- a/website/index.html
+++ b/website/index.html
@@ -167,6 +167,14 @@
           <h3>Live status</h3>
           <p>Dirty/clean, sync status, PR/MR with CI checks. Refreshed automatically every 5 seconds.</p>
         </div>
+        <div class="feature-card"><span class="icon">🎞</span>
+          <h3>Agent audit trail</h3>
+          <p><a href="https://github.com/regent-vcs/re_gent" target="_blank" rel="noopener">re_gent</a> integration. See every prompt, reply, and tool call per session. Press <code>l</code> to open the activity window; export raw JSON in one click.</p>
+        </div>
+        <div class="feature-card"><span class="icon">🩺</span>
+          <h3>System dependencies</h3>
+          <p>One systray entry shows the status of every CLI biomelab uses (<code>gh</code>, <code>glab</code>, <code>sbx</code>, <code>rgt</code>) with install hints and docs — no more guessing why a feature is grey.</p>
+        </div>
       </div>
     </div>
   </section>
@@ -742,6 +750,7 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
         <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span></div>
         <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span></div>
         <div class="key-item"><span class="key-cap key-yellow">m</span><span class="key-action">Open note editor</span></div>
+        <div class="key-item"><span class="key-cap key-magenta">l</span><span class="key-action">Open regent log</span></div>
         <div class="key-item"><span class="key-cap key-blue">f</span><span class="key-action">Fetch PR / MR</span></div>
         <div class="key-item"><span class="key-cap key-cyan">g</span><span class="key-action">Toggle kanban / grid</span></div>
         <div class="key-item"><span class="key-cap">n</span><span class="key-action">New sandbox</span></div>


### PR DESCRIPTION
## What's changed

Integrates [re_gent](https://github.com/regent-vcs/re_gent) — an audit log for AI agent activity — into biomelab. Every regular-mode worktree gets its own `.regent/` capturing each agent turn (prompts, replies, tool calls), with an in-app log viewer and JSON export.

Adds a **System Dependencies** dialog (systray entry + first-run banner) that shows the status of every external CLI biomelab relies on: `gh`, `glab`, `sbx`, and now `rgt`. Replaces the ad-hoc `warnSbxMissing` startup popup with a single discoverable surface that covers every tool.

The integration is opt-in by install: biomelab does nothing until `rgt` is on `PATH`. Once it is, hooks are installed automatically into `.claude/settings.json` on the next refresh — no terminal step required.

## Why is this important?

Biomelab already showed *that* an agent was running on a worktree. With re_gent it can show *what the agent did* — which prompts produced which changes, every tool call, the full session graph. That's the missing primitive for post-hoc analysis (diagnostics, fleet forensics, benchmarking) and for users curious about agent activity inside their own repos.

The Dependencies dialog gives `rgt` and the other CLIs a single discoverable home. Users on GitHub-only repos no longer see noisy "glab missing" warnings (suppression), and missing tools that don't apply to the user's config are hidden entirely.

## Changes

### `internal/regent/` (new)

- `regent.go` — filesystem detection (`Inspect`) of `.regent/`.
- `init.go` — `EnsureInit(wtPath)` runs `rgt init --skip-hook --skip-skills`, then `EnsureClaudeHooks`, then writes the git `info/exclude` entry. Idempotent.
- `hooks.go` — `EnsureClaudeHooks(wtPath)` writes Claude Code hook entries (`UserPromptSubmit`, `Stop`, `PostToolBatch`) into `.claude/settings.json`. Ported from rgt's own installer (Apache-2.0, attributed) because rgt's interactive installer needs a TTY biomelab can't provide.
- `log.go` / `log_json.go` — `Log(wtPath, limit)` for ANSI-stripped text and `LogJSON` / `LogJSONRaw` for structured parsing + export.

### `internal/sysdeps/` (new)

- `Check`, `Result`, `Status`, `Cache` types and a default registry covering `rgt`, `gh`, `glab`, `sbx`.
- `Partition` (`Optional` checks live in a separate section while missing), `ApplySuppression` (a missing `glab` is hidden when `gh` is installed, and vice versa), `ApplyVisibility` (hides missing entries whose `Applies` callback says the tool isn't relevant).
- ANSI-stripped version probes for tools that color their output (e.g. `rgt version`).

### `internal/git/exclude.go` (new) + `internal/notes/notes.go` refactor

- `git.EnsureExcluded(worktreeDir, line)` extracted from `internal/notes`. Both `notes` and `regent` now go through one helper for the per-worktree `info/exclude` resolution. The `git → notes` import was removed to avoid a cycle.

### GUI

- `internal/gui/sysdeps_dialog.go` — modal listing every check with status dot, version on its own line (1pt smaller), reason, copy-install-cmd, and Docs button. Optional tools section at the bottom. Re-check button refreshes the systray summary too.
- `internal/gui/regent_log_dialog.go` — single top-level resizable window (reused across cards), structured renderer with `Human` / `Agent` rows + collapsible tool list (full paths, no truncation), **Export JSON…** button.
- `internal/gui/save_file.go` — OS-native save dialog (osascript on macOS, zenity / kdialog on Linux, PowerShell on Windows) with Fyne fallback. Used by the export flow.
- `internal/gui/systray.go` — `Dependencies: N/M ✓` (or `N/M (X need attention)`) menu entry opens the dialog.
- `internal/gui/app.go` — first-run banner above the dashboard split when a primary dep is missing or degraded; old sbx-specific popup removed. Single-window tracking (`regentLogWindow` + `regentLogReload`).
- `internal/gui/shortcuts.go` — `l` opens the regent log for the selected card. Help bar updated.

### Ops integration

- `ops.CreateWorktree` calls `regent.EnsureInit` after creating a host worktree. Sandbox worktrees skip it (rgt is meant to be installed inside the container via the regent kit, not on the host).
- `app.buildRepoEntry` runs `migrateRegentForRepo` for any repo with a non-sandbox mode so existing worktrees gain `.regent/` and hooks on biomelab startup.

### Docs

- `README.md` — new feature bullets for **Agent audit trail** and **System dependencies dialog**.
- `website/index.html` — two new feature-cards in the dashboard grid (🎞 audit trail, 🩺 system dependencies).
- `ARCHITECTURE.md` — package layout updated, two new sections (`## re_gent integration`, `## System dependencies`), and five new pitfalls (rgt path-arg quirk, hook-installer TTY, Accordion-in-VScroll, single regent window).
- `CLAUDE.md` — new `rgt CLI` dependency entry, expanded package layout (regent, sysdeps, notes), and matching pitfalls for future AI sessions.

## Test plan

- [x] `task build && task test && task lint` all clean.
- [x] Launch biomelab without `rgt` installed → no nag. Dependencies dialog shows `rgt` in the "Optional tools" section.
- [x] `brew install regent` (or equivalent) → on next biomelab start, `.regent/` is created in every regular-mode worktree, `.claude/settings.json` gains the three hook entries, `git status` does not show `.regent/`.
- [x] Run a Claude Code session in any worktree → press `l` → window opens with `sha · timestamp · origin` headers, `Human` and `Agent` rows, `▶ N tools` toggle expanding to full file paths.
- [x] Press `l` on a different card → the same window updates content (no duplicate).
- [x] Click **Export JSON…** → native OS save dialog → resulting `.json` matches `rgt log --json` byte-for-byte.
- [x] Open Dependencies dialog with only `gh` installed → no missing-`glab` row. Install `glab` → re-check → both rows show OK.
- [ ] Restart biomelab with `sbx` uninstalled and a sandbox-mode repo registered → banner appears, dialog flags `sbx` as missing; remove sandbox mode → `sbx` row disappears.
