### PR TITLE
feat(web): interactive playground for biomelab features

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -2378,3 +2378,141 @@ footer {
 /* Body scroll lock while modal is open + click affordance on cards. */
 body.rgt-modal-open { overflow: hidden }
 .kb-card[data-kb] { cursor: pointer }
+
+/* ──────────────────────────────────────────────────────────────────────
+ * Keyboard simulator — interactive demo bits: selected-card outline,
+ * card create/delete/refresh animations, toast notifications, and the
+ * note editor modal (split-pane Markdown editor + live preview).
+ * ────────────────────────────────────────────────────────────────────── */
+
+.kb-card.kb-selected {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+  position: relative;
+  z-index: 1
+}
+
+@keyframes kbPulse {
+  0%   { box-shadow: 0 0 0 0 rgba(0, 212, 255, .55) }
+  100% { box-shadow: 0 0 0 12px rgba(0, 212, 255, 0) }
+}
+.kb-card.kb-pulse { animation: kbPulse .6s ease-out }
+
+@keyframes kbEnter {
+  from { opacity: 0; transform: translateY(-6px) scale(.97) }
+  to   { opacity: 1; transform: none }
+}
+.kb-card.kb-enter { animation: kbEnter .28s ease both }
+
+@keyframes kbExit {
+  from { opacity: 1; max-height: 200px; margin-bottom: 1rem }
+  to   { opacity: 0; max-height: 0;     margin: 0; padding: 0 }
+}
+.kb-card.kb-exit {
+  overflow: hidden;
+  animation: kbExit .28s ease both
+}
+
+/* Toast notification — bottom-right transient feedback */
+.kb-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: .65rem 1.05rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  font-family: var(--font-mono);
+  font-size: .85rem;
+  color: var(--text-primary);
+  z-index: 200;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity .2s ease, transform .2s ease;
+  pointer-events: none
+}
+.kb-toast.open { opacity: 1; transform: none }
+.kb-toast[hidden] { display: none }
+
+/* Key-cap hover state to cue clickability */
+.keyboard-grid .key-item { transition: transform .15s ease, background .15s ease }
+.keyboard-grid .key-item:hover {
+  transform: translateY(-1px);
+  background: var(--bg-card-hover)
+}
+.keyboard-grid .key-item:active { transform: translateY(0) }
+
+/* ── Note editor modal ─────────────────────────────────────────────── */
+
+.note-modal-window .note-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  height: 100%
+}
+.note-pane {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  overflow: hidden
+}
+.note-pane-head {
+  padding: .45rem .75rem;
+  font-family: var(--font-mono);
+  font-size: .8rem;
+  color: var(--branch, var(--magenta));
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+  font-weight: 700
+}
+#note-entry {
+  flex: 1;
+  width: 100%;
+  resize: none;
+  background: transparent;
+  color: var(--text-primary);
+  border: 0;
+  padding: .8rem;
+  font-family: var(--font-mono);
+  font-size: .9rem;
+  line-height: 1.5;
+  outline: none
+}
+#note-preview {
+  flex: 1;
+  overflow-y: auto;
+  padding: .8rem;
+  color: var(--text-primary);
+  font-size: .92rem;
+  line-height: 1.55
+}
+#note-preview h2 { font-size: 1.1rem; margin: 0 0 .5rem }
+#note-preview h3 { font-size: 1rem;   margin: .6rem 0 .35rem }
+#note-preview h4 { font-size: .92rem; margin: .5rem 0 .3rem }
+#note-preview code {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 .3rem;
+  font-family: var(--font-mono);
+  font-size: .85rem;
+  color: var(--cyan)
+}
+#note-preview ul { margin: .35rem 0 .35rem 1.2rem; padding: 0 }
+#note-preview li { margin: .15rem 0 }
+
+/* Reuse the regent-modal scaffolding for the note modal — same overlay,
+   same window chrome — but size the split area larger. */
+.note-modal-window .rgt-modal-body {
+  padding: 1rem;
+  min-height: 480px
+}
+@media (max-width: 720px) {
+  .note-modal-window .note-split {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr
+  }
+}

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -2385,7 +2385,8 @@ body.rgt-modal-open { overflow: hidden }
  * note editor modal (split-pane Markdown editor + live preview).
  * ────────────────────────────────────────────────────────────────────── */
 
-.kb-card.kb-selected {
+.kb-card.kb-selected,
+.kb-main-card.kb-selected {
   outline: 2px solid var(--cyan);
   outline-offset: 2px;
   position: relative;
@@ -2396,7 +2397,10 @@ body.rgt-modal-open { overflow: hidden }
   0%   { box-shadow: 0 0 0 0 rgba(0, 212, 255, .55) }
   100% { box-shadow: 0 0 0 12px rgba(0, 212, 255, 0) }
 }
-.kb-card.kb-pulse { animation: kbPulse .6s ease-out }
+.kb-card.kb-pulse,
+.kb-main-card.kb-pulse { animation: kbPulse .6s ease-out }
+
+.kb-main-card[data-kb] { cursor: pointer }
 
 @keyframes kbEnter {
   from { opacity: 0; transform: translateY(-6px) scale(.97) }
@@ -2435,13 +2439,18 @@ body.rgt-modal-open { overflow: hidden }
 .kb-toast.open { opacity: 1; transform: none }
 .kb-toast[hidden] { display: none }
 
-/* Key-cap hover state to cue clickability */
-.keyboard-grid .key-item { transition: transform .15s ease, background .15s ease }
-.keyboard-grid .key-item:hover {
+/* Key-cap hover state to cue clickability — applies in both the
+   landing page grid and the cloned grid inside the '?' help modal. */
+.key-item { cursor: pointer; transition: transform .15s ease, background .15s ease }
+.key-item:hover {
   transform: translateY(-1px);
   background: var(--bg-card-hover)
 }
-.keyboard-grid .key-item:active { transform: translateY(0) }
+.key-item:active { transform: translateY(0) }
+
+/* '?' help modal body: clone of .keyboard-grid sits flush against the
+   modal padding rather than carrying the section's top margin. */
+#kb-help-body .keyboard-grid { margin-top: 0 }
 
 /* ── Note editor modal ─────────────────────────────────────────────── */
 
@@ -2515,4 +2524,195 @@ body.rgt-modal-open { overflow: hidden }
     grid-template-columns: 1fr;
     grid-template-rows: 1fr 1fr
   }
+}
+
+/* ──────────────────────────────────────────────────────────────────────
+ * Fake terminal modal — Matrix opening sequence easter egg.
+ *
+ * Window chrome (head / footer / borders) inherits the theme like any
+ * other modal: feels like part of the site, dark/light toggle works.
+ * Only the BODY (the actual terminal content area) is theme-locked
+ * to phosphor green on black — that's the "DOPE" bit the user wants.
+ * ────────────────────────────────────────────────────────────────────── */
+
+.term-modal-window .rgt-modal-body {
+  background: #000;
+  padding: 1.5rem 1.8rem;
+  min-height: 320px
+}
+
+.term-output {
+  margin: 0;
+  color: #00ff66;
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1.6;
+  text-shadow: 0 0 4px rgba(0, 255, 102, .35);
+  white-space: pre-wrap;
+  word-break: break-word
+}
+
+.term-cursor {
+  display: inline-block;
+  width: .55em;
+  height: 1em;
+  background: #00ff66;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  box-shadow: 0 0 6px rgba(0, 255, 102, .6);
+  animation: termBlink 1s steps(2, end) infinite
+}
+
+@keyframes termBlink {
+  to { visibility: hidden }
+}
+
+/* Inline branch-name editor shown right after creating a card so the
+ * user can type a real name. Sized to look like the static
+ * .kb-branch span it replaces, with a thin cyan border to cue
+ * editability. */
+.kb-branch-edit {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--cyan);
+  border-radius: 4px;
+  padding: .15rem .4rem;
+  font-family: var(--font-mono);
+  font-size: .82rem;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(0, 212, 255, .18)
+}
+.kb-branch-edit:focus { border-color: var(--cyan) }
+
+/* Horizontal "main worktree" card shown above both kanban and grid
+ * views — mirrors biomelab's GUI where the main worktree sits as a
+ * full-width card at the top of the dashboard with a thicker stroke.
+ * Decorative on the demo (not part of STATE.cards). */
+.kb-main-card {
+  display: flex;
+  align-items: center;
+  gap: .85rem;
+  padding: .8rem 1.1rem;
+  margin-bottom: 1.1rem;
+  background: var(--bg-card);
+  border: 2px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: var(--shadow-soft);
+  flex-wrap: wrap
+}
+.kb-main-card .kb-branch {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  color: var(--magenta);
+  font-size: .92rem
+}
+.kb-main-badge {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: .68rem;
+  padding: .05rem .4rem;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: .04em
+}
+.kb-main-path {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: .82rem;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap
+}
+.kb-main-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.1rem;
+  font-family: var(--font-mono);
+  font-size: .8rem
+}
+.kb-main-meta .kb-sync,
+.kb-main-meta .kb-status {
+  color: var(--text-secondary)
+}
+.kb-main-meta .kb-sync-up { color: var(--green) }
+.kb-main-meta .kb-sync-behind { color: var(--yellow) }
+.kb-main-meta .kb-status-clean { color: var(--green) }
+
+/* Confirm dialog — narrower than other modals, body preserves the
+ * \n\n in the message text so the warning + detail line read as two
+ * paragraphs without HTML. */
+.confirm-modal-window .rgt-modal-window { width: min(480px, 92vw) }
+.confirm-modal-window .rgt-modal-body {
+  padding: 1.2rem 1.4rem;
+  color: var(--text-primary);
+  white-space: pre-line;
+  line-height: 1.5
+}
+.confirm-modal-window .rgt-modal-foot {
+  display: flex;
+  gap: .6rem;
+  justify-content: flex-end
+}
+.confirm-btn {
+  border: 0;
+  border-radius: 6px;
+  padding: .45rem .95rem;
+  font-size: .9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter .15s ease, background .15s ease
+}
+.confirm-no {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border)
+}
+.confirm-no:hover { background: var(--bg-card-hover) }
+.confirm-yes {
+  background: var(--red);
+  color: #fff
+}
+.confirm-yes:hover { filter: brightness(1.1) }
+
+/* Editor splash modal — sibling of the terminal modal. Same dark
+ * "tactile machine" body, cyan accent instead of phosphor green so
+ * the two surfaces read as different tools without diverging in
+ * aesthetic. */
+.editor-modal-window .rgt-modal-body {
+  background: #000;
+  padding: 1.5rem 1.8rem;
+  /* Pre-reserve enough height for the full boot + quote so adding
+     lines via the typewriter doesn't grow the window mid-animation. */
+  min-height: 460px
+}
+.editor-output {
+  margin: 0;
+  color: #5cf1ff;
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1.6;
+  text-shadow: 0 0 4px rgba(92, 241, 255, .35);
+  white-space: pre-wrap;
+  word-break: break-word
+}
+.editor-output .ed-dim { color: #2a7d8d }
+.editor-output .ed-quote {
+  color: #aef5ff;
+  font-style: italic
+}
+.editor-cursor {
+  display: inline-block;
+  width: .55em;
+  height: 1em;
+  background: #5cf1ff;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  box-shadow: 0 0 6px rgba(92, 241, 255, .6);
+  animation: termBlink 1s steps(2, end) infinite
 }

--- a/website/index.html
+++ b/website/index.html
@@ -53,8 +53,8 @@
         <li><a href="#dashboard">Dashboard</a></li>
         <li><a href="#sandboxes">Sandboxes</a></li>
         <li><a href="#workflow">Workflow</a></li>
+        <li><a href="#playground">Playground</a></li>
         <li><a href="#notes">Notes</a></li>
-        <li><a href="#kanban">Kanban</a></li>
         <li><a href="#install">Install</a></li>
         <li>
           <a href="https://github.com/mdelapenya/biomelab" class="nav-github" target="_blank" rel="noopener">
@@ -174,6 +174,10 @@
         <div class="feature-card"><span class="icon">🩺</span>
           <h3>System dependencies</h3>
           <p>One systray entry shows the status of every CLI biomelab uses (<code>gh</code>, <code>glab</code>, <code>sbx</code>, <code>rgt</code>) with install hints and docs — no more guessing why a feature is grey.</p>
+        </div>
+        <div class="feature-card"><span class="icon">⌨️</span>
+          <h3>Keyboard-first</h3>
+          <p>Every action is a single keystroke; full mouse support built in. Press <code>?</code> anywhere on the page for the cheatsheet.</p>
         </div>
       </div>
     </div>
@@ -339,62 +343,29 @@
     </div>
   </section>
 
-  <section id="notes" class="notes">
+  <section id="playground" class="kanban-board">
     <div class="container">
-      <span class="section-label">Task Notes</span>
-      <h2>Brief your agent, draft your PR — <span class="notes-accent">in the same place</span></h2>
-      <p class="notes-intro">A Markdown editor scoped to each worktree. Lives next to the code, mounted into the sandbox, and lands as your PR title and description when you ship.</p>
-      <div class="notes-features">
-        <div class="notes-feat-card"><span class="icon">📝</span>
-          <h3>Note next to the code</h3>
-          <p>Press <kbd>m</kbd> or right-click a card to open the editor. Single-line PR title above, multi-line Markdown body with a live preview pane.</p>
-        </div>
-        <div class="notes-feat-card"><span class="icon">🐋</span>
-          <h3>Reaches your agent</h3>
-          <p>Stored inside the worktree, so the file gets mounted into the sandbox microVM. Your agent reads your intent as an ordinary file at the working tree root.</p>
-        </div>
-        <div class="notes-feat-card"><span class="icon">🚀</span>
-          <h3>Becomes the PR</h3>
-          <p>On <kbd>P</kbd>, biomelab offers to use your prepared title and description in place of the commit-derived defaults. Skip the rewrite — the note <em>is</em> the description.</p>
-        </div>
-      </div>
-
-      <div class="notes-snippet">
-        <h4 class="snippet-title">Extension point</h4>
-        <pre><span class="notes-comment"># Any skill, agent, or script can populate the two artifact files:</span>
-&lt;worktree&gt;/.biomelab/pr-title.md      <span class="notes-comment"># single-line PR title</span>
-&lt;worktree&gt;/.biomelab/note.md          <span class="notes-comment"># PR description (Markdown)</span>
-
-<span class="notes-comment"># biomelab turns them into the actual PR on Shift+P:</span>
-gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</span> \
-             --body-file <span class="notes-arg">.biomelab/note.md</span></pre>
-        <p class="notes-snippet-foot">Write to those paths and biomelab handles the rest. Falls back to commit-derived <code>--fill</code> when files are absent.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="kanban" class="kanban-board">
-    <div class="container">
-      <span class="section-label">Kanban Board</span>
+      <span class="section-label">Playground</span>
       <h2>See every PR's lifecycle <span class="kb-accent">at a glance</span></h2>
       <p class="kanban-intro">The default view groups your worktrees into five columns — from closed PRs to merged. One keystroke switches to the flat grid and back.</p>
-      <div class="kanban-features">
-        <div class="kanban-feat-card"><span class="icon">📋</span>
-          <h3>Five lifecycle stages</h3>
-          <p>Closed Unmerged → Created → PR Sent → PR In Review → PR Merged. Branches self-sort as CI runs and reviewers respond.</p>
-        </div>
-        <div class="kanban-feat-card"><span class="icon">🔍</span>
-          <h3>Review status on every card</h3>
-          <p>Approved ✓, changes requested !, or commented ● — fetched live from GitHub reviews or GitLab approvals.</p>
-        </div>
-        <div class="kanban-feat-card"><span class="icon">⌨️</span>
-          <h3>Press <kbd>g</kbd> for grid view</h3>
-          <p>Toggle to the classic responsive card grid whenever you want a flat alphabetical view. Toggle back with <kbd>g</kbd>.</p>
-        </div>
-      </div>
-
       <div class="kanban-diagram-html">
-        <h4 class="diagram-title" id="kb-title">PR Lifecycle Board</h4>
+        <h4 class="diagram-title" id="kb-title">Try the playground · press <kbd class="kb-g-glow">c</kbd> to start</h4>
+
+        <!-- Main worktree row — always visible above both views, just
+             like biomelab's GUI shows the main worktree above the
+             linked-worktrees grid. Click selects it; r refreshes, ⏎
+             opens the terminal, l opens the log, m opens the note. -->
+        <div class="kb-main-card" data-kb="main">
+          <span class="kb-dot kb-dot-pink"></span>
+          <span class="kb-branch">main</span>
+          <span class="kb-main-badge">main</span>
+          <span class="kb-main-path">~/sourcecode/biomelab</span>
+          <span class="kb-main-meta">
+            <span class="kb-agent kb-agent-green">● claude</span>
+            <span class="kb-sync kb-sync-up">↕ up-to-date</span>
+            <span class="kb-status kb-status-clean">✓ clean</span>
+          </span>
+        </div>
 
         <div class="kb-board">
 
@@ -684,32 +655,42 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
         <div class="kb-footer-hint">
           <span class="kb-footer-mode">Try <kbd class="kb-g-glow">g</kbd> for grid view</span>
           <span class="kb-footer-sep">·</span>
-          <span class="kb-footer-cta">Click a card to select it — then explore the keyboard shortcuts below</span>
+          <span class="kb-footer-cta">Press <kbd class="kb-g-glow">?</kbd> to see the keybindings</span>
         </div>
       </div><!-- /.kanban-diagram-html -->
     </div>
   </section>
 
-  <section class="keyboard">
-    <div class="container text-center">
-      <span class="section-label">Keyboard-First</span>
-      <h2>Point-and-click meets keyboard shortcuts</h2>
-      <p class="mx-auto">Every action is a single keystroke. Full mouse support built in.</p>
-      <div class="keyboard-grid">
-        <div class="key-item"><span class="key-cap key-green">c</span><span class="key-action">Create worktree</span></div>
-        <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span></div>
-        <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span></div>
-        <div class="key-item"><span class="key-cap key-yellow">m</span><span class="key-action">Open note editor</span></div>
-        <div class="key-item"><span class="key-cap key-magenta">l</span><span class="key-action">Open regent log</span></div>
-        <div class="key-item"><span class="key-cap key-blue">f</span><span class="key-action">Fetch PR / MR</span></div>
-        <div class="key-item"><span class="key-cap key-cyan">g</span><span class="key-action">Toggle kanban / grid</span></div>
-        <div class="key-item"><span class="key-cap">n</span><span class="key-action">New sandbox</span></div>
-        <div class="key-item"><span class="key-cap key-orange">p</span><span class="key-action">Pull from remote</span></div>
-        <div class="key-item"><span class="key-cap key-magenta">P</span><span class="key-action">Send PR</span></div>
-        <div class="key-item"><span class="key-cap">r</span><span class="key-action">Refresh card</span></div>
-        <div class="key-item"><span class="key-cap key-green">s</span><span class="key-action">Start sandbox</span></div>
-        <div class="key-item"><span class="key-cap key-red">S</span><span class="key-action">Stop sandbox</span></div>
-        <div class="key-item"><span class="key-cap key-yellow">⏎</span><span class="key-action">Open in terminal</span></div>
+  <section id="notes" class="notes">
+    <div class="container">
+      <span class="section-label">Task Notes</span>
+      <h2>Brief your agent, draft your PR — <span class="notes-accent">in the same place</span></h2>
+      <p class="notes-intro">A Markdown editor scoped to each worktree. Lives next to the code, mounted into the sandbox, and lands as your PR title and description when you ship.</p>
+      <div class="notes-features">
+        <div class="notes-feat-card"><span class="icon">📝</span>
+          <h3>Note next to the code</h3>
+          <p>Press <kbd>m</kbd> or right-click a card to open the editor. Single-line PR title above, multi-line Markdown body with a live preview pane.</p>
+        </div>
+        <div class="notes-feat-card"><span class="icon">🐋</span>
+          <h3>Reaches your agent</h3>
+          <p>Stored inside the worktree, so the file gets mounted into the sandbox microVM. Your agent reads your intent as an ordinary file at the working tree root.</p>
+        </div>
+        <div class="notes-feat-card"><span class="icon">🚀</span>
+          <h3>Becomes the PR</h3>
+          <p>On <kbd>P</kbd>, biomelab offers to use your prepared title and description in place of the commit-derived defaults. Skip the rewrite — the note <em>is</em> the description.</p>
+        </div>
+      </div>
+
+      <div class="notes-snippet">
+        <h4 class="snippet-title">Extension point</h4>
+        <pre><span class="notes-comment"># Any skill, agent, or script can populate the two artifact files:</span>
+&lt;worktree&gt;/.biomelab/pr-title.md      <span class="notes-comment"># single-line PR title</span>
+&lt;worktree&gt;/.biomelab/note.md          <span class="notes-comment"># PR description (Markdown)</span>
+
+<span class="notes-comment"># biomelab turns them into the actual PR on Shift+P:</span>
+gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</span> \
+             --body-file <span class="notes-arg">.biomelab/note.md</span></pre>
+        <p class="notes-snippet-foot">Write to those paths and biomelab handles the rest. Falls back to commit-derived <code>--fill</code> when files are absent.</p>
       </div>
     </div>
   </section>
@@ -848,6 +829,100 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
       </div>
       <footer class="rgt-modal-foot">
         <span class="rgt-modal-hint">Press <kbd>Esc</kbd> to close · saved as <kbd>.biomelab/note.md</kbd></span>
+      </footer>
+    </div>
+  </div>
+
+  <!-- Keyboard shortcuts cheatsheet modal — opens with '?'.
+       Body is populated by cloning the .keyboard-grid section on first
+       open, so the source of truth stays in one place. -->
+  <div id="kb-help-modal" class="rgt-modal" hidden role="dialog" aria-modal="true" aria-labelledby="kb-help-title">
+    <div class="rgt-modal-overlay" data-kbhelp-close></div>
+    <div class="rgt-modal-window">
+      <header class="rgt-modal-head">
+        <h3 id="kb-help-title">Keyboard shortcuts</h3>
+        <button class="rgt-modal-close" data-kbhelp-close aria-label="Close">×</button>
+      </header>
+      <div class="rgt-modal-body" id="kb-help-body">
+        <div class="keyboard-grid">
+          <div class="key-item"><span class="key-cap key-green">c</span><span class="key-action">Create worktree</span></div>
+          <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span></div>
+          <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span></div>
+          <div class="key-item"><span class="key-cap key-yellow">m</span><span class="key-action">Open note editor</span></div>
+          <div class="key-item"><span class="key-cap key-magenta">l</span><span class="key-action">Open regent log</span></div>
+          <div class="key-item"><span class="key-cap key-blue">f</span><span class="key-action">Fetch PR / MR</span></div>
+          <div class="key-item"><span class="key-cap key-cyan">g</span><span class="key-action">Toggle kanban / grid</span></div>
+          <div class="key-item"><span class="key-cap">n</span><span class="key-action">New sandbox</span></div>
+          <div class="key-item"><span class="key-cap key-orange">p</span><span class="key-action">Pull from remote</span></div>
+          <div class="key-item"><span class="key-cap key-magenta">P</span><span class="key-action">Send PR</span></div>
+          <div class="key-item"><span class="key-cap">r</span><span class="key-action">Refresh card</span></div>
+          <div class="key-item"><span class="key-cap key-green">s</span><span class="key-action">Start sandbox</span></div>
+          <div class="key-item"><span class="key-cap key-red">S</span><span class="key-action">Stop sandbox</span></div>
+          <div class="key-item"><span class="key-cap key-yellow">⏎</span><span class="key-action">Open in terminal</span></div>
+        </div>
+      </div>
+      <footer class="rgt-modal-foot">
+        <span class="rgt-modal-hint">Press <kbd>Esc</kbd> or <kbd>?</kbd> to close · click any key to fire it</span>
+      </footer>
+    </div>
+  </div>
+
+  <!-- Fake terminal — opens with ⏎ on a selected card. Types out the
+       Matrix-opening lines that Neo first sees on his screen. Pure
+       easter egg / playground; the real biomelab opens a host
+       terminal. Theme-locked to phosphor-green-on-black regardless of
+       the page theme. -->
+  <div id="term-modal" class="rgt-modal term-modal-window" hidden role="dialog" aria-modal="true" aria-labelledby="term-modal-title">
+    <div class="rgt-modal-overlay" data-term-close></div>
+    <div class="rgt-modal-window">
+      <header class="rgt-modal-head">
+        <h3 id="term-modal-title">Terminal</h3>
+        <button class="rgt-modal-close" data-term-close aria-label="Close">×</button>
+      </header>
+      <div class="rgt-modal-body">
+        <pre id="term-output" class="term-output"></pre>
+      </div>
+      <footer class="rgt-modal-foot">
+        <span class="rgt-modal-hint">Press <kbd>Esc</kbd> to close · Welcome to the Matrix</span>
+      </footer>
+    </div>
+  </div>
+
+  <!-- Editor splash — opens with 'e' on a selected card. Aspirational
+       boot sequence + a coding quote, in cyan-on-black for an "IDE
+       opening" vibe. Same chrome as the terminal modal so they read
+       as siblings. -->
+  <div id="editor-modal" class="rgt-modal editor-modal-window" hidden role="dialog" aria-modal="true" aria-labelledby="editor-modal-title">
+    <div class="rgt-modal-overlay" data-editor-close></div>
+    <div class="rgt-modal-window">
+      <header class="rgt-modal-head">
+        <h3 id="editor-modal-title">Editor</h3>
+        <button class="rgt-modal-close" data-editor-close aria-label="Close">×</button>
+      </header>
+      <div class="rgt-modal-body">
+        <pre id="editor-output" class="editor-output"></pre>
+      </div>
+      <footer class="rgt-modal-foot">
+        <span class="rgt-modal-hint">Press <kbd>Esc</kbd> to close · just code</span>
+      </footer>
+    </div>
+  </div>
+
+  <!-- Confirm dialog — mirrors biomelab's GUI (showConfirmDelete) for
+       destructive actions on a selected card. -->
+  <div id="confirm-modal" class="rgt-modal confirm-modal-window" hidden role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title">
+    <div class="rgt-modal-overlay" data-confirm-close></div>
+    <div class="rgt-modal-window">
+      <header class="rgt-modal-head">
+        <h3 id="confirm-modal-title">Delete worktree</h3>
+        <button class="rgt-modal-close" data-confirm-close aria-label="Close">×</button>
+      </header>
+      <div class="rgt-modal-body">
+        <p id="confirm-modal-body"></p>
+      </div>
+      <footer class="rgt-modal-foot">
+        <button class="confirm-btn confirm-no" data-confirm-close>Cancel</button>
+        <button class="confirm-btn confirm-yes">Delete</button>
       </footer>
     </div>
   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -690,6 +690,30 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
     </div>
   </section>
 
+  <section class="keyboard">
+    <div class="container text-center">
+      <span class="section-label">Keyboard-First</span>
+      <h2>Point-and-click meets keyboard shortcuts</h2>
+      <p class="mx-auto">Every action is a single keystroke. Full mouse support built in.</p>
+      <div class="keyboard-grid">
+        <div class="key-item"><span class="key-cap key-green">c</span><span class="key-action">Create worktree</span></div>
+        <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span></div>
+        <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span></div>
+        <div class="key-item"><span class="key-cap key-yellow">m</span><span class="key-action">Open note editor</span></div>
+        <div class="key-item"><span class="key-cap key-magenta">l</span><span class="key-action">Open regent log</span></div>
+        <div class="key-item"><span class="key-cap key-blue">f</span><span class="key-action">Fetch PR / MR</span></div>
+        <div class="key-item"><span class="key-cap key-cyan">g</span><span class="key-action">Toggle kanban / grid</span></div>
+        <div class="key-item"><span class="key-cap">n</span><span class="key-action">New sandbox</span></div>
+        <div class="key-item"><span class="key-cap key-orange">p</span><span class="key-action">Pull from remote</span></div>
+        <div class="key-item"><span class="key-cap key-magenta">P</span><span class="key-action">Send PR</span></div>
+        <div class="key-item"><span class="key-cap">r</span><span class="key-action">Refresh card</span></div>
+        <div class="key-item"><span class="key-cap key-green">s</span><span class="key-action">Start sandbox</span></div>
+        <div class="key-item"><span class="key-cap key-red">S</span><span class="key-action">Stop sandbox</span></div>
+        <div class="key-item"><span class="key-cap key-yellow">⏎</span><span class="key-action">Open in terminal</span></div>
+      </div>
+    </div>
+  </section>
+
   <section id="install">
     <div class="container text-center">
       <span class="section-label">Get Started</span>
@@ -738,30 +762,6 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
         <span class="platform-badge">Linux amd64</span>
         <span class="platform-badge">Linux arm64</span>
         <span class="platform-badge">Windows</span>
-      </div>
-    </div>
-  </section>
-
-  <section class="keyboard">
-    <div class="container text-center">
-      <span class="section-label">Keyboard-First</span>
-      <h2>Point-and-click meets keyboard shortcuts</h2>
-      <p class="mx-auto">Every action is a single keystroke. Full mouse support built in.</p>
-      <div class="keyboard-grid">
-        <div class="key-item"><span class="key-cap key-green">c</span><span class="key-action">Create worktree</span></div>
-        <div class="key-item"><span class="key-cap key-red">d</span><span class="key-action">Delete worktree</span></div>
-        <div class="key-item"><span class="key-cap key-cyan">e</span><span class="key-action">Open in editor</span></div>
-        <div class="key-item"><span class="key-cap key-yellow">m</span><span class="key-action">Open note editor</span></div>
-        <div class="key-item"><span class="key-cap key-magenta">l</span><span class="key-action">Open regent log</span></div>
-        <div class="key-item"><span class="key-cap key-blue">f</span><span class="key-action">Fetch PR / MR</span></div>
-        <div class="key-item"><span class="key-cap key-cyan">g</span><span class="key-action">Toggle kanban / grid</span></div>
-        <div class="key-item"><span class="key-cap">n</span><span class="key-action">New sandbox</span></div>
-        <div class="key-item"><span class="key-cap key-orange">p</span><span class="key-action">Pull from remote</span></div>
-        <div class="key-item"><span class="key-cap key-magenta">P</span><span class="key-action">Send PR</span></div>
-        <div class="key-item"><span class="key-cap">r</span><span class="key-action">Refresh card</span></div>
-        <div class="key-item"><span class="key-cap key-green">s</span><span class="key-action">Start sandbox</span></div>
-        <div class="key-item"><span class="key-cap key-red">S</span><span class="key-action">Stop sandbox</span></div>
-        <div class="key-item"><span class="key-cap key-yellow">⏎</span><span class="key-action">Open in terminal</span></div>
       </div>
     </div>
   </section>

--- a/website/index.html
+++ b/website/index.html
@@ -684,7 +684,7 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
         <div class="kb-footer-hint">
           <span class="kb-footer-mode">Try <kbd class="kb-g-glow">g</kbd> for grid view</span>
           <span class="kb-footer-sep">·</span>
-          <span class="kb-footer-cta">Click any card to see the agent conversation</span>
+          <span class="kb-footer-cta">Click a card to select it — then explore the keyboard shortcuts below</span>
         </div>
       </div><!-- /.kanban-diagram-html -->
     </div>
@@ -817,11 +817,43 @@ gh pr create --title <span class="notes-arg">"$(cat .biomelab/pr-title.md)"</spa
       </header>
       <div class="rgt-modal-body"></div>
       <footer class="rgt-modal-foot">
-        <span class="rgt-modal-hint">Press <kbd>Esc</kbd> to close · click any card to reopen</span>
+        <span class="rgt-modal-hint">Press <kbd>Esc</kbd> to close · select a card and press <kbd>l</kbd> to reopen</span>
         <button class="rgt-modal-export">Export JSON…</button>
       </footer>
     </div>
   </div>
+
+  <!-- Note editor modal — opens via 'm' key or the m key-cap click.
+       Mirrors the GUI note editor: Markdown textarea on the left, live
+       preview on the right. Reuses the regent modal's overlay / window
+       chrome via shared classes. -->
+  <div id="note-modal" class="rgt-modal note-modal-window" hidden role="dialog" aria-modal="true" aria-labelledby="note-modal-title">
+    <div class="rgt-modal-overlay" data-note-close></div>
+    <div class="rgt-modal-window">
+      <header class="rgt-modal-head">
+        <h3 id="note-modal-title">Note</h3>
+        <button class="rgt-modal-close" data-note-close aria-label="Close">×</button>
+      </header>
+      <div class="rgt-modal-body">
+        <div class="note-split">
+          <div class="note-pane">
+            <div class="note-pane-head">✎ Markdown</div>
+            <textarea id="note-entry" spellcheck="false"></textarea>
+          </div>
+          <div class="note-pane">
+            <div class="note-pane-head">👁 Preview</div>
+            <div id="note-preview"></div>
+          </div>
+        </div>
+      </div>
+      <footer class="rgt-modal-foot">
+        <span class="rgt-modal-hint">Press <kbd>Esc</kbd> to close · saved as <kbd>.biomelab/note.md</kbd></span>
+      </footer>
+    </div>
+  </div>
+
+  <!-- Toast for transient feedback from keyboard simulator actions. -->
+  <div id="kb-toast" class="kb-toast" hidden role="status" aria-live="polite"></div>
 
   <script defer src="js/main.js"></script>
 </body>

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -176,12 +176,11 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
     if (e.key === 'Escape') close();
   });
 
-  document.querySelectorAll('.kb-card[data-kb]').forEach(function (card) {
-    card.addEventListener('click', function (e) {
-      e.preventDefault();
-      open(card.dataset.kb);
-    });
-  });
+  // Card click handlers are attached by the keyboard simulator IIFE
+  // (its wireCard) so existing and dynamically-created cards share
+  // one wiring path. We just expose open() here for it to call.
+  window.kbDemo = window.kbDemo || {};
+  window.kbDemo.openLog = open;
 
   body.addEventListener('click', function (e) {
     var btn = e.target.closest('.rgt-tools-toggle');
@@ -365,4 +364,260 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
       setView(diagram.classList.contains('kb-view-grid') ? 'kanban' : 'grid');
     }
   });
+})();
+
+// ────────────────────────────────────────────────────────────────────
+// Keyboard simulator — make the keyboard grid an interactive demo.
+// Each key fires whether you press it on the keyboard OR click its
+// key-cap in the "Keyboard-First" grid. Real animations for the keys
+// that have visual analogues on the kanban board (c, d, r), real
+// modals for m (note editor) and l (regent log), and educational
+// toasts for the rest (e, f, n, p, P, s, S, ⏎).
+// ────────────────────────────────────────────────────────────────────
+(function () {
+  var board = document.querySelector('.kanban-diagram-html');
+  if (!board) return;
+
+  var STATE = {
+    selectedCardId: null,
+    nextSampleN: 1
+  };
+
+  function findCard(id) {
+    return document.querySelector('.kb-card[data-kb="' + cssEsc(id) + '"]');
+  }
+  function cssEsc(s) {
+    return String(s).replace(/[\\"]/g, '\\$&');
+  }
+
+  function selectCard(id) {
+    document.querySelectorAll('.kb-card.kb-selected').forEach(function (el) {
+      el.classList.remove('kb-selected');
+    });
+    if (id) {
+      var c = findCard(id);
+      if (c) c.classList.add('kb-selected');
+    }
+    STATE.selectedCardId = id;
+  }
+
+  // Toast — bottom-right transient feedback for actions that don't
+  // have a visual analogue on the board.
+  var toast = document.getElementById('kb-toast');
+  var toastTimer = null;
+  function showToast(msg) {
+    if (!toast) return;
+    toast.textContent = msg;
+    toast.removeAttribute('hidden');
+    requestAnimationFrame(function () { toast.classList.add('open'); });
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(function () {
+      toast.classList.remove('open');
+      setTimeout(function () { toast.setAttribute('hidden', ''); }, 220);
+    }, 1700);
+  }
+
+  // ── Actions ────────────────────────────────────────────────────
+
+  function createCard() {
+    var col = document.querySelector('.kb-col-created');
+    if (!col) return;
+    var n = STATE.nextSampleN++;
+    var branch = 'feat/demo-' + n;
+    var card = document.createElement('div');
+    card.className = 'kb-card kb-enter';
+    card.dataset.kb = branch;
+    card.innerHTML =
+      '<div class="kb-card-top">'
+      + '<span class="kb-dot kb-dot-gray"></span>'
+      + '<span class="kb-branch">' + branch + '</span>'
+      + '</div>'
+      + '<div class="kb-card-meta"><span class="kb-agent kb-agent-green">● claude</span></div>'
+      + '<div class="kb-card-status"><span class="kb-no-pr">no PR</span></div>';
+    col.appendChild(card);
+    wireCard(card);
+    // Bump the column count badge if present
+    var badge = col.querySelector('.kb-col-badge');
+    if (badge) badge.textContent = String(parseInt(badge.textContent || '0', 10) + 1);
+    selectCard(branch);
+    showToast('Created worktree: ' + branch);
+    setTimeout(function () { card.classList.remove('kb-enter'); }, 280);
+  }
+
+  function deleteCard() {
+    if (!STATE.selectedCardId) { showToast('Select a card first (click one)'); return; }
+    var c = findCard(STATE.selectedCardId);
+    if (!c) return;
+    showToast('Deleted worktree: ' + STATE.selectedCardId);
+    var col = c.closest('.kb-col');
+    c.classList.add('kb-exit');
+    setTimeout(function () {
+      c.remove();
+      if (col) {
+        var badge = col.querySelector('.kb-col-badge');
+        if (badge) {
+          var n = parseInt(badge.textContent || '0', 10) - 1;
+          badge.textContent = String(Math.max(n, 0));
+        }
+      }
+    }, 280);
+    selectCard(null);
+  }
+
+  function refreshAll() {
+    document.querySelectorAll('.kb-card').forEach(function (c) {
+      c.classList.add('kb-pulse');
+      setTimeout(function () { c.classList.remove('kb-pulse'); }, 620);
+    });
+    showToast('Refreshing cards…');
+  }
+
+  function openLogModal() {
+    if (!STATE.selectedCardId) { showToast('Select a card first (click one)'); return; }
+    if (window.kbDemo && window.kbDemo.openLog) {
+      window.kbDemo.openLog(STATE.selectedCardId);
+    }
+  }
+
+  function openNoteModal() {
+    if (!STATE.selectedCardId) { showToast('Select a card first (click one)'); return; }
+    var modal = document.getElementById('note-modal');
+    if (!modal) return;
+    document.getElementById('note-modal-title').textContent = 'Note — ' + STATE.selectedCardId;
+    var entry = document.getElementById('note-entry');
+    var preview = document.getElementById('note-preview');
+    var sample =
+      '# ' + STATE.selectedCardId + '\n\n'
+      + '**TODO** — write the task description here.\n\n'
+      + '- Use *Markdown* — bold, italic, `inline code`\n'
+      + '- Live preview on the right →\n'
+      + '- Saved alongside the worktree as `.biomelab/note.md`\n\n'
+      + 'When you `Shift+P` to send the PR, biomelab uses this note as the body.';
+    entry.value = sample;
+    preview.innerHTML = renderMd(sample);
+    entry.oninput = function () { preview.innerHTML = renderMd(entry.value); };
+    modal.removeAttribute('hidden');
+    document.body.classList.add('rgt-modal-open');
+    requestAnimationFrame(function () { modal.classList.add('open'); });
+  }
+
+  function closeNoteModal() {
+    var modal = document.getElementById('note-modal');
+    if (!modal) return;
+    modal.classList.remove('open');
+    document.body.classList.remove('rgt-modal-open');
+    setTimeout(function () { modal.setAttribute('hidden', ''); }, 200);
+  }
+
+  function renderMd(s) {
+    var esc = String(s).replace(/[&<>"']/g, function (c) {
+      return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c];
+    });
+    return esc
+      .replace(/^### (.+)$/gm, '<h4>$1</h4>')
+      .replace(/^## (.+)$/gm, '<h3>$1</h3>')
+      .replace(/^# (.+)$/gm, '<h2>$1</h2>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/`(.+?)`/g, '<code>$1</code>')
+      .replace(/^- (.+)$/gm, '<li>$1</li>')
+      .replace(/(<li>.*<\/li>(?:\n|$))+/g, function (m) { return '<ul>' + m.replace(/\n/g, '') + '</ul>'; })
+      .replace(/\n/g, '<br>');
+  }
+
+  // ── Wire existing + future cards ───────────────────────────────
+
+  function wireCard(card) {
+    // Click SELECTS only (matches biomelab's GUI behavior: select-
+    // then-act). To view the log the user presses 'l' (keyboard or
+    // the l key-cap in the Keyboard-First grid). Capture phase keeps
+    // the selection from being clobbered by any sibling listener.
+    card.addEventListener('click', function () {
+      selectCard(card.dataset.kb);
+    }, true);
+  }
+  document.querySelectorAll('.kb-card[data-kb]').forEach(wireCard);
+
+  // ── Keyboard handler ───────────────────────────────────────────
+
+  document.addEventListener('keydown', function (e) {
+    var tag = document.activeElement && document.activeElement.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+    var rgtModal = document.getElementById('rgt-modal');
+    var noteModal = document.getElementById('note-modal');
+    if (rgtModal && !rgtModal.hasAttribute('hidden')) return;
+    if (noteModal && !noteModal.hasAttribute('hidden')) {
+      if (e.key === 'Escape') closeNoteModal();
+      return;
+    }
+
+    switch (e.key) {
+      case 'c': case 'C': createCard();      e.preventDefault(); break;
+      case 'd': case 'D': deleteCard();      e.preventDefault(); break;
+      case 'r': case 'R': refreshAll();      e.preventDefault(); break;
+      case 'm': case 'M': openNoteModal();   e.preventDefault(); break;
+      case 'l': case 'L': openLogModal();    e.preventDefault(); break;
+      // Toast-only actions (educational reactions for keys without
+      // their own animation on the demo board)
+      case 'e': showToast('Opening worktree in editor…');             e.preventDefault(); break;
+      case 'f': showToast('Fetching PR into a new worktree…');        e.preventDefault(); break;
+      case 'n': showToast('Creating sandbox for this worktree…');     e.preventDefault(); break;
+      case 'p': showToast('Pulling from remote…');                    e.preventDefault(); break;
+      case 'P': showToast('Send PR flow (multi-step in the app)');    e.preventDefault(); break;
+      case 's': showToast('Starting stopped sandbox…');               e.preventDefault(); break;
+      case 'S': showToast('Stopping running sandbox…');               e.preventDefault(); break;
+      case 'Enter': showToast('Opening terminal for this worktree…'); e.preventDefault(); break;
+    }
+  });
+
+  // ── Click handlers for the key-caps in the "Keyboard-First" grid ─
+
+  function fireByCap(text) {
+    switch (text) {
+      case 'c': createCard(); return;
+      case 'd': deleteCard(); return;
+      case 'r': refreshAll(); return;
+      case 'm': openNoteModal(); return;
+      case 'l': openLogModal(); return;
+      case 'e': showToast('Opening worktree in editor…'); return;
+      case 'f': showToast('Fetching PR into a new worktree…'); return;
+      case 'n': showToast('Creating sandbox for this worktree…'); return;
+      case 'p': showToast('Pulling from remote…'); return;
+      case 'P': showToast('Send PR flow (multi-step in the app)'); return;
+      case 's': showToast('Starting stopped sandbox…'); return;
+      case 'S': showToast('Stopping running sandbox…'); return;
+      case '⏎': showToast('Opening terminal for this worktree…'); return;
+      case 'g':
+        // Delegate to the existing kanban toggle by dispatching a
+        // keyboard event the toggle IIFE already listens for.
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g', bubbles: true }));
+        return;
+    }
+  }
+  document.querySelectorAll('.keyboard-grid .key-item').forEach(function (item) {
+    var cap = item.querySelector('.key-cap');
+    if (!cap) return;
+    item.style.cursor = 'pointer';
+    item.addEventListener('click', function () {
+      fireByCap(cap.textContent.trim());
+    });
+  });
+
+  // ── Note modal close handlers ──────────────────────────────────
+
+  document.querySelectorAll('[data-note-close]').forEach(function (el) {
+    el.addEventListener('click', closeNoteModal);
+  });
+  // Esc while typing in the textarea: the global keydown handler bows
+  // out on TEXTAREA focus, so add a dedicated Escape on the entry so
+  // the user doesn't have to mouse to the × button to close.
+  var noteEntry = document.getElementById('note-entry');
+  if (noteEntry) {
+    noteEntry.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeNoteModal();
+      }
+    });
+  }
 })();

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -136,6 +136,30 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
   });
 });
 
+// Shared modal show/hide helpers — the open/close boilerplate
+// (toggle [hidden] / .open class, body-class for scroll-lock, the
+// 200ms fade-out before hidden) was identical across all five
+// modals on the page. The optional hooks let callers slot in the
+// only thing that actually differs per modal: setting titles /
+// populating bodies on show, cancelling typewriter timers or
+// clearing pending callbacks on hide.
+function showModal(id, onShow) {
+  var modal = document.getElementById(id);
+  if (!modal) return;
+  if (onShow) onShow(modal);
+  modal.removeAttribute('hidden');
+  document.body.classList.add('rgt-modal-open');
+  requestAnimationFrame(function () { modal.classList.add('open'); });
+}
+function hideModal(id, onHide) {
+  var modal = document.getElementById(id);
+  if (!modal) return;
+  if (onHide) onHide();
+  modal.classList.remove('open');
+  document.body.classList.remove('rgt-modal-open');
+  setTimeout(function () { modal.setAttribute('hidden', ''); }, 200);
+}
+
 // Regent activity modal — click any kanban card (works in both
 // kanban and grid views since the DOM nodes are the same) or press
 // 'l' to open a WhatsApp-style log mirroring the biomelab GUI.
@@ -149,19 +173,14 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
 
   function open(branch) {
     lastBranch = branch || lastBranch;
-    title.textContent = 'Regent activity — ' + lastBranch;
-    body.innerHTML = renderSteps(SAMPLE);
-    body.scrollTop = 0;
-    modal.removeAttribute('hidden');
-    document.body.classList.add('rgt-modal-open');
-    requestAnimationFrame(function () { modal.classList.add('open'); });
+    showModal('rgt-modal', function () {
+      title.textContent = 'Regent activity — ' + lastBranch;
+      body.innerHTML = renderSteps(SAMPLE);
+      body.scrollTop = 0;
+    });
   }
 
-  function close() {
-    modal.classList.remove('open');
-    document.body.classList.remove('rgt-modal-open');
-    setTimeout(function () { modal.setAttribute('hidden', ''); }, 200);
-  }
+  function close() { hideModal('rgt-modal'); }
 
   modal.querySelectorAll('[data-rgt-close]').forEach(function (el) {
     el.addEventListener('click', close);
@@ -340,13 +359,14 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
   }
 
   function setView(mode) {
+    // The diagram title stays as the page's inviting CTA in both
+    // views — only the layout class and the footer hint flip on the
+    // 'g' toggle.
     if (mode === 'grid') {
       diagram.classList.add('kb-view-grid');
-      title.textContent = 'Card Grid View';
       hint.innerHTML = getHintHTML('grid');
     } else {
       diagram.classList.remove('kb-view-grid');
-      title.textContent = 'PR Lifecycle Board';
       hint.innerHTML = getHintHTML('kanban');
     }
     localStorage.setItem(STORE_KEY, mode);
@@ -367,42 +387,265 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
 })();
 
 // ────────────────────────────────────────────────────────────────────
-// Keyboard simulator — make the keyboard grid an interactive demo.
-// Each key fires whether you press it on the keyboard OR click its
-// key-cap in the "Keyboard-First" grid. Real animations for the keys
-// that have visual analogues on the kanban board (c, d, r), real
-// modals for m (note editor) and l (regent log), and educational
-// toasts for the rest (e, f, n, p, P, s, S, ⏎).
+// Keyboard simulator — make the keyboard grid an interactive demo
+// backed by a shared STATE.cards source of truth. Both the kanban
+// board (columns) and the grid view (flat) render from the same
+// model, so any mutation (create, send-PR, delete) shows up
+// consistently in either view when you toggle with `g`.
 // ────────────────────────────────────────────────────────────────────
 (function () {
   var board = document.querySelector('.kanban-diagram-html');
   if (!board) return;
 
+  // ── Source of truth ────────────────────────────────────────────
+  //
+  // Each entry models one biomelab worktree card. Stage drives which
+  // kanban column it lives in; prState / ciState drive the badges.
+  // Bootstrapped from the handcrafted DOM that ships in index.html,
+  // then re-rendered from this model after every mutation.
   var STATE = {
+    cards: [],
     selectedCardId: null,
-    nextSampleN: 1
+    nextSampleN: 1,
+    mainSync: 'up' // 'up' | 'behind' — drives the main card's sync pill
   };
 
-  function findCard(id) {
-    return document.querySelector('.kb-card[data-kb="' + cssEsc(id) + '"]');
+  var STAGES = ['closed', 'created', 'sent', 'in-review', 'merged'];
+  var STAGE_LABEL = {
+    closed: 'closed', created: 'created',
+    sent: 'PR sent', 'in-review': 'in review', merged: 'merged'
+  };
+  var STAGE_DOT = {
+    closed: 'red', created: 'gray', sent: 'blue',
+    'in-review': 'yellow', merged: 'green'
+  };
+
+  function cssEsc(s) { return String(s).replace(/[\\"]/g, '\\$&'); }
+
+  // ── Parse initial DOM into STATE.cards ─────────────────────────
+
+  function stageOfCol(col) {
+    var cl = col.className;
+    if (/kb-col-closed/.test(cl))    return 'closed';
+    if (/kb-col-created/.test(cl))   return 'created';
+    if (/kb-col-sent/.test(cl))      return 'sent';
+    if (/kb-col-in-review/.test(cl)) return 'in-review';
+    if (/kb-col-merged/.test(cl))    return 'merged';
+    return 'created';
   }
-  function cssEsc(s) {
-    return String(s).replace(/[\\"]/g, '\\$&');
+
+  function parseCard(el, stage) {
+    var agent = null;
+    var ag = el.querySelector('.kb-agent');
+    if (ag && !ag.classList.contains('kb-agent-dim')) {
+      agent = ag.textContent.replace(/[●○]\s*/g, '').trim() || null;
+    }
+    var prNumber = null, prState = null, ciState = null;
+    var prNum = el.querySelector('.kb-pr-num');
+    if (prNum) prNumber = parseInt(prNum.textContent.replace('#', ''), 10) || null;
+    var stateSpan = el.querySelector('[class*="kb-pr-state-"]');
+    if (stateSpan) {
+      var ms = stateSpan.className.match(/kb-pr-state-(\w+)/);
+      if (ms) prState = ms[1];
+    }
+    var ci = el.querySelector('[class*="kb-ci-"]:not(.kb-ci-empty)');
+    if (ci) {
+      var mc = ci.className.match(/kb-ci-(\w+)/);
+      if (mc) ciState = mc[1];
+    }
+    return {
+      id: el.dataset.kb,
+      branch: el.dataset.kb,
+      agent: agent,
+      prNumber: prNumber,
+      prState: prState,
+      ciState: ciState,
+      stage: stage
+    };
+  }
+
+  function parseInitialState() {
+    var cards = [];
+    document.querySelectorAll('.kb-board .kb-col .kb-card[data-kb]').forEach(function (el) {
+      var col = el.closest('.kb-col');
+      if (!col) return;
+      cards.push(parseCard(el, stageOfCol(col)));
+    });
+    return cards;
+  }
+
+  // ── Render board + grid from STATE.cards ───────────────────────
+
+  function cardHTML(c, mode) {
+    var dot = (c.prState === 'draft') ? 'dim' : (STAGE_DOT[c.stage] || 'gray');
+    var draftClass = (c.prState === 'draft') ? ' kb-card-draft' : '';
+    var closedClass = (c.stage === 'closed') ? ' kb-card-closed' : '';
+    var branchDim = (c.prState === 'draft') ? ' kb-branch-dim' : '';
+
+    var top = '<div class="kb-card-top">'
+      + '<span class="kb-dot kb-dot-' + dot + '"></span>';
+    if (c.editing) {
+      // Inline-edit branch name: replaces the static span with a text
+      // input until the user commits with Enter (or blur). Esc cancels
+      // and removes the half-created card.
+      top += '<input class="kb-branch-edit" value="' + esc(c.branch) + '" spellcheck="false">';
+    } else {
+      top += '<span class="kb-branch' + branchDim + '">' + esc(c.branch) + '</span>';
+    }
+    if (mode === 'grid') {
+      top += '<span class="kb-stage-pill kb-stage-' + c.stage + '">'
+        + esc(STAGE_LABEL[c.stage] || c.stage) + '</span>';
+    }
+    top += '</div>';
+
+    var meta = '<div class="kb-card-meta">'
+      + (c.agent
+          ? '<span class="kb-agent kb-agent-green">● ' + esc(c.agent) + '</span>'
+          : '<span class="kb-agent kb-agent-dim">○ no agent</span>')
+      + '</div>';
+
+    var status = '<div class="kb-card-status">';
+    if (c.prNumber) {
+      var ps = c.prState || 'open';
+      status += '<span class="kb-pr-label">PR <span class="kb-pr-num">#' + c.prNumber + '</span> '
+        + '<span class="kb-pr-state-' + ps + '">' + esc(ps) + '</span></span>';
+      if (c.ciState) {
+        var icon = c.ciState === 'pass' ? '✓' : c.ciState === 'fail' ? '✗' : '●';
+        var title = c.ciState === 'pass' ? 'CI passed' : c.ciState === 'fail' ? 'CI failed' : 'CI pending';
+        status += '<span class="kb-ci kb-ci-' + c.ciState + '" title="' + title + '">' + icon + '</span>';
+      }
+    } else {
+      status += '<span class="kb-no-pr">no PR</span>';
+    }
+    status += '</div>';
+
+    return '<div class="kb-card' + closedClass + draftClass + '" data-kb="' + esc(c.id) + '">'
+      + top + meta + status + '</div>';
+  }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c];
+    });
+  }
+
+  function renderBoard() {
+    STAGES.forEach(function (stage) {
+      var col = document.querySelector('.kb-col-' + stage);
+      if (!col) return;
+      col.querySelectorAll('.kb-card').forEach(function (c) { c.remove(); });
+      var inStage = STATE.cards.filter(function (c) { return c.stage === stage; });
+      inStage.forEach(function (c) {
+        col.insertAdjacentHTML('beforeend', cardHTML(c, 'board'));
+      });
+      var badge = col.querySelector('.kb-col-badge');
+      if (badge) badge.textContent = String(inStage.length);
+    });
+  }
+
+  function renderGrid() {
+    var grid = document.querySelector('.kb-grid');
+    if (!grid) return;
+    grid.querySelectorAll('.kb-card').forEach(function (c) { c.remove(); });
+    STATE.cards.forEach(function (c) {
+      grid.insertAdjacentHTML('beforeend', cardHTML(c, 'grid'));
+    });
+  }
+
+  function renderAll() {
+    renderBoard();
+    renderGrid();
+    document.querySelectorAll('.kb-card[data-kb]').forEach(wireCard);
+    if (STATE.selectedCardId) applySelection(STATE.selectedCardId);
+  }
+
+  // ── Selection ──────────────────────────────────────────────────
+
+  function applySelection(id) {
+    document.querySelectorAll('.kb-selected').forEach(function (el) {
+      el.classList.remove('kb-selected');
+    });
+    if (!id) return;
+    document.querySelectorAll('[data-kb="' + cssEsc(id) + '"]').forEach(function (el) {
+      el.classList.add('kb-selected');
+    });
   }
 
   function selectCard(id) {
-    document.querySelectorAll('.kb-card.kb-selected').forEach(function (el) {
-      el.classList.remove('kb-selected');
-    });
-    if (id) {
-      var c = findCard(id);
-      if (c) c.classList.add('kb-selected');
-    }
     STATE.selectedCardId = id;
+    applySelection(id);
   }
 
-  // Toast — bottom-right transient feedback for actions that don't
-  // have a visual analogue on the board.
+  function getCard(id) {
+    for (var i = 0; i < STATE.cards.length; i++) {
+      if (STATE.cards[i].id === id) return STATE.cards[i];
+    }
+    return null;
+  }
+
+  function pulseCard(id) {
+    document.querySelectorAll('[data-kb="' + cssEsc(id) + '"]').forEach(function (el) {
+      el.classList.add('kb-pulse');
+      setTimeout(function () { el.classList.remove('kb-pulse'); }, 620);
+    });
+  }
+
+  // ── Main worktree sync cycle ───────────────────────────────────
+  //
+  // Every 5 s the main card drifts to "behind" so the user has a
+  // genuine reason to press 'p'. Pulling sets it back to "up-to-date"
+  // and restarts the timer so the next drift happens 5 s from the
+  // pull (not mid-toast). The number-behind is a fixed demo value;
+  // in the real app it'd come from `git rev-list --count
+  // origin/main..HEAD`.
+  var MAIN_DRIFT_MS = 5000;
+  var mainSyncTimer = null;
+
+  function setMainSync(state) {
+    STATE.mainSync = state;
+    var syncEl = document.querySelector('.kb-main-card .kb-sync');
+    if (!syncEl) return;
+    syncEl.classList.remove('kb-sync-up', 'kb-sync-behind');
+    if (state === 'behind') {
+      // Random 1-5: keeps the demo feeling alive each cycle instead of
+      // always showing the same number.
+      var n = Math.floor(Math.random() * 5) + 1;
+      syncEl.classList.add('kb-sync-behind');
+      syncEl.textContent = '↓ ' + n + ' behind';
+    } else {
+      syncEl.classList.add('kb-sync-up');
+      syncEl.textContent = '↕ up-to-date';
+    }
+    pulseCard('main');
+  }
+
+  function startMainSyncCycle() {
+    if (mainSyncTimer) clearInterval(mainSyncTimer);
+    mainSyncTimer = setInterval(function () {
+      if (STATE.mainSync === 'up') setMainSync('behind');
+    }, MAIN_DRIFT_MS);
+  }
+
+  function pullMain() {
+    if (STATE.mainSync === 'up') {
+      showToast('Main already up-to-date');
+      return;
+    }
+    showToast('Pulling from remote…');
+    // Flip the sync pill to "up-to-date" only when the toast finishes,
+    // so the UI shows a real "pulling" window — the toast is the
+    // progress indicator, and the green state lands as it fades out.
+    // The follow-up startMainSyncCycle restart pushes the next drift
+    // a fresh interval away from THIS moment.
+    setTimeout(function () {
+      setMainSync('up');
+      startMainSyncCycle();
+    }, TOAST_VISIBLE_MS);
+  }
+
+  // ── Toast — bottom-right transient feedback ────────────────────
+
+  var TOAST_VISIBLE_MS = 1700;
   var toast = document.getElementById('kb-toast');
   var toastTimer = null;
   function showToast(msg) {
@@ -414,58 +657,128 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
     toastTimer = setTimeout(function () {
       toast.classList.remove('open');
       setTimeout(function () { toast.setAttribute('hidden', ''); }, 220);
-    }, 1700);
+    }, TOAST_VISIBLE_MS);
   }
 
   // ── Actions ────────────────────────────────────────────────────
 
   function createCard() {
-    var col = document.querySelector('.kb-col-created');
-    if (!col) return;
     var n = STATE.nextSampleN++;
     var branch = 'feat/demo-' + n;
-    var card = document.createElement('div');
-    card.className = 'kb-card kb-enter';
-    card.dataset.kb = branch;
-    card.innerHTML =
-      '<div class="kb-card-top">'
-      + '<span class="kb-dot kb-dot-gray"></span>'
-      + '<span class="kb-branch">' + branch + '</span>'
-      + '</div>'
-      + '<div class="kb-card-meta"><span class="kb-agent kb-agent-green">● claude</span></div>'
-      + '<div class="kb-card-status"><span class="kb-no-pr">no PR</span></div>';
-    col.appendChild(card);
-    wireCard(card);
-    // Bump the column count badge if present
-    var badge = col.querySelector('.kb-col-badge');
-    if (badge) badge.textContent = String(parseInt(badge.textContent || '0', 10) + 1);
-    selectCard(branch);
-    showToast('Created worktree: ' + branch);
-    setTimeout(function () { card.classList.remove('kb-enter'); }, 280);
+    STATE.cards.push({
+      id: branch, branch: branch, agent: 'claude',
+      prNumber: null, prState: null, ciState: null,
+      stage: 'created',
+      editing: true
+    });
+    STATE.selectedCardId = branch;
+    renderAll();
+    pulseCard(branch);
+    focusBranchEdit(branch);
+    showToast('Name your worktree · Enter to confirm');
+  }
+
+  // focusBranchEdit puts the cursor in the inline branch input of the
+  // just-created card so the user can type a real name immediately.
+  // Enter commits + leaves editing mode; Esc cancels and removes the
+  // card; blur also commits (clicking elsewhere). selectionStart/End
+  // place the caret at the end so users can append-or-overwrite at will.
+  function focusBranchEdit(currentId) {
+    var input = document.querySelector('.kb-card[data-kb="' + cssEsc(currentId) + '"] .kb-branch-edit');
+    if (!input) return;
+    input.focus();
+    input.setSelectionRange(0, input.value.length); // select-all for easy overwrite
+
+    var committed = false;
+    function commit() {
+      if (committed) return;
+      committed = true;
+      var newName = input.value.trim();
+      var card = getCard(currentId);
+      if (!card) return;
+      if (!newName) {
+        // Empty name → treat as cancel and drop the card.
+        STATE.cards = STATE.cards.filter(function (c) { return c.id !== currentId; });
+        STATE.selectedCardId = null;
+        renderAll();
+        return;
+      }
+      // Update id + branch. selectedCardId follows the rename so
+      // subsequent d/m/l/P still target this card.
+      card.id = newName;
+      card.branch = newName;
+      card.editing = false;
+      STATE.selectedCardId = newName;
+      renderAll();
+      pulseCard(newName);
+    }
+    function cancel() {
+      if (committed) return;
+      committed = true;
+      STATE.cards = STATE.cards.filter(function (c) { return c.id !== currentId; });
+      STATE.selectedCardId = null;
+      renderAll();
+    }
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.preventDefault(); commit(); }
+      else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+    });
+    input.addEventListener('blur', commit);
   }
 
   function deleteCard() {
     if (!STATE.selectedCardId) { showToast('Select a card first (click one)'); return; }
-    var c = findCard(STATE.selectedCardId);
-    if (!c) return;
-    showToast('Deleted worktree: ' + STATE.selectedCardId);
-    var col = c.closest('.kb-col');
-    c.classList.add('kb-exit');
-    setTimeout(function () {
-      c.remove();
-      if (col) {
-        var badge = col.querySelector('.kb-col-badge');
-        if (badge) {
-          var n = parseInt(badge.textContent || '0', 10) - 1;
-          badge.textContent = String(Math.max(n, 0));
-        }
+    if (STATE.selectedCardId === 'main') {
+      showToast('Cannot delete the main worktree');
+      return;
+    }
+    var id = STATE.selectedCardId;
+    openConfirmModal(
+      'Delete worktree',
+      "Delete worktree '" + id + "'?\n\nThis removes the directory, branch, and metadata.",
+      'Delete',
+      function () {
+        STATE.cards = STATE.cards.filter(function (c) { return c.id !== id; });
+        STATE.selectedCardId = null;
+        renderAll();
+        showToast('Deleted worktree: ' + id);
       }
-    }, 280);
-    selectCard(null);
+    );
+  }
+
+  // sendPR: only valid on cards in 'created'. Assigns a fresh PR
+  // number, sets prState/ciState to open/pending, and moves the card
+  // to the 'sent' column. Both views re-render so the transition is
+  // visible whether the user is on kanban or grid.
+  function sendPR() {
+    if (!STATE.selectedCardId) { showToast('Select a card first (click one)'); return; }
+    if (STATE.selectedCardId === 'main') {
+      showToast('Main is the parent worktree — no PR flow');
+      return;
+    }
+    var card = getCard(STATE.selectedCardId);
+    if (!card) return;
+    if (card.stage !== 'created') {
+      showToast('Send PR only works on cards in Created');
+      return;
+    }
+    card.prNumber = nextPRNumber();
+    card.prState = 'open';
+    card.ciState = 'pending';
+    card.stage = 'sent';
+    renderAll();
+    pulseCard(card.id);
+    showToast('Pushed branch · opened PR #' + card.prNumber);
+  }
+
+  function nextPRNumber() {
+    var max = 0;
+    STATE.cards.forEach(function (c) { if (c.prNumber && c.prNumber > max) max = c.prNumber; });
+    return max + 1;
   }
 
   function refreshAll() {
-    document.querySelectorAll('.kb-card').forEach(function (c) {
+    document.querySelectorAll('.kb-card, .kb-main-card').forEach(function (c) {
       c.classList.add('kb-pulse');
       setTimeout(function () { c.classList.remove('kb-pulse'); }, 620);
     });
@@ -481,32 +794,189 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
 
   function openNoteModal() {
     if (!STATE.selectedCardId) { showToast('Select a card first (click one)'); return; }
-    var modal = document.getElementById('note-modal');
-    if (!modal) return;
-    document.getElementById('note-modal-title').textContent = 'Note — ' + STATE.selectedCardId;
-    var entry = document.getElementById('note-entry');
-    var preview = document.getElementById('note-preview');
-    var sample =
-      '# ' + STATE.selectedCardId + '\n\n'
-      + '**TODO** — write the task description here.\n\n'
-      + '- Use *Markdown* — bold, italic, `inline code`\n'
-      + '- Live preview on the right →\n'
-      + '- Saved alongside the worktree as `.biomelab/note.md`\n\n'
-      + 'When you `Shift+P` to send the PR, biomelab uses this note as the body.';
-    entry.value = sample;
-    preview.innerHTML = renderMd(sample);
-    entry.oninput = function () { preview.innerHTML = renderMd(entry.value); };
-    modal.removeAttribute('hidden');
-    document.body.classList.add('rgt-modal-open');
-    requestAnimationFrame(function () { modal.classList.add('open'); });
+    showModal('note-modal', function () {
+      document.getElementById('note-modal-title').textContent = 'Note — ' + STATE.selectedCardId;
+      var entry = document.getElementById('note-entry');
+      var preview = document.getElementById('note-preview');
+      var sample =
+        '# ' + STATE.selectedCardId + '\n\n'
+        + '**TODO** — write the task description here.\n\n'
+        + '- Use *Markdown* — bold, italic, `inline code`\n'
+        + '- Live preview on the right →\n'
+        + '- Saved alongside the worktree as `.biomelab/note.md`\n\n'
+        + 'When you `Shift+P` to send the PR, biomelab uses this note as the body.';
+      entry.value = sample;
+      preview.innerHTML = renderMd(sample);
+      entry.oninput = function () { preview.innerHTML = renderMd(entry.value); };
+    });
   }
 
-  function closeNoteModal() {
-    var modal = document.getElementById('note-modal');
-    if (!modal) return;
-    modal.classList.remove('open');
-    document.body.classList.remove('rgt-modal-open');
-    setTimeout(function () { modal.setAttribute('hidden', ''); }, 200);
+  function closeNoteModal() { hideModal('note-modal'); }
+
+  // ── '?' keyboard shortcuts modal ──────────────────────────────
+  //
+  // The .keyboard-grid lives inside this modal (single source of
+  // truth — the standalone landing-page section was removed in favor
+  // of the modal-only flow). Toggle behavior on '?': open if closed,
+  // close if open. Esc also closes.
+  function openHelpModal()  { showModal('kb-help-modal'); }
+  function closeHelpModal() { hideModal('kb-help-modal'); }
+
+  // ── Confirm dialog ─────────────────────────────────────────────
+  //
+  // Generic Yes/No prompt mirroring biomelab's showConfirmDelete.
+  // openConfirmModal stores the success callback in pendingConfirm;
+  // confirmYes invokes it, anything else (Cancel / Esc / overlay
+  // click / ×) just closes without firing.
+  var pendingConfirm = null;
+  function openConfirmModal(title, message, yesLabel, onYes) {
+    pendingConfirm = onYes || null;
+    showModal('confirm-modal', function () {
+      document.getElementById('confirm-modal-title').textContent = title;
+      document.getElementById('confirm-modal-body').textContent = message;
+      var yesBtn = document.querySelector('.confirm-yes');
+      if (yesBtn && yesLabel) yesBtn.textContent = yesLabel;
+    });
+  }
+  function closeConfirmModal() {
+    hideModal('confirm-modal', function () { pendingConfirm = null; });
+  }
+  function confirmYes() {
+    var fn = pendingConfirm;
+    pendingConfirm = null;
+    closeConfirmModal();
+    if (fn) fn();
+  }
+
+  // ── Fake terminal (Matrix opening) ─────────────────────────────
+  //
+  // Opens on Enter (or ⏎ cap click) when a card is selected. Types
+  // out the iconic Matrix intro lines character-by-character. Purely
+  // playful — the real biomelab opens a host Terminal window.
+
+  var TERM_LINES = [
+    'Wake up, Neo...',
+    'The Matrix has you...',
+    'Follow the white rabbit.',
+    '',
+    'Knock, knock, Neo.'
+  ];
+  var termTimer = null;
+
+  function openTerminalModal() {
+    showModal('term-modal', function () {
+      document.getElementById('term-modal-title').textContent =
+        STATE.selectedCardId ? 'Terminal — ' + STATE.selectedCardId : 'Terminal';
+      var out = document.getElementById('term-output');
+      if (termTimer) clearTimeout(termTimer);
+      if (out) out.innerHTML = '<span class="term-cursor"></span>';
+    });
+    // Brief pause before typing starts — mimics the moment of stillness
+    // right before the lines start landing in Neo's screen.
+    termTimer = setTimeout(typeMatrixIntro, 600);
+  }
+
+  function closeTerminalModal() {
+    hideModal('term-modal', function () {
+      if (termTimer) { clearTimeout(termTimer); termTimer = null; }
+    });
+  }
+
+  // ── Editor splash (cyan sibling of the Matrix terminal) ────────
+  //
+  // Opens on 'e'. Aspirational rather than functional — a brief boot
+  // sequence and a coding quote, typed out like the Matrix lines but
+  // tinted cyan to read as a different surface. The selected card's
+  // branch threads into the path so the splash feels card-specific.
+
+  var editorTimer = null;
+
+  function openEditorModal() {
+    var branch = STATE.selectedCardId || 'main';
+    showModal('editor-modal', function () {
+      document.getElementById('editor-modal-title').textContent = 'Editor — ' + branch;
+      var out = document.getElementById('editor-output');
+      if (editorTimer) clearTimeout(editorTimer);
+      if (out) out.innerHTML = '<span class="editor-cursor"></span>';
+    });
+    editorTimer = setTimeout(function () { typeEditorSplash(branch); }, 450);
+  }
+
+  function closeEditorModal() {
+    hideModal('editor-modal', function () {
+      if (editorTimer) { clearTimeout(editorTimer); editorTimer = null; }
+    });
+  }
+
+  function typeEditorSplash(branch) {
+    var out = document.getElementById('editor-output');
+    if (!out) return;
+    // Mixed segments: plain typed lines + a pre-rendered quote block
+    // that fades in after the boot lines finish. Keeping the segments
+    // in one array means the typewriter handles ordering / timing.
+    var bootLines = [
+      '$ code .',
+      '',
+      '  Indexing workspace…',
+      '  142 files loaded.',
+      '  Spawning language servers…',
+      '  Ready.',
+      '',
+      '  Today\'s canvas: ' + branch
+    ];
+    var quote = '\n\n  "Talk is cheap.\n   Show me the code."\n\n        — Linus Torvalds, LKML 2000';
+
+    var li = 0, ci = 0, typed = '';
+    function step() {
+      if (li >= bootLines.length) {
+        // Boot finished — drop the quote in one beat for emphasis.
+        typed += quote;
+        out.innerHTML = esc(typed) + '<span class="editor-cursor"></span>';
+        return;
+      }
+      var line = bootLines[li];
+      if (ci < line.length) {
+        typed += line.charAt(ci);
+        ci++;
+        out.innerHTML = esc(typed) + '<span class="editor-cursor"></span>';
+        editorTimer = setTimeout(step, 28 + Math.random() * 30);
+      } else {
+        typed += '\n';
+        li++;
+        ci = 0;
+        out.innerHTML = esc(typed) + '<span class="editor-cursor"></span>';
+        editorTimer = setTimeout(step, 180);
+      }
+    }
+    step();
+  }
+
+  function typeMatrixIntro() {
+    var out = document.getElementById('term-output');
+    if (!out) return;
+    var li = 0, ci = 0, typed = '';
+    function step() {
+      if (li >= TERM_LINES.length) {
+        // All lines typed — leave the cursor blinking at the end.
+        out.innerHTML = esc(typed) + '<span class="term-cursor"></span>';
+        return;
+      }
+      var line = TERM_LINES[li];
+      if (ci < line.length) {
+        typed += line.charAt(ci);
+        ci++;
+        out.innerHTML = esc(typed) + '<span class="term-cursor"></span>';
+        // Slight jitter so the typing feels human, not metronomic.
+        termTimer = setTimeout(step, 55 + Math.random() * 50);
+      } else {
+        typed += '\n';
+        li++;
+        ci = 0;
+        out.innerHTML = esc(typed) + '<span class="term-cursor"></span>';
+        termTimer = setTimeout(step, 1100);
+      }
+    }
+    step();
   }
 
   function renderMd(s) {
@@ -543,13 +1013,42 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
   document.addEventListener('keydown', function (e) {
     var tag = document.activeElement && document.activeElement.tagName;
     if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-    var rgtModal = document.getElementById('rgt-modal');
-    var noteModal = document.getElementById('note-modal');
+    var rgtModal     = document.getElementById('rgt-modal');
+    var noteModal    = document.getElementById('note-modal');
+    var helpModal    = document.getElementById('kb-help-modal');
+    var termModal    = document.getElementById('term-modal');
+    var editorModal  = document.getElementById('editor-modal');
+    var confirmModal = document.getElementById('confirm-modal');
     if (rgtModal && !rgtModal.hasAttribute('hidden')) return;
     if (noteModal && !noteModal.hasAttribute('hidden')) {
       if (e.key === 'Escape') closeNoteModal();
       return;
     }
+    if (helpModal && !helpModal.hasAttribute('hidden')) {
+      // Toggle off: Esc or another '?' closes the cheatsheet.
+      if (e.key === 'Escape' || e.key === '?') {
+        closeHelpModal();
+        e.preventDefault();
+      }
+      return;
+    }
+    if (termModal && !termModal.hasAttribute('hidden')) {
+      if (e.key === 'Escape') closeTerminalModal();
+      return;
+    }
+    if (editorModal && !editorModal.hasAttribute('hidden')) {
+      if (e.key === 'Escape') closeEditorModal();
+      return;
+    }
+    if (confirmModal && !confirmModal.hasAttribute('hidden')) {
+      // Esc = Cancel · Enter = Confirm. Other keys are swallowed so
+      // the user can't accidentally trigger a card action while the
+      // dialog is in front.
+      if (e.key === 'Escape') { closeConfirmModal(); e.preventDefault(); }
+      else if (e.key === 'Enter') { confirmYes(); e.preventDefault(); }
+      return;
+    }
+    if (e.key === '?') { openHelpModal(); e.preventDefault(); return; }
 
     switch (e.key) {
       case 'c': case 'C': createCard();      e.preventDefault(); break;
@@ -559,14 +1058,23 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
       case 'l': case 'L': openLogModal();    e.preventDefault(); break;
       // Toast-only actions (educational reactions for keys without
       // their own animation on the demo board)
-      case 'e': showToast('Opening worktree in editor…');             e.preventDefault(); break;
+      case 'e':
+        if (STATE.selectedCardId) { openEditorModal(); e.preventDefault(); }
+        else showToast('Select a card first (click one)');
+        break;
       case 'f': showToast('Fetching PR into a new worktree…');        e.preventDefault(); break;
       case 'n': showToast('Creating sandbox for this worktree…');     e.preventDefault(); break;
-      case 'p': showToast('Pulling from remote…');                    e.preventDefault(); break;
-      case 'P': showToast('Send PR flow (multi-step in the app)');    e.preventDefault(); break;
+      case 'p':
+        if (STATE.selectedCardId === 'main') pullMain();
+        else showToast('Pulling from remote…');
+        e.preventDefault();
+        break;
+      case 'P': sendPR();                                              e.preventDefault(); break;
       case 's': showToast('Starting stopped sandbox…');               e.preventDefault(); break;
       case 'S': showToast('Stopping running sandbox…');               e.preventDefault(); break;
-      case 'Enter': showToast('Opening terminal for this worktree…'); e.preventDefault(); break;
+      case 'Enter':
+        if (STATE.selectedCardId) { openTerminalModal(); e.preventDefault(); }
+        break;
     }
   });
 
@@ -579,14 +1087,23 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
       case 'r': refreshAll(); return;
       case 'm': openNoteModal(); return;
       case 'l': openLogModal(); return;
-      case 'e': showToast('Opening worktree in editor…'); return;
+      case 'e':
+        if (STATE.selectedCardId) openEditorModal();
+        else showToast('Select a card first (click one)');
+        return;
       case 'f': showToast('Fetching PR into a new worktree…'); return;
       case 'n': showToast('Creating sandbox for this worktree…'); return;
-      case 'p': showToast('Pulling from remote…'); return;
-      case 'P': showToast('Send PR flow (multi-step in the app)'); return;
+      case 'p':
+        if (STATE.selectedCardId === 'main') pullMain();
+        else showToast('Pulling from remote…');
+        return;
+      case 'P': sendPR(); return;
       case 's': showToast('Starting stopped sandbox…'); return;
       case 'S': showToast('Stopping running sandbox…'); return;
-      case '⏎': showToast('Opening terminal for this worktree…'); return;
+      case '⏎':
+        if (STATE.selectedCardId) openTerminalModal();
+        else showToast('Select a card first (click one)');
+        return;
       case 'g':
         // Delegate to the existing kanban toggle by dispatching a
         // keyboard event the toggle IIFE already listens for.
@@ -594,19 +1111,29 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
         return;
     }
   }
-  document.querySelectorAll('.keyboard-grid .key-item').forEach(function (item) {
+  // Delegate so both the page-load key-items AND the clones inside the
+  // '?' help modal trigger the same actions.
+  document.addEventListener('click', function (e) {
+    var item = e.target.closest('.key-item');
+    if (!item) return;
     var cap = item.querySelector('.key-cap');
     if (!cap) return;
-    item.style.cursor = 'pointer';
-    item.addEventListener('click', function () {
-      fireByCap(cap.textContent.trim());
-    });
+    fireByCap(cap.textContent.trim());
   });
 
-  // ── Note modal close handlers ──────────────────────────────────
-
-  document.querySelectorAll('[data-note-close]').forEach(function (el) {
-    el.addEventListener('click', closeNoteModal);
+  // ── Modal close handlers (delegated) ───────────────────────────
+  //
+  // Delegate clicks on data-{kind}-close targets to document so the
+  // bindings survive any markup tweaks and work for nested overlays
+  // / buttons without per-element wiring. One listener replaces three
+  // per-element registrations.
+  document.addEventListener('click', function (e) {
+    if (e.target.closest('[data-note-close]'))    { closeNoteModal();    return; }
+    if (e.target.closest('[data-kbhelp-close]'))  { closeHelpModal();    return; }
+    if (e.target.closest('[data-term-close]'))    { closeTerminalModal(); return; }
+    if (e.target.closest('[data-editor-close]'))  { closeEditorModal();  return; }
+    if (e.target.closest('[data-confirm-close]')) { closeConfirmModal(); return; }
+    if (e.target.closest('.confirm-yes'))         { confirmYes();        return; }
   });
   // Esc while typing in the textarea: the global keydown handler bows
   // out on TEXTAREA focus, so add a dedicated Escape on the entry so
@@ -620,4 +1147,26 @@ document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
       }
     });
   }
+
+  // ── Bootstrap STATE from the initial handcrafted DOM ───────────
+  //
+  // The page ships a static kanban + grid layout for first paint /
+  // SEO. We parse it once into STATE.cards on init so subsequent
+  // mutations (create, send-PR, delete) flow through one source of
+  // truth and re-render both views. The grid view is wired here too —
+  // its initial DOM is replaced by render so the two views are always
+  // in sync, including for hand-authored cards that may have drifted
+  // between the two markup blocks in index.html.
+  STATE.cards = parseInitialState();
+  renderAll();
+
+  // Wire the static main worktree card once. It's NOT in STATE.cards
+  // (it doesn't live in a column or the grid), so renderAll never
+  // touches it — a single binding here is enough.
+  var mainCardEl = document.querySelector('.kb-main-card[data-kb]');
+  if (mainCardEl) wireCard(mainCardEl);
+
+  // Kick off the periodic sync drift so the main card flips to
+  // "behind" every 10 s and the user has a real reason to try 'p'.
+  startMainSyncCycle();
 })();


### PR DESCRIPTION
## What's changed

Turns the "Kanban Board" section on the landing page into an interactive **Playground** that lets visitors drive biomelab's keyboard-first UX from the browser. Cards now have a shared JS source of truth so both the kanban and grid views stay in sync; every key in the cheatsheet is clickable and triggers the same real animation, modal, or toast as if pressed on the keyboard; and the main worktree card drifts behind every 5 s so users have a real reason to try `p` and pull.

Modal scaffolding is factored out so the five popovers (regent log, note editor, Matrix terminal, editor splash, confirm dialog, `?` cheatsheet) share one `showModal` / `hideModal` lifecycle. Each modal supplies only what differs — title, content, timer cleanup — and the rest is one boilerplate.

## Why is this important?

The previous landing page told visitors that biomelab is keyboard-first and showed a static screenshot of the kanban board. With the playground, anyone can press `c` to create a worktree, watch it animate into the "Created" column, press `⇧P` to ship it through to "PR Sent" with a fresh PR number, press `l` to peek at the regent log, press `m` to draft a note in a live Markdown preview, press `⏎` for a Matrix-themed terminal easter egg, press `e` for a cyan editor splash with a Linus quote, and press `?` to pop the full keybindings. The pitch becomes interactive: you don't read about biomelab, you use it (in miniature) right on the landing.

## Changes

### Playground (was "Kanban Board")

- **Section renamed + reordered:** `id="kanban"` → `id="playground"`, the section label and nav link both follow, and the section moves above Task Notes so visitors hit the interactive bit first.
- **Title is a CTA:** "Try the playground · press `c` to start" — stays fixed across kanban/grid toggles instead of switching to "Card Grid View".
- **Static feature cards removed:** the three "Five lifecycle stages / Review status / Press g for grid view" cards were redundant with the live demo. The "Keyboard-first" pitch survives as one card in the main dashboard-features grid above.

### Shared state and dual rendering

- **`STATE.cards` as single source of truth:** parsed once from the page-load DOM, then mutations (create / send-PR / delete) flow through it and re-render both the `.kb-board` (columns) and `.kb-grid` (flat) views. The two views are always identical regardless of which is visible.
- **State transitions:** `c` appends a card in Created, `d` filters out the selected card after a confirm dialog, `⇧P` advances a Created card to PR Sent with a fresh PR number + `open` state + `pending` CI, others fall through to toasts.
- **Selection model:** click selects (cyan outline mirrored on both views simultaneously), then keys act on the selection — same select-then-act mental model as biomelab's GUI. The previous "click opens the regent log" was dropped; `l` opens it now.

### Main worktree card

- New horizontal card above both views — branch `main`, path, agent dot, sync pill, dirty/clean — mirrors biomelab's GUI where the main worktree sits as a full-width card above the linked grid.
- **Interactive:** click selects, `r` pulses, `⏎` opens the terminal (titled "Terminal — main"), `l` opens the regent log, `m` opens the note editor. `d` and `⇧P` are blocked with a toast ("Cannot delete the main worktree" / "Main is the parent worktree — no PR flow").
- **Sync drift cycle:** every 5 s `setInterval` flips the sync pill to `↓ N behind` (N random 1-5), `p` while main is selected fires a "Pulling from remote…" toast and restores `↕ up-to-date` when the toast finishes — so the user sees the pulling step instead of an instant flip. The cycle restarts after each pull so the next drift comes a fresh 5 s later.

### Keyboard simulator + modals

- **All 14 key-caps are clickable** via one delegated `.key-item` handler — works on the page and inside the `?` modal that clones the same grid. Hover / active styles cue interactivity.
- **`l` regent log modal**: cards still open this on `l` press; the regent IIFE exposes `open()` via `window.kbDemo.openLog` so the keyboard simulator can call it for the selected card.
- **`m` note editor modal**: split-pane Markdown textarea + live preview. Tiny Markdown renderer (`#`/`##`, `**bold**`, `*italic*`, `` `code` ``, `- list`). Esc inside the textarea closes via a dedicated listener.
- **`⏎` terminal modal**: theme-locked phosphor-green-on-black, typewriter loop with jitter, types out the Matrix-opening lines ("Wake up, Neo…" through "Knock, knock, Neo."). Title threads the selected card's branch.
- **`e` editor splash**: cyan-on-black sibling of the terminal modal — short boot sequence ("Indexing workspace… 142 files loaded… Ready") followed by Linus Torvalds' LKML 2000 quote.
- **`?` keybindings cheatsheet**: opens a modal containing the full `.keyboard-grid` (markup lives inside the modal, no clone). Toggle on / off with `?`; Esc also closes.
- **Confirm dialog**: mirrors biomelab's `showConfirmDelete`. `d` opens it with "Delete worktree '<branch>'? This removes the directory, branch, and metadata.", red Delete button + Cancel. Esc cancels, Enter confirms.
- **Inline branch naming**: on `c`, the new card renders with a focused text input instead of a span; Enter commits (updates id + branch + selection), Esc cancels and drops the half-created card, blur also commits.
- **Sample data refreshed:** the regent-log demo conversation is now three turns about Docker Sandbox + testcontainers (Postgres / network-isolation check / Redis) to land on-brand for biomelab.
- Other keys (`f`, `n`, `p` when not on main, `⇧P` when not in Created, `s`, `⇧S`) fire educational toasts.

### Modal scaffolding (refactor)

- Top-level `showModal(id, onShow?)` / `hideModal(id, onHide?)` helpers own the `[hidden]` / `.open` / body scroll-lock / 200ms fade lifecycle. Each of the six modals supplies only its specific behavior (title, content, timer cancel, pending-callback clear). Net: ~70 lines of duplicated boilerplate gone.
- **Close handlers delegated** to one document listener that matches `data-{note|kbhelp|term|editor|confirm}-close`. Survives any markup tweaks and means new modals only need to add their `data-*` attribute, not register listeners.

### CSS

- New animations: `kbPulse` (cyan ring), `kbEnter` (fade-in + slight scale for new cards), `kbExit` (collapse on delete). Themed via `var(--cyan)` so the dark/light toggle carries.
- Toast in the bottom-right with `cursor: pointer` + hover translate on `.key-item`.
- Confirm dialog: narrower window, `white-space: pre-line` on the body so the two-line message reads correctly, red `Delete` + neutral `Cancel`.
- Terminal / editor modal chrome inherits the theme; only the body is locked to black with phosphor green (terminal) or cyan (editor) text.
- Inline branch editor (`.kb-branch-edit`): thin cyan border, focus glow, sized to drop into the card row without layout shift.

## Test plan

- [x] Open `website/index.html` in a browser. The Playground section appears above Notes; the title reads "Try the playground · press `c` to start" in both views.
- [x] Press `c` → a new card appears in the Created column with the branch input focused; type a name, Enter → card commits with that branch; Esc on a fresh `c` → card disappears.
- [x] Click any card → cyan outline on both kanban and grid; press `g` to toggle → same card stays highlighted on the other view.
- [x] On a Created card press `⇧P` → toast "Pushed branch · opened PR #N", card moves to PR Sent column with `pending` CI; press `⇧P` again → toast "Send PR only works on cards in Created".
- [x] Click main → press `r` → main card pulses; press `⏎` → terminal modal with "Terminal — main"; press `l` → regent log; press `m` → note editor with main's branch.
- [x] Wait 5 s on the page → main flips to `↓ N behind`; click main + press `p` → toast "Pulling from remote…", main returns to `↕ up-to-date` when the toast fades.
- [x] Press `d` on a non-main card → confirm dialog opens; Cancel / Esc / × / overlay all close without deleting; Enter or "Delete" remove the card.
- [x] Press `?` → keybindings cheatsheet; click any cap inside → its action fires (toast or modal); `?` or Esc closes.
- [x] Theme toggle (`?` or top-right) → modal chrome adapts. Terminal/editor bodies stay matrix-themed.
